### PR TITLE
Breadcrumb in queue configuration and automatic message field removed

### DIFF
--- a/src/components/settings/forms/Queue.vue
+++ b/src/components/settings/forms/Queue.vue
@@ -7,41 +7,6 @@
         <unnnic-icon-svg icon="information-circle-4" scheme="neutral-soft" size="sm" />
       </unnnic-tool-tip>
     </p>
-    <div style="margin-bottom: 24px">
-      <unnnic-chat-text
-        style="max-width: 100%; max-height: 100%"
-        titleColor="neutral-dark"
-        size="small"
-        title="Mensagem automática"
-        info="Defina uma resposta automática para ser enviada ao contato enquanto 
-            está aguardando atendimento, deixe em branco caso não queira 
-            nenhuma mensagem."
-      >
-        <template slot="actions">
-          <unnnic-button-icon
-            v-if="!editContent"
-            type="secondary"
-            size="small"
-            icon="pencil-write-1"
-            @click="editDescription"
-          />
-        </template>
-        <template slot="description">
-          <div style="word-break: break-all">
-            <span v-show="!editContent">{{ description }}</span>
-            <div v-show="editContent">
-              <unnnic-text-area
-                @focus="focusTextEditor"
-                size="sm"
-                placeholder="Por enquanto você não definiu uma mensagem automática, defina uma mensagem para seus contatos que estão aguardando"
-                v-model="queue.default_message"
-                ref="textEditor"
-              />
-            </div>
-          </div>
-        </template>
-      </unnnic-chat-text>
-    </div>
 
     <section class="controls">
       <unnnic-input
@@ -176,6 +141,8 @@ export default {
 
     .input {
       flex: 1 1;
+
+      margin-top: -0.5rem;
     }
   }
 }

--- a/src/views/Settings/Sectors/Edit.vue
+++ b/src/views/Settings/Sectors/Edit.vue
@@ -12,6 +12,11 @@
 
       <template #queues>
         <section v-if="!!queueToEdit" class="edit-sector__edit-queue">
+          <unnnic-breadcrumb
+            class="edit-sector__breadcrumb"
+            :crumbs="queueBreadcrumb"
+            @crumbClick="handleCrumbClick"
+          />
           <h2 class="edit-sector__title">{{ queueToEdit.name }}</h2>
           <div style="margin-bottom: 24px">
             <unnnic-chat-text
@@ -19,8 +24,8 @@
               titleColor="neutral-dark"
               size="small"
               title="Mensagem automática"
-              info="Defina uma resposta automática para ser enviada ao contato enquanto 
-            está aguardando atendimento, deixe em branco caso não queira 
+              info="Defina uma resposta automática para ser enviada ao contato enquanto
+            está aguardando atendimento, deixe em branco caso não queira
             nenhuma mensagem."
             >
               <template slot="actions">
@@ -194,6 +199,14 @@ export default {
       name: '',
     },
     queueToEdit: null,
+    queueBreadcrumb: [
+      {
+        name: 'Filas',
+      },
+      {
+        name: '',
+      },
+    ],
     removedManagers: [],
     queues: [],
     agents: [],
@@ -253,6 +266,7 @@ export default {
         this.queueToEdit.currentAgents = [...agents];
         this.queueToEdit.toAddAgents = [];
         this.queueToEdit.toRemoveAgents = [];
+        this.queueBreadcrumb.at(-1).name = this.queueToEdit.name;
         this.searchDefaultMessage(queue.uuid);
       } finally {
         this.loading = false;
@@ -475,6 +489,12 @@ export default {
       this.editContent = false;
       if (!this.queueToEdit.default_message) this.queueToEdit.default_message = '';
     },
+
+    handleCrumbClick(queueCrumb) {
+      if (queueCrumb.name === this.queueToEdit.name) return;
+
+      this.queueToEdit = null;
+    },
   },
 
   watch: {
@@ -510,6 +530,22 @@ export default {
 
     & > * {
       width: 100%;
+    }
+  }
+
+  &__breadcrumb {
+    margin: $unnnic-spacing-inline-sm 0;
+
+    ::v-deep .unnnic-breadcrumb__container {
+      align-items: center;
+
+      &__divider {
+        display: flex;
+
+        svg {
+          top: 0;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
On the settings page, the quick message field on the queues tab was removed and the breadcrumb was added when entering a queue edit.