### PR TITLE
Download images

### DIFF
--- a/src/components/chats/MediaMessage/Previews/Fullscreen.vue
+++ b/src/components/chats/MediaMessage/Previews/Fullscreen.vue
@@ -23,9 +23,9 @@
       <!-- This img above is temporary. Then it will be refactored to an unnnic-icon-svg  -->
 
       <!-- eslint-disable-next-line vuejs-accessibility/anchor-has-content -->
-      <a class="clickable" download :href="downloadMediaUrl" target="_blank">
+      <span class="clickable" @click="download" @keypress.enter="download" target="_blank">
         <unnnic-icon icon="download-bottom-1" scheme="neutral-snow" />
-      </a>
+      </span>
       <span @click="close" @keypress.enter="close" class="clickable">
         <unnnic-icon-svg icon="close-1" scheme="neutral-snow" />
       </span>
@@ -126,7 +126,17 @@ export default {
     },
 
     download() {
-      this.$emit('download');
+      fetch(this.downloadMediaUrl)
+        .then((response) => response.blob())
+        .then((blob) => {
+          const link = document.createElement('a');
+          link.href = window.URL.createObjectURL(blob);
+          link.download = true;
+
+          link.click();
+
+          window.URL.revokeObjectURL(link.href);
+        });
     },
 
     next() {

--- a/src/components/chats/MediaMessage/Previews/Fullscreen.vue
+++ b/src/components/chats/MediaMessage/Previews/Fullscreen.vue
@@ -23,9 +23,9 @@
       <!-- This img above is temporary. Then it will be refactored to an unnnic-icon-svg  -->
 
       <!-- eslint-disable-next-line vuejs-accessibility/anchor-has-content -->
-      <span class="clickable" @click="download" @keypress.enter="download" target="_blank">
+      <a class="clickable" download :href="downloadMediaUrl" target="_blank">
         <unnnic-icon icon="download-bottom-1" scheme="neutral-snow" />
-      </span>
+      </a>
       <span @click="close" @keypress.enter="close" class="clickable">
         <unnnic-icon-svg icon="close-1" scheme="neutral-snow" />
       </span>
@@ -126,17 +126,7 @@ export default {
     },
 
     download() {
-      fetch(this.downloadMediaUrl)
-        .then((response) => response.blob())
-        .then((blob) => {
-          const link = document.createElement('a');
-          link.href = window.URL.createObjectURL(blob);
-          link.download = true;
-
-          link.click();
-
-          window.URL.revokeObjectURL(link.href);
-        });
+      this.$emit('download');
     },
 
     next() {

--- a/src/components/chats/MediaMessage/Previews/Fullscreen.vue
+++ b/src/components/chats/MediaMessage/Previews/Fullscreen.vue
@@ -139,6 +139,14 @@ export default {
           link.click();
 
           window.URL.revokeObjectURL(link.href);
+        })
+        .catch(() => {
+          const link = document.createElement('a');
+          link.target = '_blank';
+          link.href = this.downloadMediaUrl;
+          link.download = this.downloadMediaName;
+
+          link.click();
         });
     },
 

--- a/src/components/chats/MediaMessage/Previews/Fullscreen.vue
+++ b/src/components/chats/MediaMessage/Previews/Fullscreen.vue
@@ -23,9 +23,9 @@
       <!-- This img above is temporary. Then it will be refactored to an unnnic-icon-svg  -->
 
       <!-- eslint-disable-next-line vuejs-accessibility/anchor-has-content -->
-      <a class="clickable" download :href="downloadMediaUrl" target="_blank">
+      <span class="clickable" @click="download">
         <unnnic-icon icon="download-bottom-1" scheme="neutral-snow" />
-      </a>
+      </span>
       <span @click="close" @keypress.enter="close" class="clickable">
         <unnnic-icon-svg icon="close-1" scheme="neutral-snow" />
       </span>
@@ -65,6 +65,9 @@ export default {
 
   props: {
     downloadMediaUrl: {
+      type: String,
+    },
+    downloadMediaName: {
       type: String,
     },
   },
@@ -126,7 +129,17 @@ export default {
     },
 
     download() {
-      this.$emit('download');
+      fetch(this.downloadMediaUrl)
+        .then((response) => response.blob())
+        .then((blob) => {
+          const link = document.createElement('a');
+          link.href = window.URL.createObjectURL(blob);
+          link.download = this.downloadMediaName;
+
+          link.click();
+
+          window.URL.revokeObjectURL(link.href);
+        });
     },
 
     next() {

--- a/src/components/chats/MediaMessage/Previews/Fullscreen.vue
+++ b/src/components/chats/MediaMessage/Previews/Fullscreen.vue
@@ -129,7 +129,11 @@ export default {
     },
 
     download() {
-      fetch(this.downloadMediaUrl)
+      fetch(this.downloadMediaUrl, {
+        headers: {
+          'Access-Control-Allow-Origin': 'https://chats.dev.cloud.weni.ai/',
+        },
+      })
         .then((response) => response.blob())
         .then((blob) => {
           const link = document.createElement('a');

--- a/src/components/chats/MediaMessage/Previews/Fullscreen.vue
+++ b/src/components/chats/MediaMessage/Previews/Fullscreen.vue
@@ -21,6 +21,11 @@
         :class="['unnnic-icon__size--md', 'unnnic--clickable', `unnnic-icon-scheme--neutral-snow`]"
       />
       <!-- This img above is temporary. Then it will be refactored to an unnnic-icon-svg  -->
+
+      <!-- eslint-disable-next-line vuejs-accessibility/anchor-has-content -->
+      <a class="clickable" download :href="downloadMediaUrl" target="_blank">
+        <unnnic-icon icon="download-bottom-1" scheme="neutral-snow" />
+      </a>
       <span @click="close" @keypress.enter="close" class="clickable">
         <unnnic-icon-svg icon="close-1" scheme="neutral-snow" />
       </span>
@@ -57,6 +62,12 @@ import rotateLeftIcon from '@/assets/temporaryUndoIcon.svg';
 
 export default {
   name: 'FullscreenPreview',
+
+  props: {
+    downloadMediaUrl: {
+      type: String,
+    },
+  },
 
   data() {
     return {

--- a/src/components/chats/chat/ChatMessages.vue
+++ b/src/components/chats/chat/ChatMessages.vue
@@ -97,7 +97,7 @@
     </unnnic-modal>
     <fullscreen-preview
       v-if="isFullscreen"
-      @download="$emit('download')"
+      :downloadMediaUrl="currentMedia.url"
       @close="isFullscreen = false"
       @next="nextMedia"
       @previous="previousMedia"

--- a/src/components/chats/chat/ChatMessages.vue
+++ b/src/components/chats/chat/ChatMessages.vue
@@ -98,6 +98,7 @@
     <fullscreen-preview
       v-if="isFullscreen"
       :downloadMediaUrl="currentMedia.url"
+      :downloadMediaName="currentMedia.message"
       @close="isFullscreen = false"
       @next="nextMedia"
       @previous="previousMedia"


### PR DESCRIPTION
Added a button to download the images available in the chat.

- The treatedUrl function is necessary so that the url coming from the image is treated and returned as one that can be fetched directly from the frontend.
- The `a` element was not used for download, since the images in s3 do not have the header _Content-Disposition: attachment;_, which makes it impossible to download directly.