### PR TITLE
Layout adjusments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "mvp",
       "version": "0.1.0",
       "dependencies": {
-        "@weni/unnnic-system": "1.10.19",
+        "@weni/unnnic-system": "1.10.24",
         "axios": "^0.27.2",
         "core-js": "^3.8.3",
         "lodash.clonedeep": "^4.5.0",
@@ -4310,9 +4310,9 @@
       }
     },
     "node_modules/@weni/unnnic-system": {
-      "version": "1.10.19",
-      "resolved": "https://registry.npmjs.org/@weni/unnnic-system/-/unnnic-system-1.10.19.tgz",
-      "integrity": "sha512-B9iQmxJl1UhfPI/fCM309/wflRQMM/Ram+KxN7btYz+ZuL2yvTsnuGt60iMB29SgUODUuaHOQK6HdDDF5p53sw==",
+      "version": "1.10.24",
+      "resolved": "https://registry.npmjs.org/@weni/unnnic-system/-/unnnic-system-1.10.24.tgz",
+      "integrity": "sha512-MFQbwmki70EL+ae8YGofun24bSJPzbe8Fw7BNd7iwN6u16DIbmUazwRYL+qf6/xgBxFRiZhXalCq5/RELi/Naw==",
       "dependencies": {
         "core-js": "^3.6.5",
         "moment": "^2.29.1",
@@ -21660,9 +21660,9 @@
       }
     },
     "@weni/unnnic-system": {
-      "version": "1.10.19",
-      "resolved": "https://registry.npmjs.org/@weni/unnnic-system/-/unnnic-system-1.10.19.tgz",
-      "integrity": "sha512-B9iQmxJl1UhfPI/fCM309/wflRQMM/Ram+KxN7btYz+ZuL2yvTsnuGt60iMB29SgUODUuaHOQK6HdDDF5p53sw==",
+      "version": "1.10.24",
+      "resolved": "https://registry.npmjs.org/@weni/unnnic-system/-/unnnic-system-1.10.24.tgz",
+      "integrity": "sha512-MFQbwmki70EL+ae8YGofun24bSJPzbe8Fw7BNd7iwN6u16DIbmUazwRYL+qf6/xgBxFRiZhXalCq5/RELi/Naw==",
       "requires": {
         "core-js": "^3.6.5",
         "moment": "^2.29.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "translations:suggest-from-pt-br": "unified-translations --translations-file ./src/locales/translations.json --languages pt-br=./src/locales/pt_br.json,en-us=./src/locales/en_us.json,es=./src/locales/es.json --mode build --suggest \"pt-br:pt>en-us:en\" && unified-translations --translations-file ./src/locales/translations.json --languages pt-br=./src/locales/pt_br.json,en-us=./src/locales/en_us.json,es=./src/locales/es.json --mode reverse && unified-translations --translations-file ./src/locales/translations.json --languages pt-br=./src/locales/pt_br.json,en-us=./src/locales/en_us.json,es=./src/locales/es.json --mode build --suggest \"pt-br:pt>es\" && unified-translations --translations-file ./src/locales/translations.json --languages pt-br=./src/locales/pt_br.json,en-us=./src/locales/en_us.json,es=./src/locales/es.json --mode reverse"
   },
   "dependencies": {
-    "@weni/unnnic-system": "1.10.19",
+    "@weni/unnnic-system": "1.10.24",
     "axios": "^0.27.2",
     "core-js": "^3.8.3",
     "lodash.clonedeep": "^4.5.0",

--- a/src/components/PreferencesBar.vue
+++ b/src/components/PreferencesBar.vue
@@ -190,6 +190,10 @@ export default {
 
     .options-container {
       display: flex;
+      background: #ffffff;
+      opacity: 20;
+      z-index: 99999;
+      position: relative;
     }
 
     .background {

--- a/src/components/PreferencesBar.vue
+++ b/src/components/PreferencesBar.vue
@@ -16,7 +16,7 @@
       >
         <div class="label">
           <div class="icon">
-            <unnnic-icon size="sm" icon="preferences" scheme="neutral-cloudy" />
+            <unnnic-icon size="md" icon="preferences" scheme="neutral-cloudy" />
           </div>
 
           <div class="text">
@@ -150,10 +150,9 @@ export default {
     padding: $unnnic-spacing-inset-nano;
     display: flex;
     column-gap: $unnnic-spacing-inline-xs;
+    align-items: center;
 
     .icon {
-      padding: $unnnic-spacing-inset-nano / 4;
-
       * {
         display: block;
       }

--- a/src/components/chats/ContactInfo/Media.vue
+++ b/src/components/chats/ContactInfo/Media.vue
@@ -54,13 +54,13 @@
               <audio-preview :currentAudio="audio.url"></audio-preview>
             </div>
             <div style="width: 94%">
-              <!-- <span
-                >Enviado por {{ audio.name }} |
+              <span
+                >Enviado por {{ audio.sender }} |
                 {{ audio.duration == 'Infinity' ? 0 : audio.duration }}s
-              </span> -->
-              <span class="audio-text">
-                Áudio enviado | {{ audio.duration == 'Infinity' ? 0 : audio.duration }}s
               </span>
+              <!-- <span class="audio-text">
+                Áudio enviado | {{ audio.duration == 'Infinity' ? 0 : audio.duration }}s
+              </span> -->
             </div>
           </div>
         </section>

--- a/src/components/chats/ContactInfo/index.vue
+++ b/src/components/chats/ContactInfo/index.vue
@@ -16,7 +16,9 @@
           </p>
 
           <div class="connection-info">
-            <p v-if="room.contact.status === 'online'">{{ $t('status.online') }}</p>
+            <p v-if="room.contact.status === 'online'">
+              {{ $t('status.online') }}
+            </p>
             <!-- <p v-else>{{ getLastTimeOnlineText(room.contact.last_interaction || new Date()) }}</p> -->
             <template v-if="!!room.custom_fields">
               <p v-for="(value, key) in customFields" :key="key">
@@ -99,6 +101,15 @@ export default {
     AsideSlotTemplateSection,
     ContactMedia,
   },
+  props: {
+    contact: {
+      type: Object,
+    },
+    isHistory: {
+      type: Boolean,
+      default: false,
+    },
+  },
 
   data: () => ({
     transferOptions: [],
@@ -115,7 +126,6 @@ export default {
 
     lastMessageFromContact() {
       const messages = this.$store.state.rooms.activeRoomMessages;
-
       return messages.findLast((message) => message.contact);
     },
 
@@ -129,24 +139,26 @@ export default {
   },
 
   async created() {
-    if (!this.room.queue?.sector) {
-      throw new Error(`There is no associated sector with room ${this.room.uuid}`);
-    }
+    if (!this.isHistory) {
+      if (!this.room.queue?.sector) {
+        throw new Error(`There is no associated sector with room ${this.room.uuid}`);
+      }
 
-    try {
-      this.transferOptions = (await Sector.agents({ sectorUuid: this.room.queue.sector }))
-        .filter((agent) => agent.email !== this.$store.state.profile.me.email)
-        .map(({ first_name, last_name, email }) => {
-          return {
-            name: [first_name, last_name].join(' ').trim() || email,
-            email,
-          };
-        });
-    } catch (error) {
-      if (error?.response?.status === 403) {
-        this.transferContactError = this.$t('chats.transfer.does_not_have_permission');
-      } else {
-        throw error;
+      try {
+        this.transferOptions = (await Sector.agents({ sectorUuid: this.room.queue.sector }))
+          .filter((agent) => agent.email !== this.$store.state.profile.me.email)
+          .map(({ first_name, last_name, email }) => {
+            return {
+              name: [first_name, last_name].join(' ').trim() || email,
+              email,
+            };
+          });
+      } catch (error) {
+        if (error?.response?.status === 403) {
+          this.transferContactError = this.$t('chats.transfer.does_not_have_permission');
+        } else {
+          throw error;
+        }
       }
     }
   },

--- a/src/components/chats/QuickMessages/index.vue
+++ b/src/components/chats/QuickMessages/index.vue
@@ -39,8 +39,8 @@
       :show-modal="!!quickMessageToDelete"
     >
       <template #options>
-        <unnnic-button :text="$t('confirm')" type="terciary" @click="deleteQuickMessage" />
-        <unnnic-button :text="$t('cancel')" @click="quickMessageToDelete = null" />
+        <unnnic-button :text="$t('cancel')" type="terciary" @click="quickMessageToDelete = null" />
+        <unnnic-button :text="$t('confirm')" type="secondary" @click="deleteQuickMessage" />
       </template>
     </unnnic-modal>
   </aside-slot-template>

--- a/src/components/chats/chat/ChatHeader.vue
+++ b/src/components/chats/chat/ChatHeader.vue
@@ -30,7 +30,9 @@
     </header>
 
     <section v-if="!room.is_active" class="header-info-message">
-      <span class="message">{{ $d(room.date ? new Date(room.date) : new Date(), 'long') }}</span>
+      <span class="message">{{
+        $d(room.ended_at ? new Date(room.ended_at) : new Date(), 'long')
+      }}</span>
     </section>
 
     <section v-else-if="!room.user" class="header-info-message">
@@ -67,7 +69,6 @@ export default {
       default: false,
     },
   },
-
   methods: {
     moment,
     showContactInfo() {

--- a/src/components/chats/chat/ChatMessages.vue
+++ b/src/components/chats/chat/ChatMessages.vue
@@ -58,6 +58,7 @@
       <template #options>
         <unnnic-button type="terciary" @click="messageToResend = null" text="Cancelar envio" />
         <unnnic-button
+          type="secondary"
           @click="(messageToResend.sent = true), (messageToResend = null)"
           text="Reenviar"
         />

--- a/src/components/chats/chat/ChatMessages.vue
+++ b/src/components/chats/chat/ChatMessages.vue
@@ -36,17 +36,18 @@
         />
       </section>
     </section>
+    <div style="position: sticky; bottom: 0px; background-color: white">
+      <section v-if="!room.is_active" class="chat-messages__room__divisor">
+        <div class="chat-messages__room__divisor__line" />
+        <span class="chat-messages__room__divisor__label">{{ $t('chat_closed_by.agent') }}</span>
+        <div class="chat-messages__room__divisor__line" />
+      </section>
 
-    <section v-if="!room.is_active" class="chat-messages__room__divisor">
-      <div class="chat-messages__room__divisor__line" />
-      <span class="chat-messages__room__divisor__label">{{ $t('chat_closed_by.agent') }}</span>
-      <div class="chat-messages__room__divisor__line" />
-    </section>
-
-    <section v-if="room.tags.length > 0" class="chat-messages__tags">
-      <p class="chat-messages__tags__label">{{ $t('chats.tags') }}</p>
-      <tag-group :tags="room.tags" />
-    </section>
+      <section v-if="room.tags.length > 0" class="chat-messages__tags">
+        <p class="chat-messages__tags__label">{{ $t('chats.tags') }}</p>
+        <tag-group :tags="room.tags" />
+      </section>
+    </div>
 
     <unnnic-modal
       :showModal="!!messageToResend"

--- a/src/components/settings/forms/Agent.vue
+++ b/src/components/settings/forms/Agent.vue
@@ -21,12 +21,12 @@
           highlight
           class="input"
         />
-        <unnnic-button
+        <!-- <unnnic-button
           type="secondary"
           :text="$t('agents.add.button')"
           :disabled="!selectAgent"
           @click="emitSelectedAgent"
-        />
+        /> -->
       </section>
     </section>
 
@@ -109,8 +109,8 @@ export default {
 
         return name === selected || email === selected;
       });
-
       this.agent = agent;
+      this.emitSelectedAgent();
     },
     emitSelectedAgent() {
       if (!this.agent.uuid) return;

--- a/src/components/settings/forms/Agent.vue
+++ b/src/components/settings/forms/Agent.vue
@@ -84,8 +84,16 @@ export default {
 
         return first_name || last_name ? `${first_name} ${last_name}` : email;
       });
-
-      return agents.filter((agent) => agent.includes(this.search));
+      const filterDuplicateNames = agents.filter((item, index) => agents.indexOf(item) === index);
+      // eslint-disable-next-line func-names
+      const sort = filterDuplicateNames.sort(function (a, b) {
+        if (a < b) {
+          return -1;
+        }
+        return sort;
+      });
+      return sort;
+      // return agents.filter((agent) => agent.includes(this.search));
     },
     selectedAgents: {
       get() {

--- a/src/components/settings/forms/Agent/Edit.vue
+++ b/src/components/settings/forms/Agent/Edit.vue
@@ -42,8 +42,8 @@
       @close="queueToRemove = {}"
     >
       <template #options>
+        <unnnic-button type="terciary" @click="queueToRemove = {}" text="Cancelar" />
         <unnnic-button type="secondary" @click="removeQueue(queueToRemove)" text="Confirmar" />
-        <unnnic-button @click="queueToRemove = {}" text="Cancelar" />
       </template>
     </unnnic-modal>
 

--- a/src/components/settings/forms/Queue.vue
+++ b/src/components/settings/forms/Queue.vue
@@ -3,7 +3,7 @@
     <!-- <p v-if="showInfoIcon" class="form-queue__description">{{ infoText }}</p> -->
     <p class="title">
       {{ label }}
-      <unnnic-tool-tip enabled side="right" :text="$t('new_sector.queues_tip')">
+      <unnnic-tool-tip enabled side="right" :text="$t('new_sector.queues_tip')" maxWidth="23rem">
         <unnnic-icon-svg icon="information-circle-4" scheme="neutral-soft" size="sm" />
       </unnnic-tool-tip>
     </p>

--- a/src/components/settings/forms/Queue/Edit.vue
+++ b/src/components/settings/forms/Queue/Edit.vue
@@ -41,8 +41,8 @@
       @close="agentToRemove = {}"
     >
       <template #options>
+        <unnnic-button type="terciary" @click="agentToRemove = {}" text="Cancelar" />
         <unnnic-button type="secondary" @click="removeAgent(agentToRemove)" text="Confirmar" />
-        <unnnic-button @click="agentToRemove = {}" text="Cancelar" />
       </template>
     </unnnic-modal>
 

--- a/src/components/settings/forms/Sector.vue
+++ b/src/components/settings/forms/Sector.vue
@@ -137,7 +137,17 @@ export default {
 
         return first_name || last_name ? `${first_name} ${last_name}` : email;
       });
-      return managers.filter((manager) => manager.includes(this.manager));
+      const filterDuplicateNames = managers.filter(
+        (item, index) => managers.indexOf(item) === index,
+      );
+      const sort = filterDuplicateNames.sort(function (a, b) {
+        if (a < b) {
+          return -1;
+        }
+        return sort;
+      });
+      return sort;
+      // return managers.filter((manager) => manager.includes(this.manager));
     },
     sector: {
       get() {
@@ -170,6 +180,12 @@ export default {
 
     async addManager(manager) {
       await Sector.addManager(this.sector.uuid, manager.uuid);
+      this.getManagers();
+    },
+
+    async getManagers() {
+      const managers = await Sector.managers(this.sector.uuid);
+      this.sector.managers = managers.results.map((manager) => ({ ...manager, removed: false }));
     },
 
     selectManager(selected) {

--- a/src/components/settings/forms/Sector.vue
+++ b/src/components/settings/forms/Sector.vue
@@ -35,12 +35,12 @@
           iconLeft="search-1"
           @choose="selectManager"
         />
-        <unnnic-button
+        <!-- <unnnic-button
           text="Selecionar"
           type="secondary"
           @click="addSectorManager"
           :disabled="!selectedManager"
-        />
+        /> -->
       </div>
 
       <section v-if="sector.managers.length > 0" class="form-sector__managers">
@@ -180,6 +180,7 @@ export default {
         return name === selected || email === selected;
       });
       this.selectedManager = manager;
+      this.addSectorManager();
     },
 
     validate() {

--- a/src/components/settings/forms/Sector.vue
+++ b/src/components/settings/forms/Sector.vue
@@ -76,14 +76,6 @@
               this.message
             }}</span>
           </div>
-          <!-- <unnnic-input
-          v-model="sector.workingDay.start"
-          :label="$t('sector.managers.working_day.start.label')"
-          v-mask="'##:##'"
-          :type="timeError ? 'error' : 'normal'"
-          :message="timeError"
-          placeholder="08:00"
-        /> -->
           <div>
             <span class="label-working-day">{{ $t('sector.managers.working_day.end.label') }}</span>
             <input
@@ -93,12 +85,6 @@
               min="00:01"
               max="23:59"
             />
-            <!-- <unnnic-input
-            v-model="sector.workingDay.end"
-            label="Horário de encerramento"
-            v-mask="'##:##'"
-            placeholder="18:00"
-          /> -->
           </div>
           <unnnic-input
             v-model="sector.maxSimultaneousChatsByAgent"
@@ -114,6 +100,7 @@
 
 <script>
 import SelectedMember from '@/components/settings/forms/SelectedMember';
+import Sector from '@/services/api/resources/settings/sector';
 
 export default {
   name: 'FormSector',
@@ -176,8 +163,13 @@ export default {
         ...this.sector,
         managers,
       };
+      if (this.isEditing) this.addManager(selectedManager);
       this.manager = null;
       this.selectedManager = null;
+    },
+
+    async addManager(manager) {
+      await Sector.addManager(this.sector.uuid, manager.uuid);
     },
 
     selectManager(selected) {

--- a/src/components/settings/forms/Sector.vue
+++ b/src/components/settings/forms/Sector.vue
@@ -8,7 +8,7 @@
     <section v-else class="form-section">
       <h2 class="title">
         Adicionar novo setor
-        <unnnic-tool-tip enabled :text="$t('new_sector.sector_tip')" side="right">
+        <unnnic-tool-tip enabled :text="$t('new_sector.sector_tip')" side="right" maxWidth="21rem">
           <unnnic-icon-svg icon="information-circle-4" scheme="neutral-soft" size="sm" />
         </unnnic-tool-tip>
       </h2>
@@ -19,7 +19,7 @@
     <section class="form-section">
       <h2 class="title">
         {{ $t('sector.managers.title') }}
-        <unnnic-tool-tip enabled :text="$t('new_sector.agent_tip')" side="right">
+        <unnnic-tool-tip enabled :text="$t('new_sector.agent_tip')" side="right" maxWidth="15rem">
           <unnnic-icon-svg icon="information-circle-4" scheme="neutral-soft" size="sm" />
         </unnnic-tool-tip>
       </h2>

--- a/src/components/settings/forms/Tags.vue
+++ b/src/components/settings/forms/Tags.vue
@@ -5,7 +5,7 @@
     <section class="form-tags__section">
       <p class="form-tags__section__label">
         {{ $t('tags.add.title') }}
-        <unnnic-tool-tip enabled side="right" :text="$t('new_sector.tags_tip')">
+        <unnnic-tool-tip enabled side="right" :text="$t('new_sector.tags_tip')" maxWidth="23rem">
           <unnnic-icon-svg icon="information-circle-4" scheme="neutral-soft" size="sm" />
         </unnnic-tool-tip>
       </p>

--- a/src/layouts/ChatsLayout/components/TheRoomList/RoomGroup/ContactRoom.vue
+++ b/src/layouts/ChatsLayout/components/TheRoomList/RoomGroup/ContactRoom.vue
@@ -29,7 +29,9 @@
           <template v-if="newMessages?.length">
             {{ newMessages[newMessages.length - 1].text }}
           </template>
-          {{ room.lastMessage }}
+          <!-- <template v-if="!newMessages?.length">
+            {{ room.last_message }}
+          </template> -->
         </span>
       </div>
     </div>
@@ -37,6 +39,9 @@
     <span v-if="newMessages?.length" class="unread-messages" :class="{ filled }">
       {{ newMessages?.length }}
     </span>
+    <!-- <span v-if="!newMessages?.length" class="unread-messages" :class="{ filled }">
+      {{ room.unread_msgs }}
+    </span> -->
   </div>
 </template>
 

--- a/src/layouts/ChatsLayout/components/TheRoomList/index.vue
+++ b/src/layouts/ChatsLayout/components/TheRoomList/index.vue
@@ -12,8 +12,7 @@
 
     <unnnic-button
       :text="isHistoryView ? $t('back_to_chats') : $t('chats.see_history')"
-      :iconRight="isHistoryView ? '' : 'task-list-clock-1'"
-      :iconLeft="isHistoryView ? 'keyboard-arrow-left-1' : ''"
+      :iconLeft="isHistoryView ? 'keyboard-arrow-left-1' : 'task-list-clock-1'"
       type="secondary"
       size="small"
       @click="navigate(isHistoryView ? 'home' : 'rooms.closed')"

--- a/src/layouts/ChatsLayout/components/TheRoomList/index.vue
+++ b/src/layouts/ChatsLayout/components/TheRoomList/index.vue
@@ -3,10 +3,12 @@
     <section class="chat-groups">
       <room-group v-if="queue.length" :label="$t('line')" :rooms="queue" filled @open="open" />
       <room-group
+        v-bind:style="isHistoryView ? 'opacity: 0.5;' : 'opacity: 20'"
         v-if="rooms.length"
         :label="$t('chats.in_progress')"
         :rooms="rooms"
         @open="open"
+        :isHistory="isHistoryView"
       />
     </section>
 

--- a/src/locales/translations.json
+++ b/src/locales/translations.json
@@ -475,7 +475,7 @@
   },
   "contact_transferred_to": {
     "line": {
-      "pt-br": "Contato transferido para fila {name}",
+      "pt-br": "Contato encaminhado para fila {name}",
       "en-us": "Contact transferred to the {name} line",
       "es": "Contacto transferido a la línea {name}"
     },

--- a/src/services/api/resources/settings/sector.js
+++ b/src/services/api/resources/settings/sector.js
@@ -52,6 +52,9 @@ export default {
       permission: managerUuid,
     });
   },
+  async removeManager(managerUuid) {
+    await http.delete(`/authorization/sector/${managerUuid}`);
+  },
 
   async tags(sectorUuid) {
     const response = await http.get('/tag/', { params: { sector: sectorUuid } });

--- a/src/views/Settings/Sectors/Edit.vue
+++ b/src/views/Settings/Sectors/Edit.vue
@@ -69,10 +69,27 @@
         v-if="!!queueToEdit"
         text="Excluir"
         icon-left="delete-1"
-        type="secondary"
-        @click="deleteQueue(queueToEdit.uuid)"
+        type="terciary"
+        @click="openModalDeleteQueue(queueToEdit)"
       />
-      <unnnic-button text="Salvar" :type="!!queueToEdit ? 'primary' : 'secondary'" @click="save" />
+      <unnnic-button text="Salvar" type="secondary" @click="save" />
+      <unnnic-modal
+        :showModal="openModal"
+        modalIcon="alert-circle-1"
+        scheme="feedback-red"
+        :text="`Excluir a fila ${selectedQueue.name}`"
+        :description="`A fila ${selectedQueue.name} será permanentemente excluída`"
+        @close="closeModalDeleteQueue"
+      >
+        <template #options>
+          <unnnic-button type="terciary" @click="closeModalDeleteQueue" text="Cancelar" />
+          <unnnic-button
+            type="secondary"
+            @click="deleteQueue(selectedQueue.uuid)"
+            text="Confirmar"
+          />
+        </template>
+      </unnnic-modal>
     </section>
   </section>
 </template>
@@ -119,6 +136,7 @@ export default {
 
   data: () => ({
     currentTab: '',
+    openModal: false,
     sector: {
       uuid: '',
       name: '',
@@ -143,6 +161,7 @@ export default {
     currentTags: [],
     toAddTags: [],
     toRemoveTags: [],
+    selectedQueue: [],
   }),
 
   methods: {
@@ -154,6 +173,8 @@ export default {
       const sectorUuid = this.sector.uuid;
       await Queue.create({ name, sectorUuid });
       await this.getQueues();
+      const lastQueue = this.queues[this.queues.length - 1];
+      this.visualizeQueue(lastQueue);
     },
     async visualizeQueue(queue) {
       let agents = [];
@@ -172,6 +193,14 @@ export default {
       await Queue.delete(queueUuid);
       this.queues = this.queues.filter((queue) => queue.uuid !== queueUuid);
       this.queueToEdit = null;
+      this.closeModalDeleteQueue();
+    },
+    async openModalDeleteQueue(queue) {
+      this.selectedQueue = queue;
+      this.openModal = true;
+    },
+    async closeModalDeleteQueue() {
+      this.openModal = false;
     },
     async getSector() {
       const { name, rooms_limit, uuid, work_end, work_start } = await Sector.find(this.uuid);

--- a/src/views/Settings/Sectors/Edit.vue
+++ b/src/views/Settings/Sectors/Edit.vue
@@ -66,13 +66,18 @@
 
     <section class="actions">
       <unnnic-button
-        v-if="!!queueToEdit"
+        v-if="!!queueToEdit && this.currentTab === 'queues'"
         text="Excluir"
         icon-left="delete-1"
         type="terciary"
         @click="openModalDeleteQueue(queueToEdit)"
       />
-      <unnnic-button text="Salvar" type="secondary" @click="save" />
+      <unnnic-button
+        text="Salvar"
+        type="secondary"
+        @click="save"
+        v-if="this.currentTab === 'sector'"
+      />
       <unnnic-modal
         :showModal="openModal"
         modalIcon="alert-circle-1"
@@ -238,7 +243,7 @@ export default {
       if (this.currentTab === 'queues' && this.queueToEdit) await this.saveQueue();
       if (this.currentTab === 'tags') await this.saveTags();
 
-      this.$router.push({ name: 'sectors' });
+      // this.$router.push({ name: 'sectors' });
     },
 
     async removeManager(managerUuid) {
@@ -353,7 +358,7 @@ export default {
     height: 100%;
     overflow-y: auto;
     padding-right: 1rem;
-    margin-right: 0.5rem;
+    // margin-right: 0.5rem;
   }
 
   .actions {

--- a/src/views/Settings/Sectors/Edit.vue
+++ b/src/views/Settings/Sectors/Edit.vue
@@ -211,6 +211,11 @@ export default {
 
       this.$router.push({ name: 'sectors' });
     },
+
+    async removeManager(managerUuid) {
+      await Sector.removeManager(managerUuid);
+      this.removeManagerFromTheList(managerUuid);
+    },
     async saveSector() {
       const { uuid, name, workingDay, maxSimultaneousChatsByAgent } = this.sector;
       const sector = {
@@ -263,7 +268,7 @@ export default {
       if (currentTab === 'tags' && this.tags.length === 0) await this.getTags();
       this.queueToEdit = null;
     },
-    removeManager(managerUuid) {
+    removeManagerFromTheList(managerUuid) {
       const manager = this.sector.managers.find((manager) => manager.uuid === managerUuid);
       if (!manager) return;
 

--- a/src/views/Settings/index.vue
+++ b/src/views/Settings/index.vue
@@ -82,7 +82,7 @@ export default {
 .settings-chats {
   overflow-y: auto;
   padding-right: 1rem;
-  margin-right: 0.5rem;
+  // margin-right: 0.5rem;
 
   header {
     margin-bottom: 1.5rem;

--- a/src/views/chats/ActiveChat.vue
+++ b/src/views/chats/ActiveChat.vue
@@ -61,8 +61,8 @@
       scheme="feedback-yellow"
     >
       <template #options>
-        <unnnic-button :text="$t('confirm')" type="terciary" @click="classifyRoom" />
-        <unnnic-button :text="$t('cancel')" @click="isCloseChatModalOpen = false" />
+        <unnnic-button :text="$t('cancel')" type="terciary" @click="isCloseChatModalOpen = false" />
+        <unnnic-button :text="$t('confirm')" type="secondary" @click="classifyRoom" />
       </template>
     </unnnic-modal>
 

--- a/src/views/chats/ClosedChats.vue
+++ b/src/views/chats/ClosedChats.vue
@@ -44,20 +44,10 @@
               </option>
             </unnnic-select>
           </div>
-
-          <!-- <unnnic-multi-select
-              v-model="tags"
-              class="input"
-              label="Filtrar por tags"
-              input-title="Pesquise e selecione tags"
-              expand
-              hide-group-title
-              style="width: 35%"
-            /> -->
           <div class="unnnic-grid-span-3">
             <div style="padding-top: 38px"></div>
             <unnnic-autocomplete-select
-              :value="[]"
+              v-model="selecteds"
               :items="tags"
               placeholder="Pesquisar tags"
               :disabled="!this.filteredSectorUuid"
@@ -80,7 +70,6 @@
                 icon="button-refresh-arrows-1"
                 size="large"
                 @click="clearFilters"
-                style="margin-left: -28px"
               />
             </unnnic-tool-tip>
           </div>
@@ -175,6 +164,7 @@ export default {
       end: moment(new Date()).endOf('month').format('YYYY-MM-DD'),
     },
     sectorTags: [],
+    selecteds: [],
     contacts: [],
     sectors: [],
     filteredSectorUuid: '',
@@ -220,13 +210,9 @@ export default {
     },
 
     filteredTags() {
-      if (this.tags.length === 0) return [];
-
-      const group = this.tags[0];
-      if (!group?.selected && group?.selected !== 0) return [];
-
-      const tag = group.items[group.selected];
-      return [tag];
+      if (this.selecteds.length === 0) return [];
+      const group = this.selecteds;
+      return group;
     },
   },
 
@@ -265,11 +251,8 @@ export default {
         const response = await Sector.tags(sectorUuid);
         const tags = response.results;
 
-        const tagGroup = {
-          items: tags.map((tag) => ({ ...tag, title: tag.name })),
-        };
-
-        this.tags = [tagGroup];
+        const tagGroup = tags.map((tag) => ({ ...tag, value: tag.uuid, text: tag.name }));
+        this.tags = tagGroup;
         this.isLoading = false;
       } catch (error) {
         this.isLoading = false;
@@ -288,15 +271,7 @@ export default {
     contactHasAllActiveFilterTags(contact) {
       if (this.filteredTags.length === 0) return true;
       if (!contact.room.tags) return false;
-
-      // eslint-disable-next-line no-restricted-syntax
-      for (const tag of this.filteredTags) {
-        if (!contact.room.tags.some((t) => t.uuid === tag.uuid)) {
-          return false;
-        }
-      }
-
-      return true;
+      return contact.room.tags.some((tag) => this.filteredTags.find((el) => el.uuid === tag.uuid));
     },
 
     isRoomEndDateInFilteredRange(contact) {

--- a/src/views/chats/ClosedChats.vue
+++ b/src/views/chats/ClosedChats.vue
@@ -23,8 +23,8 @@
           </div>
         </header>
 
-        <section class="filters">
-          <div style="display: flex; align-items: flex-end; gap: 1rem; width: 100%">
+        <section class="filters unnnic-grid-giant" style="padding: 0">
+          <div class="unnnic-grid-span-3">
             <unnnic-select
               v-if="sectors.length > 1"
               v-model="filteredSectorUuid"
@@ -43,8 +43,9 @@
                 {{ sector.name }}
               </option>
             </unnnic-select>
+          </div>
 
-            <!-- <unnnic-multi-select
+          <!-- <unnnic-multi-select
               v-model="tags"
               class="input"
               label="Filtrar por tags"
@@ -53,13 +54,17 @@
               hide-group-title
               style="width: 35%"
             /> -->
+          <div class="unnnic-grid-span-3">
+            <div style="padding-top: 38px"></div>
             <unnnic-autocomplete-select
               :value="[]"
               :items="tags"
               placeholder="Pesquisar tags"
               :disabled="!this.filteredSectorUuid"
             />
-
+          </div>
+          <div class="unnnic-grid-span-3">
+            <div style="padding-top: 38px"></div>
             <unnnic-input-date-picker
               v-model="filteredDateRange"
               size="md"
@@ -67,15 +72,17 @@
               :input-format="$t('date_format')"
               position="right"
             />
-            <div class="clear-filters-button">
-              <unnnic-tool-tip enabled :text="$t('filter.clear_all')" side="right">
-                <unnnic-button-icon
-                  icon="button-refresh-arrows-1"
-                  size="large"
-                  @click="clearFilters"
-                />
-              </unnnic-tool-tip>
-            </div>
+          </div>
+          <div class="clear-filters-button unnnic-grid-span-1">
+            <div style="padding-top: 38px"></div>
+            <unnnic-tool-tip enabled :text="$t('filter.clear_all')" side="right">
+              <unnnic-button-icon
+                icon="button-refresh-arrows-1"
+                size="large"
+                @click="clearFilters"
+                style="margin-left: -28px"
+              />
+            </unnnic-tool-tip>
           </div>
         </section>
 
@@ -105,7 +112,7 @@
                 <unnnic-button
                   :text="$t('chats.open_chat')"
                   type="secondary"
-                  size="small"
+                  size="large"
                   class="visualize-button"
                   @click="openContactHistory(item)"
                 />
@@ -359,10 +366,10 @@ export default {
   }
 
   .filters {
-    display: flex;
-    align-items: flex-end;
-    gap: $unnnic-spacing-stack-sm;
-    width: 100%;
+    // display: flex;
+    // align-items: flex-end;
+    // gap: $unnnic-spacing-stack-sm;
+    // width: 100%;
 
     & > .input {
       flex: 1 1;

--- a/src/views/chats/ClosedChats.vue
+++ b/src/views/chats/ClosedChats.vue
@@ -49,7 +49,7 @@
             <unnnic-autocomplete-select
               v-model="selecteds"
               :items="tags"
-              :placeholder="messageInputTags"
+              :placeholder="this.messageInputTags"
               :disabled="!this.filteredSectorUuid"
             />
           </div>
@@ -156,9 +156,9 @@ export default {
   },
 
   data: () => ({
-    messageInputTags: 'Pesquisar tags',
     contact: null,
     messages: [],
+    messageInputTags: 'Filtrar por tags',
     isLoading: false,
     filteredDateRange: {
       start: moment(new Date()).startOf('month').format('YYYY-MM-DD'),
@@ -272,6 +272,8 @@ export default {
     contactHasAllActiveFilterTags(contact) {
       if (this.filteredTags.length === 0) return true;
       if (!contact.room.tags) return false;
+      // const placeholderTags = this.filteredTags.map((el) => el.name);
+      // this.messageInputTags = placeholderTags ? placeholderTags.toString() : 'Filtrar por tags';
       return contact.room.tags.some((tag) => this.filteredTags.find((el) => el.uuid === tag.uuid));
     },
 

--- a/src/views/chats/ClosedChats.vue
+++ b/src/views/chats/ClosedChats.vue
@@ -49,7 +49,7 @@
             <unnnic-autocomplete-select
               v-model="selecteds"
               :items="tags"
-              placeholder="Pesquisar tags"
+              :placeholder="messageInputTags"
               :disabled="!this.filteredSectorUuid"
             />
           </div>
@@ -156,6 +156,7 @@ export default {
   },
 
   data: () => ({
+    messageInputTags: 'Pesquisar tags',
     contact: null,
     messages: [],
     isLoading: false,

--- a/src/views/chats/ClosedChats.vue
+++ b/src/views/chats/ClosedChats.vue
@@ -32,7 +32,6 @@
               size="md"
               class="input"
               @input="getSectorTags(filteredSectorUuid)"
-              style="width: 25%"
             >
               <option value="">Todos</option>
               <option
@@ -45,7 +44,7 @@
               </option>
             </unnnic-select>
 
-            <unnnic-multi-select
+            <!-- <unnnic-multi-select
               v-model="tags"
               class="input"
               label="Filtrar por tags"
@@ -53,6 +52,12 @@
               expand
               hide-group-title
               style="width: 35%"
+            /> -->
+            <unnnic-autocomplete-select
+              :value="[]"
+              :items="tags"
+              placeholder="Pesquisar tags"
+              :disabled="!this.filteredSectorUuid"
             />
 
             <unnnic-input-date-picker
@@ -60,6 +65,7 @@
               size="md"
               class="input"
               :input-format="$t('date_format')"
+              position="right"
             />
             <div class="clear-filters-button">
               <unnnic-tool-tip enabled :text="$t('filter.clear_all')" side="right">
@@ -127,6 +133,8 @@ import ChatsLayout from '@/layouts/ChatsLayout';
 import TagGroup from '@/components/TagGroup';
 import UserAvatar from '@/components/chats/UserAvatar';
 
+const moment = require('moment');
+
 export default {
   name: 'ClosedChatsView',
 
@@ -156,8 +164,8 @@ export default {
     messages: [],
     isLoading: false,
     filteredDateRange: {
-      start: '',
-      end: '',
+      start: moment(new Date()).startOf('month').format('YYYY-MM-DD'),
+      end: moment(new Date()).endOf('month').format('YYYY-MM-DD'),
     },
     sectorTags: [],
     contacts: [],
@@ -302,7 +310,10 @@ export default {
     clearFilters() {
       this.filteredSectorUuid = '';
       this.tags = [];
-      this.filteredDateRange = { start: '', end: '' };
+      this.filteredDateRange = {
+        start: moment(new Date()).startOf('month').format('YYYY-MM-DD'),
+        end: moment(new Date()).endOf('month').format('YYYY-MM-DD'),
+      };
     },
   },
 };

--- a/src/views/chats/ClosedChats.vue
+++ b/src/views/chats/ClosedChats.vue
@@ -323,7 +323,6 @@ export default {
   display: flex;
   flex-direction: column;
   height: 100%;
-  padding-right: $unnnic-spacing-inset-md;
 
   .messages {
     overflow-y: auto;


### PR DESCRIPTION
Field select user
Put width in the tooltips component
Put the names in alphabetic order on select manager and agent
Change the layout of save and delete button in the queue configuration
when a new queue is add, open the layout for add agents
Modal for confirmation of delete the queue
Fix the button of the queue because is was appearing in the sector part
Fixed the alert of saving the new configurations on sector e remove the redirecting part  
Fixed the margin of scroll in the list of sectors and sector configuration