### PR TITLE
Adjusted the shortcut for keys to uuids

### DIFF
--- a/src/components/chats/MessageEditor/SuggestionBox.vue
+++ b/src/components/chats/MessageEditor/SuggestionBox.vue
@@ -9,7 +9,7 @@
     <section class="suggestion-box__shortcuts" @mousemove="activeShortcutIndex = -1">
       <div
         v-for="(suggestion, index) in filteredSuggestions"
-        :key="suggestion.shortcut"
+        :key="suggestion.uuid"
         @click="select(suggestion)"
         @keypress.enter="select(suggestion)"
         tabindex="-1"


### PR DESCRIPTION
Fixed crash when shotcurts were opened and there were many duplicate keys