### PR TITLE
WS reconnection when connection is closed

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -257,24 +257,23 @@ export default {
     },
 
     intervalPing() {
-      try {
+      if (this.ws.ws.readyState === this.ws.ws.OPEN) {
         this.ws.send({
           type: 'ping',
           message: {},
         });
+        console.log('ping', `${new Date().getHours()}:${new Date().getMinutes()}`);
+      } else {
+        console.log('reconnecting');
         this.reconect();
-      } catch (error) {
-        console.log(error);
-        clearInterval(this.intervalPing);
       }
     },
 
     reconect() {
-      // if (!this.ws.pongData) return;
-      if (this.ws.pongData.type !== 'pong' && this.ws.pongData.type !== 'notify') {
-        this.ws.ws.close();
-        this.initializeWebSocket();
-      }
+      this.ws.ws.close();
+      console.log('close', `${new Date().getHours()}:${new Date().getMinutes()}`);
+      this.initializeWebSocket();
+      console.log('inicialize', `${new Date().getHours()}:${new Date().getMinutes()}`);
     },
   },
 };


### PR DESCRIPTION
The connection with the WebSocket closes when there is some instability in the server, but the front was not able to open the connection again. The old code tried to reconnect when catching 'catch' after sending 'ping' failed, but it didn't. Basically, the logic failure occurs when the method of sending 'ping' fails and, as it is asynchronous, it does not interrupt the flow, it just displays an error message on the console, so it would never fall into the 'catch'.

Better explanation in this thread: https://stackoverflow.com/questions/31002592/javascript-doesnt-catch-error-in-websocket-instantiation

Now, instead of waiting for the error to happen, a validation is performed to check the status of the connection with the WebSocket and if it is closed, it tries to reconnect.