### PR TITLE
Quick messages by sector

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -132,7 +132,8 @@ export default {
       this.loading = true;
       let hasNext = false;
       try {
-        const response = await QuickMessage.all(this.page * this.limit, this.limit);
+        const { page, limit } = this;
+        const response = await QuickMessage.getAll({ offset: page * limit, limit, sector: true });
         this.page += 1;
         this.$store.state.chats.quickMessages.messages =
           this.$store.state.chats.quickMessages.messages.concat(response.results);

--- a/src/components/chats/AppAccordion.vue
+++ b/src/components/chats/AppAccordion.vue
@@ -57,6 +57,7 @@ export default {
 <style lang="scss" scoped>
 .app-accordion {
   margin-bottom: $unnnic-spacing-stack-sm;
+
   header {
     display: flex;
     align-items: center;

--- a/src/components/chats/AppAccordion.vue
+++ b/src/components/chats/AppAccordion.vue
@@ -2,12 +2,15 @@
 <template>
   <div>
     <div
+      class="app-accordion"
       @click="toggleAccordion()"
       :aria-expanded="isOpen"
       :aria-controls="`collapse${_uid}`"
       style="display: flex; align-items: center; justify-content: space-between; cursor: pointer"
     >
-      <slot name="title" />
+      <header :class="{ disabled }">
+        <h2>{{ title }}</h2>
+      </header>
       <unnnic-icon
         size="xs"
         :icon="isOpen ? 'arrow-button-up-1' : 'arrow-button-down-1'"
@@ -32,6 +35,10 @@ export default {
     };
   },
   props: {
+    title: {
+      type: String,
+      default: 'Seção',
+    },
     isDefaultOpen: {
       type: Boolean,
       default: true,
@@ -47,4 +54,27 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.app-accordion {
+  header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    padding: 0 0 0.5rem 0.5rem;
+
+    &.disabled {
+      h2 {
+        color: $unnnic-color-neutral-lightest;
+      }
+    }
+
+    h2 {
+      font-size: $unnnic-font-size-body-md;
+      font-weight: $unnnic-font-weight-regular;
+      line-height: 1.25rem;
+      color: $unnnic-color-neutral-cloudy;
+    }
+  }
+}
+</style>

--- a/src/components/chats/AppAccordion.vue
+++ b/src/components/chats/AppAccordion.vue
@@ -56,12 +56,11 @@ export default {
 
 <style lang="scss" scoped>
 .app-accordion {
+  margin-bottom: $unnnic-spacing-stack-sm;
   header {
     display: flex;
     align-items: center;
     justify-content: space-between;
-
-    padding: 0 0 0.5rem 0.5rem;
 
     h2 {
       font-size: $unnnic-font-size-body-md;

--- a/src/components/chats/AppAccordion.vue
+++ b/src/components/chats/AppAccordion.vue
@@ -8,7 +8,7 @@
       :aria-controls="`collapse${_uid}`"
       style="display: flex; align-items: center; justify-content: space-between; cursor: pointer"
     >
-      <header :class="{ disabled }">
+      <header>
         <h2>{{ title }}</h2>
       </header>
       <unnnic-icon
@@ -62,12 +62,6 @@ export default {
     justify-content: space-between;
 
     padding: 0 0 0.5rem 0.5rem;
-
-    &.disabled {
-      h2 {
-        color: $unnnic-color-neutral-lightest;
-      }
-    }
 
     h2 {
       font-size: $unnnic-font-size-body-md;

--- a/src/components/chats/MessageEditor/index.vue
+++ b/src/components/chats/MessageEditor/index.vue
@@ -86,6 +86,8 @@
 </template>
 
 <script>
+import { mapState } from 'vuex';
+
 import TextBox from './TextBox';
 import MoreActionsOption from './MoreActionsOption.vue';
 import SuggestionBox from './SuggestionBox.vue';
@@ -126,6 +128,11 @@ export default {
   }),
 
   computed: {
+    ...mapState({
+      quickMessages: (state) => state.chats.quickMessages.quickMessages,
+      quickMessagesShared: (state) => state.chats.quickMessagesShared.quickMessagesShared,
+    }),
+
     message: {
       get() {
         return this.value;
@@ -149,7 +156,7 @@ export default {
       );
     },
     shortcuts() {
-      return this.$store.state.chats.quickMessages.messages;
+      return [...this.quickMessages, ...this.quickMessagesShared];
     },
     showActionButton() {
       const { isTyping, isAudioRecorderVisible, loadingValue } = this;

--- a/src/components/chats/QuickMessages/QuickMessageCard.vue
+++ b/src/components/chats/QuickMessages/QuickMessageCard.vue
@@ -15,7 +15,7 @@
       "
       size="small"
     >
-      <template slot="actions">
+      <template slot="actions" v-if="withActions">
         <unnnic-dropdown>
           <template #trigger>
             <unnnic-tool-tip enabled :text="$t('quick_messages.delete_or_edit')" side="left">
@@ -57,13 +57,17 @@ export default {
   name: 'QuickMessageCard',
 
   props: {
+    quickMessage: {
+      type: Object,
+      required: true,
+    },
     clickable: {
       type: Boolean,
       default: false,
     },
-    quickMessage: {
-      type: Object,
-      required: true,
+    withActions: {
+      type: Boolean,
+      default: true,
     },
   },
 };

--- a/src/components/chats/QuickMessages/QuickMessageCard.vue
+++ b/src/components/chats/QuickMessages/QuickMessageCard.vue
@@ -75,6 +75,10 @@ export default {
 
 <style lang="scss" scoped>
 .quick-message-card {
+  :deep(.unnnic-chat-text) {
+    line-break: anywhere;
+  }
+
   .quick-message-actions {
     display: flex;
     align-items: center;
@@ -84,6 +88,8 @@ export default {
     display: flex;
     align-items: center;
     gap: 0.5rem;
+
+    white-space: nowrap;
   }
 }
 .clickable {

--- a/src/components/chats/QuickMessages/QuickMessageForm.vue
+++ b/src/components/chats/QuickMessages/QuickMessageForm.vue
@@ -32,7 +32,7 @@
       size="sm"
     />
 
-    <div class="actions">
+    <div class="actions" v-if="!externalActions">
       <unnnic-button
         class="button"
         :text="$t('cancel')"
@@ -60,6 +60,10 @@ export default {
     value: {
       type: Object,
       default: null,
+    },
+    externalActions: {
+      type: Boolean,
+      default: false,
     },
   },
 

--- a/src/components/chats/QuickMessages/QuickMessageForm.vue
+++ b/src/components/chats/QuickMessages/QuickMessageForm.vue
@@ -3,7 +3,7 @@
     <unnnic-input
       :value="quickMessage.title"
       @input="quickMessage = { ...quickMessage, title: $event }"
-      size="sm"
+      :size="size"
       :label="$t('title')"
       :placeholder="$t('quick_messages.title_field_placeholder')"
     />
@@ -11,7 +11,7 @@
     <unnnic-input
       :value="quickMessage.shortcut"
       @input="quickMessage = { ...quickMessage, shortcut: $event }"
-      size="sm"
+      :size="size"
       :placeholder="$t('quick_messages.shortcut_field_placeholder')"
     >
       <template #label>
@@ -29,7 +29,7 @@
       @input="quickMessage = { ...quickMessage, text: $event }"
       :label="$t('message')"
       :placeholder="$t('quick_messages.message_field_placeholder')"
-      size="sm"
+      :size="size"
     />
 
     <div class="actions" v-if="!externalActions">
@@ -60,6 +60,10 @@ export default {
     value: {
       type: Object,
       default: null,
+    },
+    size: {
+      type: String,
+      default: 'sm',
     },
     externalActions: {
       type: Boolean,

--- a/src/components/chats/QuickMessages/index.vue
+++ b/src/components/chats/QuickMessages/index.vue
@@ -29,6 +29,7 @@
                 v-for="quickMessage in quickMessagesShared"
                 :key="quickMessage.uuid"
                 :quickMessage="quickMessage"
+                :withActions="false"
                 clickable
                 @select="$emit('select-quick-message', quickMessage)"
                 @edit="quickMessageToEdit = quickMessage"

--- a/src/components/chats/QuickMessages/index.vue
+++ b/src/components/chats/QuickMessages/index.vue
@@ -5,51 +5,49 @@
     icon="flash-1-3"
     @action="$emit('close')"
   >
-    <section class="messages-container">
-      <aside-slot-template-section class="messages-section">
-        <div>
-          <app-accordion class="messages" :title="$t('quick_messages.personal')">
-            <template v-slot:content>
-              <div class="chat-group">
-                <quick-message-card
-                  v-for="quickMessage in $store.state.chats.quickMessages.messages"
-                  :key="quickMessage.uuid"
-                  :quickMessage="quickMessage"
-                  clickable
-                  @select="$emit('select-quick-message', quickMessage)"
-                  @edit="quickMessageToEdit = quickMessage"
-                  @delete="quickMessageToDelete = quickMessage"
-                />
-              </div>
-            </template>
-          </app-accordion>
-          <app-accordion class="messages-shared" :title="$t('quick_messages.shared')">
-            <template v-slot:content>
-              <div class="chat-group">
-                <quick-message-card
-                  v-for="quickMessage in $store.state.chats.quickMessages.messages"
-                  :key="quickMessage.uuid"
-                  :quickMessage="quickMessage"
-                  clickable
-                  @select="$emit('select-quick-message', quickMessage)"
-                  @edit="quickMessageToEdit = quickMessage"
-                  @delete="quickMessageToDelete = quickMessage"
-                />
-              </div>
-            </template>
-          </app-accordion>
-        </div>
+    <aside-slot-template-section class="messages-section__container">
+      <div class="messages-section">
+        <app-accordion class="messages" :title="$t('quick_messages.personal')">
+          <template v-slot:content>
+            <div class="chat-group">
+              <quick-message-card
+                v-for="quickMessage in quickMessages"
+                :key="quickMessage.uuid"
+                :quickMessage="quickMessage"
+                clickable
+                @select="$emit('select-quick-message', quickMessage)"
+                @edit="quickMessageToEdit = quickMessage"
+                @delete="quickMessageToDelete = quickMessage"
+              />
+            </div>
+          </template>
+        </app-accordion>
+        <app-accordion class="messages-shared" :title="$t('quick_messages.shared')">
+          <template v-slot:content>
+            <div class="chat-group">
+              <quick-message-card
+                v-for="quickMessage in quickMessagesShared"
+                :key="quickMessage.uuid"
+                :quickMessage="quickMessage"
+                clickable
+                @select="$emit('select-quick-message', quickMessage)"
+                @edit="quickMessageToEdit = quickMessage"
+                @delete="quickMessageToDelete = quickMessage"
+              />
+            </div>
+          </template>
+        </app-accordion>
+      </div>
 
-        <unnnic-button
-          icon-left="add-circle-1"
-          :text="$t('quick_messages.add_new')"
-          type="secondary"
-          size="small"
-          class="fill-w"
-          @click="quickMessageToEdit = createEmptyQuickMessage()"
-        />
-      </aside-slot-template-section>
-    </section>
+      <unnnic-button
+        icon-left="add-circle-1"
+        :text="$t('quick_messages.add_new')"
+        type="secondary"
+        size="small"
+        class="fill-w"
+        @click="quickMessageToEdit = createEmptyQuickMessage()"
+      />
+    </aside-slot-template-section>
 
     <unnnic-modal
       :text="$t('quick_messages.delete')"
@@ -96,6 +94,7 @@ import AsideSlotTemplate from '@/components/layouts/chats/AsideSlotTemplate';
 import AsideSlotTemplateSection from '@/components/layouts/chats/AsideSlotTemplate/Section';
 import AppAccordion from '@/components/chats/AppAccordion';
 import QuickMessage from '@/services/api/resources/chats/quickMessage';
+import { mapState } from 'vuex';
 import QuickMessageCard from './QuickMessageCard';
 import QuickMessageForm from './QuickMessageForm';
 
@@ -116,6 +115,11 @@ export default {
   }),
 
   computed: {
+    ...mapState({
+      quickMessages: (state) => state.chats.quickMessages.quickMessages,
+      quickMessagesShared: (state) => state.chats.quickMessagesShared.quickMessagesShared,
+    }),
+
     isEditing() {
       return !!this.quickMessageToEdit && this.quickMessageToEdit.id;
     },
@@ -185,29 +189,28 @@ export default {
   width: 103%;
 }
 
-.messages-container {
+.messages-section {
   height: 100%;
+  overflow: hidden scroll;
 
-  .messages-section {
+  &__container {
     display: flex;
     flex-direction: column;
     gap: $unnnic-spacing-stack-sm;
     height: 100%;
   }
+}
 
-  .messages {
-    flex: 1 1;
-    display: flex;
-    flex-direction: column;
-    gap: $unnnic-spacing-stack-sm;
-    border-right: solid 1px #e2e6ed;
+.messages {
+  flex: 1 1;
+  display: flex;
+  flex-direction: column;
+  gap: $unnnic-spacing-stack-sm;
+  border-right: solid 1px #e2e6ed;
 
-    max-height: 100%;
-    overflow: hidden auto;
-    // insert space between content and scrollbar
-    margin-right: -$unnnic-spacing-inline-md;
-    padding-right: $unnnic-spacing-inset-md;
-  }
+  // insert space between content and scrollbar
+  margin-right: -$unnnic-spacing-inline-md;
+  padding-right: $unnnic-spacing-inset-md;
 }
 
 .quick-message-form {

--- a/src/components/chats/QuickMessages/index.vue
+++ b/src/components/chats/QuickMessages/index.vue
@@ -9,7 +9,7 @@
       <div class="messages-section">
         <app-accordion class="messages" :title="$t('quick_messages.personal')">
           <template v-slot:content>
-            <div class="chat-group">
+            <div class="messages-group">
               <quick-message-card
                 v-for="quickMessage in quickMessages"
                 :key="quickMessage.uuid"
@@ -22,9 +22,13 @@
             </div>
           </template>
         </app-accordion>
-        <app-accordion class="messages-shared" :title="$t('quick_messages.shared')">
+        <app-accordion
+          v-if="quickMessagesShared.length > 0"
+          class="messages-shared"
+          :title="$t('quick_messages.shared')"
+        >
           <template v-slot:content>
-            <div class="chat-group">
+            <div class="messages-group">
               <quick-message-card
                 v-for="quickMessage in quickMessagesShared"
                 :key="quickMessage.uuid"
@@ -195,7 +199,15 @@ export default {
 .messages-section {
   height: 100%;
   width: 100%;
-  overflow: hidden scroll;
+  overflow: hidden auto;
+
+  display: grid;
+  grid-template-rows: auto 1fr;
+  gap: $unnnic-spacing-stack-md;
+
+  // insert space between content and scrollbar
+  margin-right: -$unnnic-spacing-inline-sm;
+  padding-right: $unnnic-spacing-inline-sm;
 
   &__container {
     display: flex;
@@ -209,11 +221,11 @@ export default {
   flex: 1 1;
   display: flex;
   flex-direction: column;
-  gap: $unnnic-spacing-stack-sm;
 
-  // insert space between content and scrollbar
-  margin-right: -$unnnic-spacing-inline-md;
-  padding-right: $unnnic-spacing-inset-md;
+  &-group {
+    display: grid;
+    gap: $unnnic-spacing-stack-sm;
+  }
 }
 
 .quick-message-form {

--- a/src/components/chats/QuickMessages/index.vue
+++ b/src/components/chats/QuickMessages/index.vue
@@ -89,12 +89,14 @@
 </template>
 
 <script>
+import { mapState, mapActions } from 'vuex';
+
 import { unnnicCallAlert } from '@weni/unnnic-system';
+
 import AsideSlotTemplate from '@/components/layouts/chats/AsideSlotTemplate';
 import AsideSlotTemplateSection from '@/components/layouts/chats/AsideSlotTemplate/Section';
 import AppAccordion from '@/components/chats/AppAccordion';
-import QuickMessage from '@/services/api/resources/chats/quickMessage';
-import { mapState } from 'vuex';
+
 import QuickMessageCard from './QuickMessageCard';
 import QuickMessageForm from './QuickMessageForm';
 
@@ -129,9 +131,14 @@ export default {
   },
 
   methods: {
+    ...mapActions({
+      actionCreateQuickMessage: 'chats/quickMessages/create',
+      actionUpdateQuickMessage: 'chats/quickMessages/update',
+      actionDeleteQuickMessage: 'chats/quickMessages/delete',
+    }),
+
     async createQuickMessage({ title, text, shortcut }) {
-      const quickMessage = await QuickMessage.create({ title, text, shortcut });
-      this.$store.state.chats.quickMessages.messages.push(quickMessage);
+      this.actionCreateQuickMessage({ title, text, shortcut });
 
       unnnicCallAlert({
         props: {
@@ -147,11 +154,7 @@ export default {
       this.quickMessageToEdit = null;
     },
     async updateQuickMessage({ uuid, title, text, shortcut }) {
-      const quickMessage = await QuickMessage.update(uuid, { title, text, shortcut });
-      this.$store.state.chats.quickMessages.messages =
-        this.$store.state.chats.quickMessages.messages.map((m) =>
-          m.uuid === quickMessage.uuid ? quickMessage : m,
-        );
+      this.actionUpdateQuickMessage({ uuid, title, text, shortcut });
 
       unnnicCallAlert({
         props: {
@@ -171,9 +174,8 @@ export default {
     },
     async deleteQuickMessage() {
       const { uuid } = this.quickMessageToDelete;
-      await QuickMessage.delete(uuid);
-      this.$store.state.chats.quickMessages.messages =
-        this.$store.state.chats.quickMessages.messages.filter((m) => m.uuid !== uuid);
+
+      this.actionDeleteQuickMessage(uuid);
       this.quickMessageToDelete = null;
     },
   },

--- a/src/components/chats/QuickMessages/index.vue
+++ b/src/components/chats/QuickMessages/index.vue
@@ -7,16 +7,37 @@
   >
     <section class="messages-container">
       <aside-slot-template-section class="messages-section">
-        <div class="messages">
-          <quick-message-card
-            v-for="quickMessage in $store.state.chats.quickMessages.messages"
-            :key="quickMessage.uuid"
-            :quickMessage="quickMessage"
-            clickable
-            @select="$emit('select-quick-message', quickMessage)"
-            @edit="quickMessageToEdit = quickMessage"
-            @delete="quickMessageToDelete = quickMessage"
-          />
+        <div>
+          <app-accordion class="messages" :title="$t('quick_messages.personal')">
+            <template v-slot:content>
+              <div class="chat-group">
+                <quick-message-card
+                  v-for="quickMessage in $store.state.chats.quickMessages.messages"
+                  :key="quickMessage.uuid"
+                  :quickMessage="quickMessage"
+                  clickable
+                  @select="$emit('select-quick-message', quickMessage)"
+                  @edit="quickMessageToEdit = quickMessage"
+                  @delete="quickMessageToDelete = quickMessage"
+                />
+              </div>
+            </template>
+          </app-accordion>
+          <app-accordion class="messages-shared" :title="$t('quick_messages.shared')">
+            <template v-slot:content>
+              <div class="chat-group">
+                <quick-message-card
+                  v-for="quickMessage in $store.state.chats.quickMessages.messages"
+                  :key="quickMessage.uuid"
+                  :quickMessage="quickMessage"
+                  clickable
+                  @select="$emit('select-quick-message', quickMessage)"
+                  @edit="quickMessageToEdit = quickMessage"
+                  @delete="quickMessageToDelete = quickMessage"
+                />
+              </div>
+            </template>
+          </app-accordion>
         </div>
 
         <unnnic-button
@@ -73,6 +94,7 @@
 import { unnnicCallAlert } from '@weni/unnnic-system';
 import AsideSlotTemplate from '@/components/layouts/chats/AsideSlotTemplate';
 import AsideSlotTemplateSection from '@/components/layouts/chats/AsideSlotTemplate/Section';
+import AppAccordion from '@/components/chats/AppAccordion';
 import QuickMessage from '@/services/api/resources/chats/quickMessage';
 import QuickMessageCard from './QuickMessageCard';
 import QuickMessageForm from './QuickMessageForm';
@@ -83,6 +105,7 @@ export default {
   components: {
     AsideSlotTemplate,
     AsideSlotTemplateSection,
+    AppAccordion,
     QuickMessageCard,
     QuickMessageForm,
   },
@@ -180,7 +203,7 @@ export default {
     border-right: solid 1px #e2e6ed;
 
     max-height: 100%;
-    overflow-y: auto;
+    overflow: hidden auto;
     // insert space between content and scrollbar
     margin-right: -$unnnic-spacing-inline-md;
     padding-right: $unnnic-spacing-inset-md;

--- a/src/components/chats/QuickMessages/index.vue
+++ b/src/components/chats/QuickMessages/index.vue
@@ -189,11 +189,12 @@ export default {
 }
 
 .fill-w {
-  width: 103%;
+  width: 100%;
 }
 
 .messages-section {
   height: 100%;
+  width: 100%;
   overflow: hidden scroll;
 
   &__container {
@@ -209,7 +210,6 @@ export default {
   display: flex;
   flex-direction: column;
   gap: $unnnic-spacing-stack-sm;
-  border-right: solid 1px #e2e6ed;
 
   // insert space between content and scrollbar
   margin-right: -$unnnic-spacing-inline-md;

--- a/src/components/settings/SectorTabs.vue
+++ b/src/components/settings/SectorTabs.vue
@@ -1,5 +1,5 @@
 <template>
-  <unnnic-tab v-model="tab" initialTab="sector" :tabs="tabs" class="sector-tabs">
+  <unnnic-tab v-model="tab" :initialTab="tab || 'sector'" :tabs="tabs" class="sector-tabs">
     <template slot="tab-head-sector">
       <div class="form-tab">
         <span class="name">{{ $t('sector.title') }}</span>

--- a/src/components/settings/SectorTabs.vue
+++ b/src/components/settings/SectorTabs.vue
@@ -12,6 +12,12 @@
       </div>
     </template>
 
+    <template slot="tab-head-quick-messages">
+      <div class="form-tab">
+        <span class="name">{{ $t('quick_messages.title') }}</span>
+      </div>
+    </template>
+
     <template slot="tab-head-tags">
       <div class="form-tab">
         <span class="name">{{ $t('tags.title') }}</span>
@@ -24,6 +30,10 @@
 
     <template slot="tab-panel-queues">
       <slot name="queues" />
+    </template>
+
+    <template slot="tab-panel-quick-messages">
+      <slot name="quick-messages" />
     </template>
 
     <template slot="tab-panel-tags">
@@ -50,7 +60,7 @@ export default {
   },
 
   data: () => ({
-    tabs: ['sector', 'queues', 'tags'],
+    tabs: ['sector', 'queues', 'quick-messages', 'tags'],
   }),
 
   computed: {

--- a/src/components/settings/forms/Queue.vue
+++ b/src/components/settings/forms/Queue.vue
@@ -19,19 +19,19 @@
     </section>
 
     <section v-if="isEditing" class="form-queue__queues">
-      <sector-queues-list :sector="sector.name" :queues="queues" @visualize="visualize" />
+      <list-sector-queues :sector="sector.name" :queues="queues" @visualize="visualize" />
     </section>
   </section>
 </template>
 
 <script>
-import SectorQueuesList from '@/components/settings/lists/ListSectorQueues';
+import ListSectorQueues from '@/components/settings/lists/ListSectorQueues';
 
 export default {
   name: 'FormQueue',
 
   components: {
-    SectorQueuesList,
+    ListSectorQueues,
   },
 
   props: {

--- a/src/components/settings/forms/QuickMessages.vue
+++ b/src/components/settings/forms/QuickMessages.vue
@@ -7,7 +7,7 @@
         @crumbClick="
           () => {
             this.handleIsQuickMessageEditing(false);
-            this.quickMessageToUpdate = null;
+            this.resetQuickMessageToUpdate();
           }
         "
       />
@@ -68,23 +68,16 @@ export default {
     ],
   }),
 
-  computed: {
-    tags: {
-      get() {
-        return this.value;
-      },
-      set(tags) {
-        this.$emit('input', tags);
-      },
-    },
-  },
-
   methods: {
     ...mapActions({
       actionCreateQuickMessage: 'chats/quickMessagesShared/create',
       actionUpdateQuickMessage: 'chats/quickMessagesShared/update',
       actionDeleteQuickMessage: 'chats/quickMessagesShared/delete',
     }),
+
+    resetQuickMessageToUpdate() {
+      this.quickMessageToUpdate = null;
+    },
 
     handleIsQuickMessageEditing(boolean) {
       this.$emit('update-is-quick-message-editing', boolean);
@@ -116,7 +109,7 @@ export default {
         seconds: 5,
       });
 
-      this.quickMessageToUpdate = null;
+      this.resetQuickMessageToUpdate();
     },
 
     async update(quickMessage) {

--- a/src/components/settings/forms/QuickMessages.vue
+++ b/src/components/settings/forms/QuickMessages.vue
@@ -1,0 +1,79 @@
+<template>
+  <section class="form-quick-messages">
+    <section class="form-queue__queues">
+      <list-sector-quick-messages :sector="sector.name" :quick_messages="quick_messages" />
+    </section>
+  </section>
+</template>
+
+<script>
+import ListSectorQuickMessages from '@/components/settings/lists/ListSectorQuickMessages';
+
+export default {
+  name: 'FormQuickMessages',
+
+  components: {
+    ListSectorQuickMessages,
+  },
+
+  props: {
+    quick_messages: {
+      type: Array,
+      default: () => [],
+    },
+    sector: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+
+  data: () => ({
+    tag: '',
+  }),
+
+  computed: {
+    tags: {
+      get() {
+        return this.value;
+      },
+      set(tags) {
+        this.$emit('input', tags);
+      },
+    },
+  },
+
+  methods: {},
+};
+</script>
+
+<style lang="scss" scoped>
+.form-quick-messages {
+  display: flex;
+  flex-direction: column;
+  gap: $unnnic-spacing-stack-md;
+
+  &__description {
+    font-size: $unnnic-font-size-body-gt;
+    color: $unnnic-color-neutral-cloudy;
+  }
+
+  &__section {
+    &__label {
+      font-size: $unnnic-font-size-body-lg;
+      font-weight: $unnnic-font-weight-bold;
+      color: $unnnic-color-neutral-dark;
+      margin-bottom: $unnnic-spacing-inline-sm;
+    }
+
+    &__input-group {
+      display: flex;
+      align-items: flex-end;
+      gap: $unnnic-spacing-stack-sm;
+
+      &__input {
+        flex: 1 1;
+      }
+    }
+  }
+}
+</style>

--- a/src/components/settings/forms/QuickMessages.vue
+++ b/src/components/settings/forms/QuickMessages.vue
@@ -1,11 +1,18 @@
 <template>
   <section class="form-quick-messages">
-    <quick-message-form
-      v-if="quickMessageToUpdate"
-      v-model="quickMessageToUpdate"
-      class="quick-message-form__form"
-      externalActions
-    />
+    <section v-if="quickMessageToUpdate">
+      <unnnic-breadcrumb
+        class="form-quick-messages__breadcrumb"
+        :crumbs="quickMessagesBreadcrumb"
+        @crumbClick="handleIsQuickMessageEditing(false)"
+      />
+      <quick-message-form
+        v-model="quickMessageToUpdate"
+        class="quick-message-form__form"
+        externalActions
+        size="md"
+      />
+    </section>
     <list-sector-quick-messages
       v-else
       :sector="sector.name"
@@ -45,6 +52,14 @@ export default {
 
   data: () => ({
     quickMessageToUpdate: null,
+    quickMessagesBreadcrumb: [
+      {
+        name: 'Mensagens',
+      },
+      {
+        name: 'Adicionar nova mensagem',
+      },
+    ],
   }),
 
   computed: {
@@ -64,6 +79,10 @@ export default {
       actionUpdateQuickMessage: 'chats/quickMessagesShared/update',
       actionDeleteQuickMessage: 'chats/quickMessagesShared/delete',
     }),
+
+    handleIsQuickMessageEditing(boolean) {
+      this.$emit('update-is-quick-message-editing', boolean);
+    },
 
     create() {
       this.quickMessageToUpdate = { title: '', text: '', shortcut: null };
@@ -94,7 +113,7 @@ export default {
     },
 
     async update(quickMessage) {
-      this.$emit('update-is-quick-message-editing', true);
+      this.handleIsQuickMessageEditing(true);
       this.quickMessageToUpdate = quickMessage;
     },
 
@@ -131,6 +150,26 @@ export default {
 
       &__input {
         flex: 1 1;
+      }
+    }
+  }
+
+  &__breadcrumb {
+    margin: 0 0 $unnnic-spacing-stack-md;
+
+    ::v-deep .unnnic-breadcrumb__container {
+      align-items: center;
+
+      &__link {
+        font-size: $unnnic-font-size-body-gt;
+      }
+
+      &__divider {
+        display: flex;
+
+        svg {
+          top: 0;
+        }
       }
     }
   }

--- a/src/components/settings/forms/QuickMessages.vue
+++ b/src/components/settings/forms/QuickMessages.vue
@@ -4,7 +4,12 @@
       <unnnic-breadcrumb
         class="form-quick-messages__breadcrumb"
         :crumbs="quickMessagesBreadcrumb"
-        @crumbClick="handleIsQuickMessageEditing(false)"
+        @crumbClick="
+          () => {
+            this.handleIsQuickMessageEditing(false);
+            this.quickMessageToUpdate = null;
+          }
+        "
       />
       <quick-message-form
         v-model="quickMessageToUpdate"
@@ -17,6 +22,7 @@
       v-else
       :sector="sector.name"
       :quick-messages-shared="quickMessagesShared"
+      @create-quick-message="this.create"
       @edit-quick-message="this.update"
       @delete-quick-message="this.delete"
     />
@@ -85,6 +91,7 @@ export default {
     },
 
     create() {
+      this.handleIsQuickMessageEditing(true);
       this.quickMessageToUpdate = { title: '', text: '', shortcut: null };
     },
 

--- a/src/components/settings/forms/QuickMessages.vue
+++ b/src/components/settings/forms/QuickMessages.vue
@@ -10,6 +10,7 @@
       v-else
       :sector="sector.name"
       :quick-messages-shared="quickMessagesShared"
+      @delete-quick-message="this.delete"
     />
   </section>
 </template>
@@ -101,11 +102,8 @@ export default {
       this.quickMessageToEdit = null;
     },
 
-    async delete() {
-      const { uuid } = this.quickMessageToDelete;
-
+    async delete(uuid) {
       this.actionDeleteQuickMessage(uuid);
-      this.quickMessageToDelete = null;
     },
   },
 };

--- a/src/components/settings/forms/QuickMessages.vue
+++ b/src/components/settings/forms/QuickMessages.vue
@@ -72,8 +72,8 @@ export default {
       this.quickMessageToUpdate = { title: '', text: '', shortcut: null };
     },
 
-    async createQuickMessage() {
-      await this.actionCreateQuickMessage(this.quickMessageToUpdate);
+    async createQuickMessage({ sectorUuid }) {
+      await this.actionCreateQuickMessage({ sectorUuid, ...this.quickMessageToUpdate });
 
       unnnicCallAlert({
         props: {

--- a/src/components/settings/forms/QuickMessages.vue
+++ b/src/components/settings/forms/QuickMessages.vue
@@ -10,6 +10,7 @@
       v-else
       :sector="sector.name"
       :quick-messages-shared="quickMessagesShared"
+      @edit-quick-message="this.update"
       @delete-quick-message="this.delete"
     />
   </section>
@@ -68,8 +69,15 @@ export default {
       this.quickMessageToUpdate = { title: '', text: '', shortcut: null };
     },
 
-    async save({ sectorUuid }) {
-      await this.actionCreateQuickMessage({ sectorUuid, ...this.quickMessageToUpdate });
+    async save({ uuid }) {
+      if (this.quickMessageToUpdate.uuid) {
+        await this.actionUpdateQuickMessage({
+          quickMessageUuid: this.quickMessageToUpdate.uuid,
+          ...this.quickMessageToUpdate,
+        });
+      } else {
+        await this.actionCreateQuickMessage({ sectorUuid: uuid, ...this.quickMessageToUpdate });
+      }
 
       unnnicCallAlert({
         props: {
@@ -85,21 +93,9 @@ export default {
       this.quickMessageToUpdate = null;
     },
 
-    async update({ uuid, title, text, shortcut }) {
-      this.actionUpdateQuickMessage({ uuid, title, text, shortcut });
-
-      unnnicCallAlert({
-        props: {
-          title: this.$t('quick_messages.successfully_added'),
-          icon: 'check-circle-1-1-1',
-          scheme: 'feedback-green',
-          closeText: this.$t('close'),
-          position: 'bottom-right',
-        },
-        seconds: 5,
-      });
-
-      this.quickMessageToEdit = null;
+    async update(quickMessage) {
+      this.$emit('update-is-quick-message-editing', true);
+      this.quickMessageToUpdate = quickMessage;
     },
 
     async delete(uuid) {

--- a/src/components/settings/forms/QuickMessages.vue
+++ b/src/components/settings/forms/QuickMessages.vue
@@ -1,6 +1,18 @@
 <template>
   <section class="form-quick-messages">
+    <quick-message-form
+      v-if="quickMessageToUpdate"
+      v-model="quickMessageToUpdate"
+      class="quick-message-form__form"
+      @submit="
+        !!quickMessageToEdit.uuid
+          ? updateQuickMessage(quickMessageToEdit)
+          : createQuickMessage(quickMessageToEdit)
+      "
+      @cancel="quickMessageToEdit = null"
+    />
     <list-sector-quick-messages
+      v-else
       :sector="sector.name"
       :quick-messages-shared="quickMessagesShared"
     />
@@ -8,12 +20,18 @@
 </template>
 
 <script>
+import { mapActions } from 'vuex';
+
+import { unnnicCallAlert } from '@weni/unnnic-system';
+
 import ListSectorQuickMessages from '@/components/settings/lists/ListSectorQuickMessages';
+import QuickMessageForm from '@/components/chats/QuickMessages/QuickMessageForm';
 
 export default {
   name: 'FormQuickMessages',
 
   components: {
+    QuickMessageForm,
     ListSectorQuickMessages,
   },
 
@@ -29,7 +47,7 @@ export default {
   },
 
   data: () => ({
-    tag: '',
+    quickMessageToUpdate: null,
   }),
 
   computed: {
@@ -43,7 +61,58 @@ export default {
     },
   },
 
-  methods: {},
+  methods: {
+    ...mapActions({
+      actionCreateQuickMessage: 'chats/quickMessagesShared/create',
+      actionUpdateQuickMessage: 'chats/quickMessagesShared/update',
+      actionDeleteQuickMessage: 'chats/quickMessagesShared/delete',
+    }),
+
+    createEmptyQuickMessage() {
+      this.quickMessageToUpdate = { title: '', text: '', shortcut: null };
+    },
+
+    async createQuickMessage() {
+      await this.actionCreateQuickMessage(this.quickMessageToUpdate);
+
+      unnnicCallAlert({
+        props: {
+          title: this.$t('quick_messages.successfully_added'),
+          icon: 'check-circle-1-1-1',
+          scheme: 'feedback-green',
+          closeText: this.$t('close'),
+          position: 'bottom-right',
+        },
+        seconds: 5,
+      });
+
+      this.quickMessageToUpdate = null;
+    },
+
+    async updateQuickMessage({ uuid, title, text, shortcut }) {
+      this.actionUpdateQuickMessage({ uuid, title, text, shortcut });
+
+      unnnicCallAlert({
+        props: {
+          title: this.$t('quick_messages.successfully_added'),
+          icon: 'check-circle-1-1-1',
+          scheme: 'feedback-green',
+          closeText: this.$t('close'),
+          position: 'bottom-right',
+        },
+        seconds: 5,
+      });
+
+      this.quickMessageToEdit = null;
+    },
+
+    async deleteQuickMessage() {
+      const { uuid } = this.quickMessageToDelete;
+
+      this.actionDeleteQuickMessage(uuid);
+      this.quickMessageToDelete = null;
+    },
+  },
 };
 </script>
 

--- a/src/components/settings/forms/QuickMessages.vue
+++ b/src/components/settings/forms/QuickMessages.vue
@@ -4,12 +4,7 @@
       v-if="quickMessageToUpdate"
       v-model="quickMessageToUpdate"
       class="quick-message-form__form"
-      @submit="
-        !!quickMessageToEdit.uuid
-          ? updateQuickMessage(quickMessageToEdit)
-          : createQuickMessage(quickMessageToEdit)
-      "
-      @cancel="quickMessageToEdit = null"
+      externalActions
     />
     <list-sector-quick-messages
       v-else
@@ -68,11 +63,11 @@ export default {
       actionDeleteQuickMessage: 'chats/quickMessagesShared/delete',
     }),
 
-    createEmptyQuickMessage() {
+    create() {
       this.quickMessageToUpdate = { title: '', text: '', shortcut: null };
     },
 
-    async createQuickMessage({ sectorUuid }) {
+    async save({ sectorUuid }) {
       await this.actionCreateQuickMessage({ sectorUuid, ...this.quickMessageToUpdate });
 
       unnnicCallAlert({
@@ -89,7 +84,7 @@ export default {
       this.quickMessageToUpdate = null;
     },
 
-    async updateQuickMessage({ uuid, title, text, shortcut }) {
+    async update({ uuid, title, text, shortcut }) {
       this.actionUpdateQuickMessage({ uuid, title, text, shortcut });
 
       unnnicCallAlert({
@@ -106,7 +101,7 @@ export default {
       this.quickMessageToEdit = null;
     },
 
-    async deleteQuickMessage() {
+    async delete() {
       const { uuid } = this.quickMessageToDelete;
 
       this.actionDeleteQuickMessage(uuid);

--- a/src/components/settings/forms/QuickMessages.vue
+++ b/src/components/settings/forms/QuickMessages.vue
@@ -120,6 +120,20 @@ export default {
     async delete(uuid) {
       this.actionDeleteQuickMessage(uuid);
     },
+    validate() {
+      if (!this.quickMessageToUpdate) return false;
+
+      const { title, shortcut, text } = this.quickMessageToUpdate;
+      return !!title && shortcut && text;
+    },
+  },
+
+  computed: {},
+
+  watch: {
+    quickMessageToUpdate() {
+      this.$emit('validate', this.validate());
+    },
   },
 };
 </script>

--- a/src/components/settings/forms/QuickMessages.vue
+++ b/src/components/settings/forms/QuickMessages.vue
@@ -1,8 +1,9 @@
 <template>
   <section class="form-quick-messages">
-    <section class="form-queue__queues">
-      <list-sector-quick-messages :sector="sector.name" :quick_messages="quick_messages" />
-    </section>
+    <list-sector-quick-messages
+      :sector="sector.name"
+      :quick-messages-shared="quickMessagesShared"
+    />
   </section>
 </template>
 
@@ -17,7 +18,7 @@ export default {
   },
 
   props: {
-    quick_messages: {
+    quickMessagesShared: {
       type: Array,
       default: () => [],
     },

--- a/src/components/settings/lists/ListSectorQueues.vue
+++ b/src/components/settings/lists/ListSectorQueues.vue
@@ -32,7 +32,7 @@
 
 <script>
 export default {
-  name: 'ListSectorQueue',
+  name: 'ListSectorQueues',
 
   props: {
     queues: {

--- a/src/components/settings/lists/ListSectorQuickMessages.vue
+++ b/src/components/settings/lists/ListSectorQuickMessages.vue
@@ -7,8 +7,8 @@
       :key="message.uuid"
       :quickMessage="message"
       clickable
-      @select.stop
-      @edit.stop
+      @select="$emit('edit-quick-message', message)"
+      @edit="$emit('edit-quick-message', message)"
       @delete="$emit('delete-quick-message', message.uuid)"
     />
   </section>

--- a/src/components/settings/lists/ListSectorQuickMessages.vue
+++ b/src/components/settings/lists/ListSectorQuickMessages.vue
@@ -3,7 +3,7 @@
     <p v-if="sector" class="title">{{ $t('quick_messages.title_by_sector', { sector }) }}</p>
 
     <quick-message-card
-      v-for="message in quick_messages"
+      v-for="message in quickMessagesShared"
       :key="message.uuid"
       :quickMessage="message"
       clickable
@@ -25,7 +25,7 @@ export default {
   },
 
   props: {
-    quick_messages: {
+    quickMessagesShared: {
       type: Array,
       default: () => [],
     },

--- a/src/components/settings/lists/ListSectorQuickMessages.vue
+++ b/src/components/settings/lists/ListSectorQuickMessages.vue
@@ -1,6 +1,13 @@
 <template>
   <section class="list-sector-quick-messages">
     <p v-if="sector" class="title">{{ $t('quick_messages.title_by_sector', { sector }) }}</p>
+    <p v-if="quickMessagesShared.length === 0" class="without-messages">
+      {{ $t('quick_messages.without_messages.start') }}
+      <button @click="$emit('create-quick-message')">
+        {{ $t('quick_messages.without_messages.middle') }}
+      </button>
+      {{ $t('quick_messages.without_messages.end') }}
+    </p>
 
     <quick-message-card
       v-for="message in quickMessagesShared"
@@ -46,6 +53,23 @@ export default {
     line-height: 1.5rem;
 
     margin-bottom: 1rem;
+  }
+
+  .without-messages {
+    font-size: $unnnic-font-size-body-gt;
+    color: $unnnic-color-neutral-dark;
+
+    button {
+      background: none;
+      border: none;
+      padding: 0;
+
+      text-decoration: underline;
+      font-weight: $unnnic-font-weight-bold;
+      color: $unnnic-color-neutral-dark;
+
+      cursor: pointer;
+    }
   }
 
   .quick-message-card {

--- a/src/components/settings/lists/ListSectorQuickMessages.vue
+++ b/src/components/settings/lists/ListSectorQuickMessages.vue
@@ -9,7 +9,7 @@
       clickable
       @select.stop
       @edit.stop
-      @delete.stop
+      @delete="$emit('delete-quick-message', message.uuid)"
     />
   </section>
 </template>

--- a/src/components/settings/lists/ListSectorQuickMessages.vue
+++ b/src/components/settings/lists/ListSectorQuickMessages.vue
@@ -49,6 +49,9 @@ export default {
   }
 
   .quick-message-card {
+    &:not(:first-child) {
+      margin-top: $unnnic-spacing-stack-sm;
+    }
     :deep(.unnnic-chat-text) {
       max-width: initial;
     }

--- a/src/components/settings/lists/ListSectorQuickMessages.vue
+++ b/src/components/settings/lists/ListSectorQuickMessages.vue
@@ -1,0 +1,57 @@
+<template>
+  <section class="list-sector-quick-messages">
+    <p v-if="sector" class="title">{{ $t('quick_messages.title_by_sector', { sector }) }}</p>
+
+    <quick-message-card
+      v-for="message in quick_messages"
+      :key="message.uuid"
+      :quickMessage="message"
+      clickable
+      @select.stop
+      @edit.stop
+      @delete.stop
+    />
+  </section>
+</template>
+
+<script>
+import QuickMessageCard from '@/components/chats/QuickMessages/QuickMessageCard';
+
+export default {
+  name: 'ListSectorQuickMessages',
+
+  components: {
+    QuickMessageCard,
+  },
+
+  props: {
+    quick_messages: {
+      type: Array,
+      default: () => [],
+    },
+    sector: {
+      type: String,
+      default: '',
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.list-sector-quick-messages {
+  .title {
+    font-weight: $unnnic-font-weight-bold;
+    color: $unnnic-color-neutral-dark;
+    font-size: $unnnic-font-size-body-lg;
+    line-height: 1.5rem;
+
+    margin-bottom: 1rem;
+  }
+
+  .quick-message-card {
+    :deep(.unnnic-chat-text) {
+      max-width: initial;
+    }
+  }
+}
+</style>

--- a/src/layouts/ChatsLayout/components/TheRoomList/RoomGroup/index.vue
+++ b/src/layouts/ChatsLayout/components/TheRoomList/RoomGroup/index.vue
@@ -1,12 +1,5 @@
 <template>
-  <app-accordion :isDefaultOpen="isDefaultOpen" @change="changeAccordionOption">
-    <template v-slot:title>
-      <div class="chat-group" :class="{ disabled }">
-        <header>
-          <h2>{{ label }}</h2>
-        </header>
-      </div>
-    </template>
+  <app-accordion :title="label" :isDefaultOpen="isDefaultOpen" @change="changeAccordionOption">
     <template v-slot:content>
       <div class="chat-group">
         <ul class="chats" :class="{ filled }">
@@ -26,8 +19,8 @@
 </template>
 
 <script>
+import AppAccordion from '@/components/chats/AppAccordion';
 import ContactRoom from './ContactRoom';
-import AppAccordion from './AppAccordion';
 
 export default {
   name: 'RoomGroup',
@@ -88,28 +81,6 @@ export default {
 
 <style lang="scss" scoped>
 .chat-group {
-  &.disabled {
-    header {
-      h2 {
-        color: $unnnic-color-neutral-lightest;
-      }
-    }
-  }
-
-  header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-
-    padding: 0 0 0.5rem 0.5rem;
-    h2 {
-      font-size: $unnnic-font-size-body-md;
-      font-weight: $unnnic-font-weight-regular;
-      line-height: 1.25rem;
-      color: $unnnic-color-neutral-cloudy;
-    }
-  }
-
   ul.chats {
     list-style-type: none;
     margin: 0;

--- a/src/layouts/ChatsLayout/components/TheRoomList/index.vue
+++ b/src/layouts/ChatsLayout/components/TheRoomList/index.vue
@@ -249,7 +249,7 @@ export default {
   .order-by {
     display: flex;
     justify-content: space-between;
-    padding: 6px;
+
     font-size: $unnnic-font-size-body-md;
     color: $unnnic-color-neutral-cloudy;
   }

--- a/src/locales/translations.json
+++ b/src/locales/translations.json
@@ -846,6 +846,23 @@
       "en-us": "Quick messages in {sector}",
       "es": "Mensajes rápidos en {sector}"
     },
+    "without_messages": {
+      "start": {
+        "pt-br": "Por enquanto não há mensagens rápidas neste setor,",
+        "en-us": "For now there are no quick messages in this sector,",
+        "es": "Por ahora no hay mensajes rápidos en este sector,"
+      },
+      "middle": {
+        "pt-br": "adicione uma mensagem",
+        "en-us": "add a message",
+        "es": "añade un mensaje"
+      },
+      "end": {
+        "pt-br": "para os agentes deste setor utilizarem.",
+        "en-us": "for agents in this sector to use.",
+        "es": "para los agentes en este sector los usan."
+      }
+    },
     "personal": {
       "pt-br": "Suas mensagens rápidas",
       "en-us": "Your quick messages",

--- a/src/locales/translations.json
+++ b/src/locales/translations.json
@@ -416,11 +416,6 @@
     "en-us": "Waiting",
     "es": "Espera"
   },
-  "quick_message": {
-    "pt-br": "Mensagens rápidas",
-    "en-us": "Quick messages",
-    "es": "Mensajes rápidos"
-  },
   "suggested_answers": {
     "pt-br": "Respostas sugeridas",
     "en-us": "Suggested Answers",
@@ -835,7 +830,22 @@
     "en-us": "Send image | Send image | Send images",
     "es": "Enviar imagen | Enviar imagen | Enviar imágenes"
   },
+  "quick_message": {
+    "pt-br": "Mensagens rápidas",
+    "en-us": "Quick messages",
+    "es": "Mensajes rápidos"
+  },
   "quick_messages": {
+    "personal": {
+      "pt-br": "Suas mensagens rápidas",
+      "en-us": "Your quick messages",
+      "es": "Tus mensajes rápidos"
+    },
+    "shared": {
+      "pt-br": "Mensagens rápidas compartilhadas",
+      "en-us": "Shared quick messages",
+      "es": "Mensajes rápidos compartidos"
+    },
     "delete": {
       "pt-br": "Excluir mensagem rápida",
       "en-us": "Delete quick message",

--- a/src/locales/translations.json
+++ b/src/locales/translations.json
@@ -836,6 +836,16 @@
     "es": "Mensajes rápidos"
   },
   "quick_messages": {
+    "title": {
+      "pt-br": "Mensagens rápidas",
+      "en-us": "Quick messages",
+      "es": "Mensajes rápidos"
+    },
+    "title_by_sector": {
+      "pt-br": "Mensagens rápidas em {sector}",
+      "en-us": "Quick messages in {sector}",
+      "es": "Mensajes rápidos en {sector}"
+    },
     "personal": {
       "pt-br": "Suas mensagens rápidas",
       "en-us": "Your quick messages",

--- a/src/router/routes/settings.js
+++ b/src/router/routes/settings.js
@@ -20,7 +20,7 @@ const routes = [
         component: () => import('@/views/Settings/Sectors/Edit'),
         props: (route) => ({
           uuid: route.params.uuid,
-          tag: route.query.tag,
+          tab: route.query.tab,
         }),
       },
     ],

--- a/src/services/api/resources/chats/quickMessage.js
+++ b/src/services/api/resources/chats/quickMessage.js
@@ -1,8 +1,10 @@
 import http from '@/services/api/http';
 
 export default {
-  async all(offset, limit) {
-    const response = await http.get('/quick_messages/', {
+  async getAll({ offset, limit, sector = false }) {
+    const endpoint = sector ? '/sector_quick_messages/' : '/quick_messages/';
+
+    const response = await http.get(endpoint, {
       params: {
         offset,
         limit,

--- a/src/services/api/resources/chats/quickMessage.js
+++ b/src/services/api/resources/chats/quickMessage.js
@@ -5,7 +5,7 @@ export default {
     const endpoint = sector ? '/sector_quick_messages/' : '/quick_messages/';
 
     const response = await http.get(endpoint, {
-      params: {
+      [sector ? 'data' : 'params']: {
         offset,
         limit,
       },

--- a/src/services/api/resources/chats/quickMessage.js
+++ b/src/services/api/resources/chats/quickMessage.js
@@ -35,6 +35,17 @@ export default {
     return response.data;
   },
 
+  async createBySector({ sectorUuid, title, text, shortcut = null }) {
+    const response = await http.post('/sector_quick_messages/', {
+      sector: sectorUuid,
+      title,
+      text,
+      shortcut,
+    });
+
+    return response.data;
+  },
+
   async update(uuid, { title, text, shortcut = null }) {
     const response = await http.patch(`/quick_messages/${uuid}/`, {
       title,
@@ -45,8 +56,23 @@ export default {
     return response.data;
   },
 
+  async updateBySector(quickMessageUuid, { title, text, shortcut = null }) {
+    const response = await http.patch(`/sector_quick_messages/${quickMessageUuid}/`, {
+      title,
+      text,
+      shortcut,
+    });
+
+    return response.data;
+  },
+
   async delete(uuid) {
     const response = await http.delete(`/quick_messages/${uuid}/`);
+    return response.data;
+  },
+
+  async deleteBySector(quickMessageUuid) {
+    const response = await http.delete(`/sector_quick_messages/${quickMessageUuid}/`);
     return response.data;
   },
 };

--- a/src/services/api/resources/chats/quickMessage.js
+++ b/src/services/api/resources/chats/quickMessage.js
@@ -1,15 +1,27 @@
 import http from '@/services/api/http';
 
-export default {
-  async getAll({ offset, limit, sector = false }) {
-    const endpoint = sector ? '/sector_quick_messages/' : '/quick_messages/';
+function getURLParams({ URL, endpoint }) {
+  return URL?.split(endpoint)?.[1];
+}
 
-    const response = await http.get(endpoint, {
-      [sector ? 'data' : 'params']: {
-        offset,
-        limit,
-      },
-    });
+export default {
+  async getAll({ nextQuickMessages = '' }) {
+    const endpoint = '/quick_messages/';
+    const params = getURLParams({ URL: nextQuickMessages, endpoint });
+
+    const url = nextQuickMessages ? `${endpoint}${params}` : endpoint;
+    const response = await http.get(url);
+
+    return response.data;
+  },
+
+  async getAllBySector({ nextQuickMessagesShared = '' }) {
+    const endpoint = '/sector_quick_messages/';
+    const params = getURLParams({ URL: nextQuickMessagesShared, endpoint });
+
+    const url = nextQuickMessagesShared ? `${endpoint}${params}` : endpoint;
+    const response = await http.get(url);
+
     return response.data;
   },
 

--- a/src/services/api/resources/chats/quickMessage.js
+++ b/src/services/api/resources/chats/quickMessage.js
@@ -1,4 +1,5 @@
 import http from '@/services/api/http';
+import { getProject } from '@/utils/config';
 
 function getURLParams({ URL, endpoint }) {
   return URL?.split(endpoint)?.[1];
@@ -16,7 +17,8 @@ export default {
   },
 
   async getAllBySector({ nextQuickMessagesShared = '' }) {
-    const endpoint = '/sector_quick_messages/';
+    const projectUuid = getProject();
+    const endpoint = `/sector_quick_messages/?project=${projectUuid}`;
     const params = getURLParams({ URL: nextQuickMessagesShared, endpoint });
 
     const url = nextQuickMessagesShared ? `${endpoint}${params}` : endpoint;

--- a/src/store/modules/chats/index.js
+++ b/src/store/modules/chats/index.js
@@ -1,4 +1,5 @@
-import quickMessagesModule from './quickMessages';
+import quickMessages from './quickMessages';
+import quickMessagesShared from './quickMessagesShared';
 
 const tags = [
   { text: 'Dúvidas', value: 'doubts' },
@@ -551,7 +552,8 @@ chats = chats.map((group) => ({
 const module = {
   namespaced: true,
   modules: {
-    quickMessages: quickMessagesModule,
+    quickMessages,
+    quickMessagesShared,
   },
   state: {
     activeChat: null,

--- a/src/store/modules/chats/quickMessages.js
+++ b/src/store/modules/chats/quickMessages.js
@@ -1,25 +1,45 @@
-const module = {
+import QuickMessage from '@/services/api/resources/chats/quickMessage';
+
+const mutations = {
+  SET_QUICK_MESSAGES: 'SET_QUICK_MESSAGES',
+  ADD_QUICK_MESSAGE: 'ADD_QUICK_MESSAGE',
+  UPDATE_QUICK_MESSAGE: 'UPDATE_QUICK_MESSAGE',
+  DELETE_QUICK_MESSAGE: 'DELETE_QUICK_MESSAGE',
+  SET_NEXT_QUICK_MESSAGES: 'SET_NEXT_QUICK_MESSAGES',
+};
+
+export default {
   namespaced: true,
+
   state: {
-    messages: [],
-    sharedMessages: [],
+    quickMessages: [],
+    nextQuickMessages: '',
   },
+
   mutations: {
-    addMessage(state, message) {
-      const messagesIds = state.messages.map((m) => m.id);
-      const highestMessageId = Math.max(...messagesIds);
-      state.messages.push({
-        ...message,
-        id: highestMessageId + 1,
-      });
+    [mutations.SET_QUICK_MESSAGES](state, quickMessages) {
+      state.quickMessages = quickMessages;
     },
-    updateMessage(state, message) {
-      state.messages = state.messages.map((m) => (m.id === message.id ? { ...message } : m));
+    [mutations.ADD_QUICK_MESSAGE](state, quickMessage) {
+      state.quickMessages.unshift({ ...quickMessage });
     },
-    deleteMessage(state, message) {
-      state.messages = state.messages.filter((m) => m.id !== message.id);
+    [mutations.SET_NEXT_QUICK_MESSAGES](state, nextQuickMessages) {
+      state.nextQuickMessages = nextQuickMessages;
+    },
+  },
+
+  actions: {
+    async getAll({ commit, state }) {
+      const { quickMessages, nextQuickMessages } = state;
+
+      const response = await QuickMessage.getAll({ nextQuickMessages });
+      const responseNext = response.next;
+      const newQuickMessages = [...quickMessages, ...response.results] || [];
+
+      commit(mutations.SET_NEXT_QUICK_MESSAGES, responseNext);
+      commit(mutations.SET_QUICK_MESSAGES, newQuickMessages);
+
+      return newQuickMessages;
     },
   },
 };
-
-export default module;

--- a/src/store/modules/chats/quickMessages.js
+++ b/src/store/modules/chats/quickMessages.js
@@ -2,6 +2,7 @@ const module = {
   namespaced: true,
   state: {
     messages: [],
+    sharedMessages: [],
   },
   mutations: {
     addMessage(state, message) {

--- a/src/store/modules/chats/quickMessages.js
+++ b/src/store/modules/chats/quickMessages.js
@@ -20,8 +20,31 @@ export default {
     [mutations.SET_QUICK_MESSAGES](state, quickMessages) {
       state.quickMessages = quickMessages;
     },
-    [mutations.ADD_QUICK_MESSAGE](state, quickMessage) {
-      state.quickMessages.unshift({ ...quickMessage });
+    [mutations.ADD_QUICK_MESSAGE](state, { title, text, shortcut }) {
+      state.quickMessages.unshift({ title, text, shortcut });
+    },
+    [mutations.UPDATE_QUICK_MESSAGE](state, { uuid, title, text, shortcut }) {
+      const quickMessageToUpdate = state.quickMessages.find(
+        (quickMessage) => quickMessage.uuid === uuid,
+      );
+
+      if (quickMessageToUpdate) {
+        const updatedQuickMessage = {
+          ...quickMessageToUpdate,
+          title,
+          text,
+          shortcut,
+        };
+
+        state.quickMessages = state.quickMessages.map((quickMessage) =>
+          quickMessage.uuid === uuid ? updatedQuickMessage : quickMessage,
+        );
+      }
+    },
+    [mutations.DELETE_QUICK_MESSAGE](state, uuid) {
+      state.quickMessages = state.quickMessages.filter(
+        (quickMessage) => quickMessage.uuid !== uuid,
+      );
     },
     [mutations.SET_NEXT_QUICK_MESSAGES](state, nextQuickMessages) {
       state.nextQuickMessages = nextQuickMessages;
@@ -40,6 +63,26 @@ export default {
       commit(mutations.SET_QUICK_MESSAGES, newQuickMessages);
 
       return newQuickMessages;
+    },
+
+    async create({ commit }, { title, text, shortcut }) {
+      const newQuickMessage = { title, text, shortcut };
+      await QuickMessage.create(newQuickMessage);
+
+      commit(mutations.ADD_QUICK_MESSAGE, newQuickMessage);
+    },
+
+    async update({ commit }, { uuid, title, text, shortcut }) {
+      const dataToUpdate = { title, text, shortcut };
+      await QuickMessage.update(uuid, dataToUpdate);
+
+      commit(mutations.UPDATE_QUICK_MESSAGE, { uuid, ...dataToUpdate });
+    },
+
+    async delete({ commit }, uuid) {
+      await QuickMessage.delete(uuid);
+
+      commit(mutations.DELETE_QUICK_MESSAGE, uuid);
     },
   },
 };

--- a/src/store/modules/chats/quickMessagesShared.js
+++ b/src/store/modules/chats/quickMessagesShared.js
@@ -74,13 +74,13 @@ export default {
 
     async update({ commit }, { quickMessageUuid, title, text, shortcut }) {
       const dataToUpdate = { title, text, shortcut };
-      await QuickMessage.update(quickMessageUuid, dataToUpdate);
+      await QuickMessage.updateBySector(quickMessageUuid, dataToUpdate);
 
-      commit(mutations.UPDATE_QUICK_MESSAGE, { uuid: quickMessageUuid, ...dataToUpdate });
+      commit(mutations.UPDATE_QUICK_MESSAGE_SHARED, { uuid: quickMessageUuid, ...dataToUpdate });
     },
 
     async delete({ commit }, quickMessageUuid) {
-      await QuickMessage.delete(quickMessageUuid);
+      await QuickMessage.deleteBySector(quickMessageUuid);
 
       commit(mutations.DELETE_QUICK_MESSAGE_SHARED, quickMessageUuid);
     },

--- a/src/store/modules/chats/quickMessagesShared.js
+++ b/src/store/modules/chats/quickMessagesShared.js
@@ -20,8 +20,31 @@ export default {
     [mutations.SET_QUICK_MESSAGES_SHARED](state, quickMessagesShared) {
       state.quickMessagesShared = quickMessagesShared;
     },
-    [mutations.ADD_QUICK_MESSAGE_SHARED](state, quickMessagesShared) {
-      state.quickMessagesShared.unshift({ ...quickMessagesShared });
+    [mutations.ADD_QUICK_MESSAGE_SHARED](state, { sectorUuid, title, text, shortcut }) {
+      state.quickMessagesShared.unshift({ sector: sectorUuid, title, text, shortcut });
+    },
+    [mutations.UPDATE_QUICK_MESSAGE_SHARED](state, { uuid, title, text, shortcut }) {
+      const quickMessageToUpdate = state.quickMessagesShared.find(
+        (quickMessage) => quickMessage.uuid === uuid,
+      );
+
+      if (quickMessageToUpdate) {
+        const updatedQuickMessageShared = {
+          ...quickMessageToUpdate,
+          title,
+          text,
+          shortcut,
+        };
+
+        state.quickMessagesShared = state.quickMessagesShared.map((quickMessage) =>
+          quickMessage.uuid === uuid ? updatedQuickMessageShared : quickMessage,
+        );
+      }
+    },
+    [mutations.DELETE_QUICK_MESSAGE_SHARED](state, uuid) {
+      state.quickMessagesShared = state.quickMessagesShared.filter(
+        (quickMessage) => quickMessage.uuid !== uuid,
+      );
     },
     [mutations.SET_NEXT_QUICK_MESSAGES_SHARED](state, nextQuickMessagesShared) {
       state.nextQuickMessagesShared = nextQuickMessagesShared;
@@ -40,6 +63,26 @@ export default {
       commit(mutations.SET_QUICK_MESSAGES_SHARED, newQuickMessagesShared);
 
       return newQuickMessagesShared;
+    },
+
+    async create({ commit }, { sectorUuid, title, text, shortcut }) {
+      const newQuickMessageShared = { sectorUuid, title, text, shortcut };
+      await QuickMessage.createBySector(newQuickMessageShared);
+
+      commit(mutations.ADD_QUICK_MESSAGE_SHARED, newQuickMessageShared);
+    },
+
+    async update({ commit }, { quickMessageUuid, title, text, shortcut }) {
+      const dataToUpdate = { title, text, shortcut };
+      await QuickMessage.update(quickMessageUuid, dataToUpdate);
+
+      commit(mutations.UPDATE_QUICK_MESSAGE, { uuid: quickMessageUuid, ...dataToUpdate });
+    },
+
+    async delete({ commit }, quickMessageUuid) {
+      await QuickMessage.delete(quickMessageUuid);
+
+      commit(mutations.DELETE_QUICK_MESSAGE, quickMessageUuid);
     },
   },
 };

--- a/src/store/modules/chats/quickMessagesShared.js
+++ b/src/store/modules/chats/quickMessagesShared.js
@@ -20,8 +20,9 @@ export default {
     [mutations.SET_QUICK_MESSAGES_SHARED](state, quickMessagesShared) {
       state.quickMessagesShared = quickMessagesShared;
     },
-    [mutations.ADD_QUICK_MESSAGE_SHARED](state, { sectorUuid, title, text, shortcut }) {
-      state.quickMessagesShared.unshift({ sector: sectorUuid, title, text, shortcut });
+    [mutations.ADD_QUICK_MESSAGE_SHARED](state, quickMessage) {
+      state.quickMessagesShared.unshift(quickMessage);
+      console.log();
     },
     [mutations.UPDATE_QUICK_MESSAGE_SHARED](state, { uuid, title, text, shortcut }) {
       const quickMessageToUpdate = state.quickMessagesShared.find(
@@ -67,9 +68,9 @@ export default {
 
     async create({ commit }, { sectorUuid, title, text, shortcut }) {
       const newQuickMessageShared = { sectorUuid, title, text, shortcut };
-      await QuickMessage.createBySector(newQuickMessageShared);
+      const response = await QuickMessage.createBySector(newQuickMessageShared);
 
-      commit(mutations.ADD_QUICK_MESSAGE_SHARED, newQuickMessageShared);
+      commit(mutations.ADD_QUICK_MESSAGE_SHARED, response);
     },
 
     async update({ commit }, { quickMessageUuid, title, text, shortcut }) {

--- a/src/store/modules/chats/quickMessagesShared.js
+++ b/src/store/modules/chats/quickMessagesShared.js
@@ -1,0 +1,45 @@
+import QuickMessage from '@/services/api/resources/chats/quickMessage';
+
+const mutations = {
+  SET_QUICK_MESSAGES_SHARED: 'SET_QUICK_MESSAGES_SHARED',
+  ADD_QUICK_MESSAGE_SHARED: 'ADD_QUICK_MESSAGE_SHARED',
+  UPDATE_QUICK_MESSAGE_SHARED: 'UPDATE_QUICK_MESSAGE_SHARED',
+  DELETE_QUICK_MESSAGE_SHARED: 'DELETE_QUICK_MESSAGE_SHARED',
+  SET_NEXT_QUICK_MESSAGES_SHARED: 'SET_NEXT_QUICK_MESSAGES_SHARED',
+};
+
+export default {
+  namespaced: true,
+
+  state: {
+    quickMessagesShared: [],
+    nextQuickMessagesShared: '',
+  },
+
+  mutations: {
+    [mutations.SET_QUICK_MESSAGES_SHARED](state, quickMessagesShared) {
+      state.quickMessagesShared = quickMessagesShared;
+    },
+    [mutations.ADD_QUICK_MESSAGE_SHARED](state, quickMessagesShared) {
+      state.quickMessagesShared.unshift({ ...quickMessagesShared });
+    },
+    [mutations.SET_NEXT_QUICK_MESSAGES_SHARED](state, nextQuickMessagesShared) {
+      state.nextQuickMessagesShared = nextQuickMessagesShared;
+    },
+  },
+
+  actions: {
+    async getAll({ commit, state }) {
+      const { quickMessagesShared, nextQuickMessagesShared } = state;
+
+      const response = await QuickMessage.getAllBySector({ nextQuickMessagesShared });
+      const responseNext = response.next;
+      const newQuickMessagesShared = [...quickMessagesShared, ...response.results] || [];
+
+      commit(mutations.SET_NEXT_QUICK_MESSAGES_SHARED, responseNext);
+      commit(mutations.SET_QUICK_MESSAGES_SHARED, newQuickMessagesShared);
+
+      return newQuickMessagesShared;
+    },
+  },
+};

--- a/src/store/modules/chats/quickMessagesShared.js
+++ b/src/store/modules/chats/quickMessagesShared.js
@@ -82,7 +82,7 @@ export default {
     async delete({ commit }, quickMessageUuid) {
       await QuickMessage.delete(quickMessageUuid);
 
-      commit(mutations.DELETE_QUICK_MESSAGE, quickMessageUuid);
+      commit(mutations.DELETE_QUICK_MESSAGE_SHARED, quickMessageUuid);
     },
   },
 };

--- a/src/views/Settings/Sectors/Edit.vue
+++ b/src/views/Settings/Sectors/Edit.vue
@@ -101,7 +101,11 @@
       </template>
 
       <template #quick-messages>
-        <form-quick-messages :quick-messages-shared="quickMessagesShared" :sector="sector" />
+        <form-quick-messages
+          ref="formQuickMessages"
+          :quick-messages-shared="quickMessagesShared"
+          :sector="sector"
+        />
       </template>
 
       <template #tags>
@@ -124,10 +128,11 @@
         v-if="this.currentTab === 'sector' || this.queueToEdit || currentTab === 'tags'"
       />
       <unnnic-button
-        icon-left="add-circle-1"
-        :text="$t('quick_messages.add_new')"
-        type="secondary"
         v-if="this.currentTab === 'quick-messages'"
+        :text="$t('quick_messages.add_new')"
+        icon-left="add-circle-1"
+        type="secondary"
+        @click="() => quickMessageHandler('create')"
       />
       <unnnic-modal
         :showModal="openModal"
@@ -151,6 +156,8 @@
 </template>
 
 <script>
+import { mapState } from 'vuex';
+
 import { unnnicCallAlert } from '@weni/unnnic-system';
 
 import FormAgent from '@/components/settings/forms/Agent';
@@ -163,7 +170,6 @@ import SectorTabs from '@/components/settings/SectorTabs';
 import Sector from '@/services/api/resources/settings/sector';
 import Queue from '@/services/api/resources/settings/queue';
 import Project from '@/services/api/resources/settings/project';
-import { mapState } from 'vuex';
 
 export default {
   name: 'EditSector',
@@ -253,6 +259,25 @@ export default {
       this.$nextTick(() => {
         this.$refs.textEditor?.focus();
       });
+    },
+    quickMessageHandler(action) {
+      const actions = {
+        create() {
+          this.$refs.formQuickMessages.createEmptyQuickMessage();
+        },
+        update() {
+          console.log('Update');
+        },
+        delete() {
+          console.log('Delete');
+        },
+      };
+
+      if (actions[action]) {
+        actions[action]();
+      } else {
+        console.log('Invalid action.');
+      }
     },
     async listProjectManagers() {
       const managers = (await Project.managers()).results.concat((await Project.admins()).results);

--- a/src/views/Settings/Sectors/Edit.vue
+++ b/src/views/Settings/Sectors/Edit.vue
@@ -100,6 +100,10 @@
         />
       </template>
 
+      <template #quick-messages>
+        <form-quick-messages :quick_messages="quick_messages" :sector="sector" />
+      </template>
+
       <template #tags>
         <form-tags v-model="tags" @add="addTagToAddList" @remove="addTagToRemoveList" />
       </template>
@@ -118,6 +122,12 @@
         type="secondary"
         @click="save"
         v-if="this.currentTab === 'sector' || this.queueToEdit || currentTab === 'tags'"
+      />
+      <unnnic-button
+        icon-left="add-circle-1"
+        :text="$t('quick_messages.add_new')"
+        type="secondary"
+        v-if="this.currentTab === 'quick-messages'"
       />
       <unnnic-modal
         :showModal="openModal"
@@ -146,11 +156,13 @@ import { unnnicCallAlert } from '@weni/unnnic-system';
 import FormAgent from '@/components/settings/forms/Agent';
 import FormSector from '@/components/settings/forms/Sector';
 import FormQueue from '@/components/settings/forms/Queue';
+import FormQuickMessages from '@/components/settings/forms/QuickMessages';
 import FormTags from '@/components/settings/forms/Tags';
 import SectorTabs from '@/components/settings/SectorTabs';
 
 import Sector from '@/services/api/resources/settings/sector';
 import Queue from '@/services/api/resources/settings/queue';
+import QuickMessage from '@/services/api/resources/chats/quickMessage';
 import Project from '@/services/api/resources/settings/project';
 
 export default {
@@ -160,6 +172,7 @@ export default {
     FormAgent,
     FormQueue,
     FormSector,
+    FormQuickMessages,
     FormTags,
     SectorTabs,
   },
@@ -214,6 +227,7 @@ export default {
     agents: [],
     projectAgents: [],
     projectManagers: [],
+    quick_messages: [],
     tags: [],
     currentTags: [],
     toAddTags: [],
@@ -342,6 +356,10 @@ export default {
         this.getQueues();
       }
     },
+    async getQuickMessages() {
+      const quick_messages = await QuickMessage.getAll({ offset: 10, limit: 10, sector: true });
+      this.quick_messages = quick_messages.results;
+    },
     async getTags() {
       const tags = await Sector.tags(this.sector.uuid);
       this.tags = tags.results;
@@ -422,6 +440,8 @@ export default {
     async handleTabChange(currentTab) {
       if (currentTab === 'sector') return;
       if (currentTab === 'queues' && this.queues.length === 0) await this.getQueues();
+      if (currentTab === 'quick-messages' && this.quick_messages.length === 0)
+        await this.getQuickMessages();
       if (currentTab === 'tags' && this.tags.length === 0) await this.getTags();
       this.queueToEdit = null;
       this.pageAgents = 0;

--- a/src/views/Settings/Sectors/Edit.vue
+++ b/src/views/Settings/Sectors/Edit.vue
@@ -269,6 +269,12 @@ export default {
   },
 
   methods: {
+    resetTabsData() {
+      this.queueToEdit = null;
+      this.isQuickMessageEditing = false;
+      this.pageAgents = 0;
+      this.$refs.formQuickMessages?.resetQuickMessageToUpdate();
+    },
     focusTextEditor() {
       this.$nextTick(() => {
         this.$refs.textEditor?.focus();
@@ -412,7 +418,7 @@ export default {
     },
 
     async cancel() {
-      this.$router.push({ name: 'sectors' });
+      this.resetTabsData();
     },
 
     async save() {
@@ -420,6 +426,11 @@ export default {
       if (this.currentTab === 'queues' && this.queueToEdit) await this.saveQueue();
       if (this.currentTab === 'quick-messages') await this.quickMessageHandler('save');
       if (this.currentTab === 'tags') await this.saveTags();
+
+      if (['queues', 'quick-messages'].includes(this.currentTab)) {
+        this.resetTabsData();
+        return;
+      }
 
       this.$router.push({ name: 'sectors' });
     },
@@ -492,9 +503,8 @@ export default {
       if (currentTab === 'sector') return;
       if (currentTab === 'queues' && this.queues.length === 0) await this.getQueues();
       if (currentTab === 'tags' && this.tags.length === 0) await this.getTags();
-      this.queueToEdit = null;
-      this.isQuickMessageEditing = false;
-      this.pageAgents = 0;
+
+      this.resetTabsData();
     },
     removeManagerFromTheList(managerUuid) {
       const manager = this.sector.managers.find((manager) => manager.uuid === managerUuid);

--- a/src/views/Settings/Sectors/Edit.vue
+++ b/src/views/Settings/Sectors/Edit.vue
@@ -106,6 +106,7 @@
           :quick-messages-shared="quickMessagesShared"
           :sector="sector"
           @update-is-quick-message-editing="handleIsQuickMessageEditing"
+          @validate="isQuickMessagesFormValid = $event"
         />
       </template>
 
@@ -132,6 +133,7 @@
         :text="$t('save')"
         type="secondary"
         @click="save"
+        :disabled="isQuickMessageEditing && !isQuickMessagesFormValid"
         v-if="
           this.currentTab === 'sector' ||
           this.queueToEdit ||
@@ -260,6 +262,7 @@ export default {
     editContent: false,
     content: '',
     isQuickMessageEditing: false,
+    isQuickMessagesFormValid: false,
   }),
 
   computed: {

--- a/src/views/Settings/Sectors/Edit.vue
+++ b/src/views/Settings/Sectors/Edit.vue
@@ -493,6 +493,7 @@ export default {
       if (currentTab === 'queues' && this.queues.length === 0) await this.getQueues();
       if (currentTab === 'tags' && this.tags.length === 0) await this.getTags();
       this.queueToEdit = null;
+      this.isQuickMessageEditing = false;
       this.pageAgents = 0;
     },
     removeManagerFromTheList(managerUuid) {

--- a/src/views/Settings/Sectors/Edit.vue
+++ b/src/views/Settings/Sectors/Edit.vue
@@ -101,7 +101,7 @@
       </template>
 
       <template #quick-messages>
-        <form-quick-messages :quick_messages="quick_messages" :sector="sector" />
+        <form-quick-messages :quick-messages-shared="quickMessagesShared" :sector="sector" />
       </template>
 
       <template #tags>
@@ -162,8 +162,8 @@ import SectorTabs from '@/components/settings/SectorTabs';
 
 import Sector from '@/services/api/resources/settings/sector';
 import Queue from '@/services/api/resources/settings/queue';
-import QuickMessage from '@/services/api/resources/chats/quickMessage';
 import Project from '@/services/api/resources/settings/project';
+import { mapState } from 'vuex';
 
 export default {
   name: 'EditSector',
@@ -227,7 +227,6 @@ export default {
     agents: [],
     projectAgents: [],
     projectManagers: [],
-    quick_messages: [],
     tags: [],
     currentTags: [],
     toAddTags: [],
@@ -242,6 +241,12 @@ export default {
     editContent: false,
     content: '',
   }),
+
+  computed: {
+    ...mapState({
+      quickMessagesShared: (state) => state.chats.quickMessagesShared.quickMessagesShared,
+    }),
+  },
 
   methods: {
     focusTextEditor() {
@@ -356,10 +361,6 @@ export default {
         this.getQueues();
       }
     },
-    async getQuickMessages() {
-      const quick_messages = await QuickMessage.getAll({ offset: 10, limit: 10, sector: true });
-      this.quick_messages = quick_messages.results;
-    },
     async getTags() {
       const tags = await Sector.tags(this.sector.uuid);
       this.tags = tags.results;
@@ -440,8 +441,6 @@ export default {
     async handleTabChange(currentTab) {
       if (currentTab === 'sector') return;
       if (currentTab === 'queues' && this.queues.length === 0) await this.getQueues();
-      if (currentTab === 'quick-messages' && this.quick_messages.length === 0)
-        await this.getQuickMessages();
       if (currentTab === 'tags' && this.tags.length === 0) await this.getTags();
       this.queueToEdit = null;
       this.pageAgents = 0;

--- a/src/views/Settings/Sectors/Edit.vue
+++ b/src/views/Settings/Sectors/Edit.vue
@@ -273,23 +273,23 @@ export default {
         this.$refs.textEditor?.focus();
       });
     },
-    async quickMessageHandler(action) {
+    async quickMessageHandler(action, uuid = '') {
       const { formQuickMessages } = this.$refs;
 
       const actions = {
         create: () => {
-          formQuickMessages.createEmptyQuickMessage();
+          formQuickMessages.create();
           this.isQuickMessageEditing = true;
         },
         update: () => {
           console.log('Update');
         },
         save: () => {
-          formQuickMessages.createQuickMessage({ sectorUuid: this.uuid });
+          formQuickMessages.save({ sectorUuid: this.uuid });
           this.isQuickMessageEditing = false;
         },
         delete: () => {
-          console.log('Delete');
+          formQuickMessages.delete(uuid);
         },
       };
 

--- a/src/views/Settings/Sectors/Edit.vue
+++ b/src/views/Settings/Sectors/Edit.vue
@@ -105,6 +105,7 @@
           ref="formQuickMessages"
           :quick-messages-shared="quickMessagesShared"
           :sector="sector"
+          @update-is-quick-message-editing="handleIsQuickMessageEditing"
         />
       </template>
 
@@ -273,7 +274,11 @@ export default {
         this.$refs.textEditor?.focus();
       });
     },
-    async quickMessageHandler(action, uuid = '') {
+    handleIsQuickMessageEditing(boolean) {
+      this.isQuickMessageEditing = boolean;
+    },
+    async quickMessageHandler(action) {
+      const { uuid } = this;
       const { formQuickMessages } = this.$refs;
 
       const actions = {
@@ -281,15 +286,9 @@ export default {
           formQuickMessages.create();
           this.isQuickMessageEditing = true;
         },
-        update: () => {
-          console.log('Update');
-        },
         save: () => {
-          formQuickMessages.save({ sectorUuid: this.uuid });
+          formQuickMessages.save({ uuid });
           this.isQuickMessageEditing = false;
-        },
-        delete: () => {
-          formQuickMessages.delete(uuid);
         },
       };
 


### PR DESCRIPTION
- Added the quick messages tab when editing sectors and with it the listing, creation, editing and removal of shared quick messages;
- Refactored the AppAccordion component;
- Added "My quick messages" and "Shared quick messages (by sector)" sections in the chat quick messages tab;
- Added quick messages shared in SuggestionBox of textbox.
- Created the quick messages global state controller
- Refactored the quick messages api controller