### PR TITLE
 Fixed table metrics for key

### DIFF
--- a/src/components/dashboard/TableMetrics.vue
+++ b/src/components/dashboard/TableMetrics.vue
@@ -13,7 +13,7 @@
       </header>
 
       <section class="items">
-        <section v-for="item in items" :key="item.user__first_name" class="item table-row">
+        <section v-for="item in items" :key="item.user" class="item table-row">
           <span class="table-col">
             {{ item.user__first_name }}
           </span>


### PR DESCRIPTION
Fixed the crash in dashboard that occurred when trying to filter a sector that had agents with the same names. 
The problem was in passing the key, which previously differentiated by name and was adjusted to differentiate by email