### PR TITLE
Change old selects to SelectSmart

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@emoji-mart/data": "^1.1.2",
-    "@weni/unnnic-system": "1.16.17",
+    "@weni/unnnic-system": "1.16.31",
     "axios": "^0.27.2",
     "core-js": "^3.8.3",
     "emoji-mart": "^5.5.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@emoji-mart/data": "^1.1.2",
-    "@weni/unnnic-system": "1.16.31",
+    "@weni/unnnic-system": "1.16.35",
     "axios": "^0.27.2",
     "core-js": "^3.8.3",
     "emoji-mart": "^5.5.2",

--- a/src/components/ModalOnBoardingChats.vue
+++ b/src/components/ModalOnBoardingChats.vue
@@ -51,7 +51,7 @@
                 <unnnic-icon
                   icon="arrow-left-1-1"
                   size="sm"
-                  scheme="neutral-clean"
+                  scheme="neutral-cleanest"
                   clickable
                   @click="
                     resetAutoSkip();
@@ -74,7 +74,7 @@
                 <unnnic-icon
                   icon="arrow-right-1-1"
                   size="sm"
-                  scheme="neutral-clean"
+                  scheme="neutral-cleanest"
                   clickable
                   @click="
                     resetAutoSkip();
@@ -256,12 +256,12 @@ export default {
         width: 0.25rem;
         height: 0.25rem;
         border-radius: 0.25rem;
-        background-color: rgba($unnnic-color-neutral-clean, $unnnic-opacity-level-overlay);
+        background-color: rgba($unnnic-color-neutral-cleanest, $unnnic-opacity-level-overlay);
         transition: all 0.5s;
 
         &.active {
           width: 1rem;
-          background-color: $unnnic-color-neutral-clean;
+          background-color: $unnnic-color-neutral-cleanest;
         }
       }
     }

--- a/src/components/chats/ContactInfo/CustomField.vue
+++ b/src/components/chats/ContactInfo/CustomField.vue
@@ -133,13 +133,13 @@ export default {
       cursor: text;
 
       &:hover {
-        border: 1px solid $unnnic-color-neutral-clean;
+        border: 1px solid $unnnic-color-neutral-cleanest;
       }
     }
 
     &.current {
       width: 100%;
-      border: 1px solid $unnnic-color-neutral-cleanest;
+      border: 1px solid $unnnic-color-neutral-clean;
 
       input {
         width: 100%;

--- a/src/components/chats/MediaMessage/Controls.vue
+++ b/src/components/chats/MediaMessage/Controls.vue
@@ -1,6 +1,6 @@
 <template>
   <section class="media-message-controls">
-    <unnnic-icon-svg icon="paginate-filter-text-1" scheme="neutral-cleanest" size="sm" />
+    <unnnic-icon-svg icon="paginate-filter-text-1" scheme="neutral-clean" size="sm" />
     <span class="filename">
       {{ fullFilename }}
     </span>
@@ -34,7 +34,7 @@ export default {
 
   .filename {
     font-size: 0.75rem;
-    color: $unnnic-color-neutral-cleanest;
+    color: $unnnic-color-neutral-clean;
     line-height: 1.25rem;
   }
 }

--- a/src/components/chats/MessageEditor/TextBox.vue
+++ b/src/components/chats/MessageEditor/TextBox.vue
@@ -186,7 +186,7 @@ export default {
       outline: none;
 
       &::placeholder {
-        color: $unnnic-color-neutral-clean;
+        color: $unnnic-color-neutral-cleanest;
       }
     }
 
@@ -194,7 +194,7 @@ export default {
       margin-bottom: $padding-vertical;
 
       svg > path {
-        fill: $unnnic-color-neutral-cleanest;
+        fill: $unnnic-color-neutral-clean;
       }
     }
   }

--- a/src/components/chats/MessageEditor/index.vue
+++ b/src/components/chats/MessageEditor/index.vue
@@ -269,14 +269,14 @@ export default {
   &-box__container {
     position: relative;
 
-    border: $unnnic-border-width-thinner solid $unnnic-color-neutral-clean;
+    border: $unnnic-border-width-thinner solid $unnnic-color-neutral-cleanest;
     border-radius: $unnnic-border-radius-sm;
     background-color: $unnnic-color-neutral-snow;
 
     height: 100%;
 
     &.focused {
-      border-color: $unnnic-color-neutral-cleanest;
+      border-color: $unnnic-color-neutral-clean;
     }
 
     &.loading {
@@ -292,14 +292,14 @@ export default {
         width: 100%;
         height: $unnnic-border-width-thin;
 
-        background-color: rgba($unnnic-color-neutral-cleanest, $unnnic-opacity-level-light);
+        background-color: rgba($unnnic-color-neutral-clean, $unnnic-opacity-level-light);
 
         overflow: hidden;
 
         .loading-indicator {
           height: $unnnic-border-width-thin;
 
-          background-color: $unnnic-color-neutral-cleanest;
+          background-color: $unnnic-color-neutral-clean;
           transition: width 0.2s;
         }
       }

--- a/src/components/chats/QuickMessages/QuickMessageForm.vue
+++ b/src/components/chats/QuickMessages/QuickMessageForm.vue
@@ -18,7 +18,7 @@
         <span class="label">
           {{ $t('shortcut') }}
           <unnnic-tool-tip enabled :text="$t('quick_messages.shortcut_field_tooltip')" side="right">
-            <unnnic-icon-svg scheme="neutral-clean" icon="information-circle-4" size="sm" />
+            <unnnic-icon-svg scheme="neutral-cleanest" icon="information-circle-4" size="sm" />
           </unnnic-tool-tip>
         </span>
       </template>

--- a/src/components/chats/TemplateMessages/LayoutTemplateMessage.vue
+++ b/src/components/chats/TemplateMessages/LayoutTemplateMessage.vue
@@ -10,7 +10,7 @@
           text="Os fluxos disponíveis aqui devem ser previamente cadastrados no módulo de fluxos, caso tenha dúvidas converse com seu gerente."
           side="bottom"
         >
-          <unnnic-icon-svg scheme="neutral-clean" icon="information-circle-4" size="sm" />
+          <unnnic-icon-svg scheme="neutral-cleanest" icon="information-circle-4" size="sm" />
         </unnnic-tool-tip>
       </div>
       <div style="padding-left: 12px" v-if="!loadingFlows">

--- a/src/components/chats/UserAvatar.vue
+++ b/src/components/chats/UserAvatar.vue
@@ -94,12 +94,12 @@ $avatar-sizes: '2xl' 3rem, 'xl' $unnnic-icon-size-xl, 'lg' $unnnic-icon-size-lg,
   }
 
   &.disabled {
-    background: $unnnic-color-neutral-clean;
+    background: $unnnic-color-neutral-cleanest;
     color: $unnnic-color-neutral-snow;
   }
 
   &.off {
-    color: $unnnic-color-neutral-clean;
+    color: $unnnic-color-neutral-cleanest;
   }
 
   @each $name, $size in $avatar-sizes {

--- a/src/components/chats/chat/ChatMessage.vue
+++ b/src/components/chats/chat/ChatMessage.vue
@@ -203,7 +203,7 @@ export default {
       }
 
       & .unsent-message {
-        color: $unnnic-color-neutral-clean;
+        color: $unnnic-color-neutral-cleanest;
 
         & .resend-button {
           display: inline-flex;

--- a/src/components/chats/chat/ChatMessages.vue
+++ b/src/components/chats/chat/ChatMessages.vue
@@ -28,18 +28,13 @@
         <div class="chat-messages__room__divisor__line" style="background: #d0d3d9" />
       </div> -->
       <div v-if="isTransferInfoMessage(message)" class="chat-messages__room__transfer-info">
-        <unnnic-icon
-          v-if="!room.is_waiting"
-          icon="logout-1-1"
-          size="sm"
-          scheme="neutral-cleanest"
-        />
+        <unnnic-icon v-if="!room.is_waiting" icon="logout-1-1" size="sm" scheme="neutral-clean" />
         {{ !room.is_waiting ? createTransferLabel(message) : $t('waiting_answer.send_template') }}
         <unnnic-icon
           v-if="room.is_waiting"
           icon="send-email-3-1"
           size="sm"
-          scheme="neutral-cleanest"
+          scheme="neutral-clean"
         />
       </div>
 
@@ -276,7 +271,7 @@ export default {
       text-align: center;
       font-size: $unnnic-font-size-body-md;
       line-height: 1.25rem;
-      color: $unnnic-color-neutral-cleanest;
+      color: $unnnic-color-neutral-clean;
     }
   }
 

--- a/src/components/dashboard/Filters.vue
+++ b/src/components/dashboard/Filters.vue
@@ -24,26 +24,16 @@
         </option>
       </unnnic-select>
 
-      <unnnic-select
-        style="min-width: 11.81rem; width: 18.65rem"
-        v-if="filteredSectorUuid"
-        v-model="filteredAgent"
-        label="Filtrar por agente"
-        size="md"
-        class="input"
-        @input="sendFilter('sector', filteredSectorUuid, filteredAgent)"
-        searchPlaceholder="oi"
-      >
-        <option value="">Buscar por agente</option>
-        <option
-          v-for="agent in agents"
-          :key="agent.email"
-          :value="agent.email"
-          :selected="agent.email === filteredAgent"
-        >
-          {{ agent.name }}
-        </option>
-      </unnnic-select>
+      <div v-if="filteredSectorUuid" style="min-width: 11.81rem; width: 18.65rem">
+        <unnnic-label label="Filtrar por agente" />
+        <unnnic-select-smart
+          v-model="filteredAgent"
+          :options="agents"
+          autocomplete
+          autocompleteClearOnFocus
+          @input="sendFilter('sector', filteredSectorUuid, filteredAgent)"
+        />
+      </div>
 
       <unnnic-select-smart
         style="min-width: 11.81rem; width: 18.65rem"
@@ -166,7 +156,7 @@ export default {
     messageInputAgent: 'Filtrar por agente',
     sectors: [],
     sectorTags: [],
-    tags: [],
+    tags: [{ value: '', label: 'Filtrar por tags' }],
     agents: [],
     selecteds: [],
     filteredDateRange: {
@@ -222,7 +212,7 @@ export default {
         type,
         sectorUuid: filteredSectorUuid,
         tag,
-        agent,
+        agent: agent?.[0]?.value || '',
         filteredDateRange,
       };
       this.$emit('filter', filter);
@@ -270,10 +260,11 @@ export default {
         const response = await Sector.agents({ sectorUuid: uuid });
         const agents = response.map(({ first_name, last_name, email }) => {
           return {
-            name: [first_name, last_name].join(' ').trim() || email,
-            email,
+            label: [first_name, last_name].join(' ').trim() || email,
+            value: email,
           };
         });
+        agents.push({ value: '', label: 'Buscar por agente' });
         this.agents = agents;
         this.isLoading = false;
       } catch (error) {
@@ -296,7 +287,7 @@ export default {
     filteredSectorUuid: {
       deep: true,
       handler() {
-        this.sendFilter('sector', this.filteredSectorUuid, null, null, null);
+        this.sendFilter('sector', this.filteredAgent, null, null, null);
       },
     },
     filteredAgent: {

--- a/src/components/dashboard/Filters.vue
+++ b/src/components/dashboard/Filters.vue
@@ -45,11 +45,13 @@
         </option>
       </unnnic-select>
 
-      <unnnic-autocomplete-select
+      <unnnic-select-smart
         style="min-width: 11.81rem; width: 18.65rem"
+        :options="tags"
         v-model="selecteds"
-        :items="tags"
-        :placeholder="this.messageInputTags"
+        autocomplete
+        autocompleteIconLeft
+        autocompleteClearOnFocus
         :disabled="!this.filteredSectorUuid && sectors.length !== 1"
         @input="sendFilter('sector', filteredSectorUuid, filteredAgent, selecteds)"
       />
@@ -177,7 +179,7 @@ export default {
     async downloadMetric(option) {
       const temTag = ![null, undefined, ''].includes(this.selecteds);
       if (temTag) {
-        this.nameTag = this.selecteds.map((el) => el.text).toString();
+        this.nameTag = this.selecteds.map((el) => el.label).toString();
       } else {
         this.nameTag = this.selecteds;
       }
@@ -197,7 +199,7 @@ export default {
     async downloadDashboardData(option) {
       const temTag = ![null, undefined, ''].includes(this.selecteds);
       if (temTag) {
-        this.nameTag = this.selecteds.map((el) => el.text).toString();
+        this.nameTag = this.selecteds.map((el) => el.label).toString();
       } else {
         this.nameTag = this.selecteds;
       }
@@ -248,9 +250,10 @@ export default {
       try {
         this.isLoading = true;
         const response = await Sector.tags(sectorUuid);
-        const tags = response.results;
+        const responseTags = response.results;
 
-        const tagGroup = tags.map((tag) => ({ value: tag.uuid, text: tag.name }));
+        const tagGroup = responseTags.map((tag) => ({ value: tag.uuid, label: tag.name }));
+        tagGroup.push({ value: '', label: 'Filtrar por tags' });
         this.tags = tagGroup;
         this.isLoading = false;
       } catch (error) {

--- a/src/components/dashboard/metrics/BySector/HistoryMetrics.vue
+++ b/src/components/dashboard/metrics/BySector/HistoryMetrics.vue
@@ -111,7 +111,7 @@ export default {
     async agentInfo() {
       const temTag = ![null, undefined, ''].includes(this.filter.tag);
       if (temTag) {
-        this.nameTag = this.filter.tag.map((el) => el.text).toString();
+        this.nameTag = this.filter.tag.map((el) => el.value).toString();
       } else {
         this.nameTag = this.filter.tag;
       }
@@ -131,7 +131,7 @@ export default {
     async roomInfo() {
       const temTag = ![null, undefined, ''].includes(this.filter.tag);
       if (temTag) {
-        this.nameTag = this.filter.tag.map((el) => el.text).toString();
+        this.nameTag = this.filter.tag.map((el) => el.value).toString();
       } else {
         this.nameTag = this.filter.tag;
       }
@@ -151,7 +151,7 @@ export default {
     async sectorInfo() {
       const temTag = ![null, undefined, ''].includes(this.filter.tag);
       if (temTag) {
-        this.nameTag = this.filter.tag.map((el) => el.text).toString();
+        this.nameTag = this.filter.tag.map((el) => el.value).toString();
       } else {
         this.nameTag = this.filter.tag;
       }
@@ -170,7 +170,7 @@ export default {
     async rawDataInfo() {
       const temTag = ![null, undefined, ''].includes(this.filter.tag);
       if (temTag) {
-        this.nameTag = this.filter.tag.map((el) => el.text).toString();
+        this.nameTag = this.filter.tag.map((el) => el.value).toString();
       } else {
         this.nameTag = this.filter.tag;
       }
@@ -189,7 +189,7 @@ export default {
     async downloadDashboardData() {
       const temTag = ![null, undefined, ''].includes(this.filter.tag);
       if (temTag) {
-        this.nameTag = this.filter.tag.map((el) => el.text).toString();
+        this.nameTag = this.filter.tag.map((el) => el.value).toString();
       } else {
         this.nameTag = this.filter.tag;
       }

--- a/src/components/settings/forms/Agent.vue
+++ b/src/components/settings/forms/Agent.vue
@@ -9,18 +9,18 @@
       </p>
 
       <section class="controls">
-        <unnnic-autocomplete
-          v-model="search"
-          :data="agentsNames"
-          @choose="chooseAgent"
-          :label="$t('agents.add.select.label')"
-          :placeholder="$t('agents.add.select.placeholder')"
-          iconLeft="search-1"
-          iconRight="keyboard-return-1"
-          open-with-focus
-          highlight
-          class="input"
-        />
+        <div>
+          <unnnic-label :label="$t('agents.add.select.label')" />
+          <unnnic-select-smart
+            v-model="search"
+            class="input"
+            :options="agentsNames"
+            autocomplete
+            autocompleteIconLeft
+            autocompleteClearOnFocus
+            @input="chooseAgent"
+          />
+        </div>
         <!-- <unnnic-button
           type="secondary"
           :text="$t('agents.add.button')"
@@ -72,25 +72,31 @@ export default {
   data: () => ({
     search: '',
     selectAgent: null,
-    agent: {
-      uuid: '',
-    },
+    agent: '',
   }),
 
   computed: {
     agentsNames() {
-      const agents = this.agents.map((agent) => {
-        const { email, first_name, last_name } = agent.user;
+      const agentsNames = [
+        {
+          value: '',
+          label: this.$t('agents.add.select.placeholder'),
+        },
+      ];
 
-        return first_name || last_name ? `${first_name} ${last_name}` : email;
+      this.agents.forEach((agent) => {
+        const {
+          user: { email, first_name, last_name },
+          uuid,
+        } = agent;
+
+        agentsNames.push({
+          value: uuid,
+          label: first_name || last_name ? `${first_name} ${last_name}` : email,
+        });
       });
-      const filterDuplicateNames = agents.filter((item, index) => agents.indexOf(item) === index);
-      // eslint-disable-next-line func-names
-      // const mapped = filterDuplicateNames.map((el, i) => ({ index: i, value: el.toLowerCase() }));
-      // const sort = mapped.sort((a, b) => +(a.value > b.value) || +(a.value === b.value) - 1);
-      // const result = sort.map((el) => filterDuplicateNames[el.index]);
-      return filterDuplicateNames;
-      // return agents.filter((agent) => agent.includes(this.search));
+
+      return agentsNames;
     },
     selectedAgents: {
       get() {
@@ -109,10 +115,9 @@ export default {
     chooseAgent(selected) {
       this.selectAgent = selected;
       const agent = this.agents.find((agent) => {
-        const { first_name, last_name, email } = agent.user;
-        const name = `${first_name} ${last_name}`;
+        const { uuid } = agent;
 
-        return name === selected || email === selected;
+        return uuid === selected[0].value;
       });
       this.agent = agent;
       this.emitSelectedAgent();
@@ -160,16 +165,6 @@ export default {
     line-height: 1.5rem;
 
     margin-bottom: 0.5rem;
-  }
-
-  .controls {
-    display: flex;
-    align-items: flex-end;
-    gap: 1rem;
-
-    .input {
-      flex: 1 1;
-    }
   }
 
   &__agents {

--- a/src/components/settings/forms/Queue.vue
+++ b/src/components/settings/forms/Queue.vue
@@ -93,7 +93,6 @@ export default {
       this.editContent = false;
     },
     visualize(queue) {
-      console.log(queue, 'visualize');
       this.$emit('visualize', queue);
     },
     addQueue() {

--- a/src/components/settings/forms/Sector.vue
+++ b/src/components/settings/forms/Sector.vue
@@ -25,16 +25,17 @@
       </h2>
 
       <div class="inline-input-and-button">
-        <unnnic-autocomplete
-          v-model="manager"
-          :label="$t('sector.managers.add.label')"
-          :data="managersNames"
-          open-with-focus
-          highlight
-          :placeholder="$t('sector.managers.add.placeholder')"
-          iconLeft="search-1"
-          @choose="selectManager"
-        />
+        <div>
+          <unnnic-label :label="$t('sector.managers.add.label')" />
+          <unnnic-select-smart
+            v-model="manager"
+            :options="managersNames"
+            autocomplete
+            autocompleteIconLeft
+            autocompleteClearOnFocus
+            @input="selectManager"
+          />
+        </div>
         <!-- <unnnic-button
           text="Selecionar"
           type="secondary"
@@ -169,13 +170,23 @@ export default {
   computed: {
     managersNames() {
       const managers = this.managers.map((manager) => {
-        const { email, first_name, last_name } = manager.user;
+        const {
+          user: { email, first_name, last_name },
+          uuid,
+        } = manager;
 
-        return first_name || last_name ? `${first_name} ${last_name}` : email;
+        return {
+          value: uuid,
+          label: first_name || last_name ? `${first_name} ${last_name}` : email,
+        };
       });
       const filterDuplicateNames = managers.filter(
         (item, index) => managers.indexOf(item) === index,
       );
+      filterDuplicateNames.push({
+        value: '',
+        label: this.$t('sector.managers.add.placeholder'),
+      });
       // const mapped = filterDuplicateNames.map((el, i) => ({ index: i, value: el.toLowerCase() }));
       // const sort = mapped.sort((a, b) => +(a.value > b.value) || +(a.value === b.value) - 1);
       // const result = sort.map((el) => filterDuplicateNames[el.index]);
@@ -214,7 +225,12 @@ export default {
       const { selectedManager } = this;
       if (!selectedManager) return;
 
-      const managers = [...this.sector.managers, selectedManager];
+      const managers = this.sector.managers.some(
+        (manager) => manager.email === selectedManager.email,
+      )
+        ? this.sector.managers
+        : [...this.sector.managers, selectedManager];
+
       this.sector = {
         ...this.sector,
         managers,
@@ -236,10 +252,9 @@ export default {
 
     selectManager(selected) {
       const manager = this.managers.find((manager) => {
-        const { first_name, last_name, email } = manager.user;
-        const name = `${first_name} ${last_name}`;
+        const { uuid } = manager;
 
-        return name === selected || email === selected;
+        return uuid === selected[0].value;
       });
       this.selectedManager = manager;
       this.addSectorManager();

--- a/src/components/settings/forms/Sector.vue
+++ b/src/components/settings/forms/Sector.vue
@@ -169,29 +169,26 @@ export default {
 
   computed: {
     managersNames() {
-      const managers = this.managers.map((manager) => {
+      const managersNames = [
+        {
+          value: '',
+          label: this.$t('sector.managers.add.placeholder'),
+        },
+      ];
+
+      this.managers.forEach((manager) => {
         const {
           user: { email, first_name, last_name },
           uuid,
         } = manager;
 
-        return {
+        managersNames.push({
           value: uuid,
           label: first_name || last_name ? `${first_name} ${last_name}` : email,
-        };
+        });
       });
-      const filterDuplicateNames = managers.filter(
-        (item, index) => managers.indexOf(item) === index,
-      );
-      filterDuplicateNames.push({
-        value: '',
-        label: this.$t('sector.managers.add.placeholder'),
-      });
-      // const mapped = filterDuplicateNames.map((el, i) => ({ index: i, value: el.toLowerCase() }));
-      // const sort = mapped.sort((a, b) => +(a.value > b.value) || +(a.value === b.value) - 1);
-      // const result = sort.map((el) => filterDuplicateNames[el.index]);
-      return filterDuplicateNames;
-      // return managers.filter((manager) => manager.includes(this.manager));
+
+      return managersNames;
     },
 
     sector: {

--- a/src/layouts/ChatsLayout/components/TheRoomList/RoomGroup/ContactRoom.vue
+++ b/src/layouts/ChatsLayout/components/TheRoomList/RoomGroup/ContactRoom.vue
@@ -152,7 +152,7 @@ export default {
   &.disabled {
     .content {
       .username {
-        color: $unnnic-color-neutral-clean;
+        color: $unnnic-color-neutral-cleanest;
       }
 
       .additional-information {
@@ -161,7 +161,7 @@ export default {
     }
 
     .unread-messages {
-      color: $unnnic-color-neutral-clean;
+      color: $unnnic-color-neutral-cleanest;
     }
   }
 

--- a/src/locales/translations.json
+++ b/src/locales/translations.json
@@ -164,6 +164,18 @@
     "en-us": "Justify",
     "es": "Justificar"
   },
+  "select_smart": {
+    "without_results": {
+      "pt-br": "Nenhum resultado encontrado",
+      "en-us": "No results found",
+      "es": "Ningún resultado encontrado"
+    },
+    "without_multiple_selected": {
+      "pt-br": "Nenhuma opção selecionada",
+      "en-us": "No option selected",
+      "es": "Ninguna opción seleccionada"
+    }
+  },
   "sector": {
     "title": {
       "pt-br": "Setor",

--- a/src/views/Settings/Sectors/New.vue
+++ b/src/views/Settings/Sectors/New.vue
@@ -143,9 +143,8 @@ export default {
     },
     async listProjectAgents() {
       const agents = (await Project.agents()).results.concat((await Project.admins()).results);
-      console.log('agents', agents);
       const uniqueAgents = [...new Map(agents.map((agent) => [agent.uuid, agent])).values()];
-      console.log('uniqueAgents', uniqueAgents);
+
       this.projectAgents = uniqueAgents;
     },
     async nextStep() {

--- a/src/views/Settings/Sectors/New.vue
+++ b/src/views/Settings/Sectors/New.vue
@@ -143,7 +143,10 @@ export default {
     },
     async listProjectAgents() {
       const agents = (await Project.agents()).results.concat((await Project.admins()).results);
-      this.projectAgents = agents;
+      console.log('agents', agents);
+      const uniqueAgents = [...new Map(agents.map((agent) => [agent.uuid, agent])).values()];
+      console.log('uniqueAgents', uniqueAgents);
+      this.projectAgents = uniqueAgents;
     },
     async nextStep() {
       const steps = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2148,10 +2148,10 @@
     "@webassemblyjs/ast" "1.11.1"
     "@xtuc/long" "4.2.2"
 
-"@weni/unnnic-system@1.16.31":
-  version "1.16.31"
-  resolved "https://registry.yarnpkg.com/@weni/unnnic-system/-/unnnic-system-1.16.31.tgz#2984c59846c52a51f933bc2fe9de31d21d9c6562"
-  integrity sha512-4zVG8P0qwhjTfz7g6UnDBOuf1ha5pxXR+qoecgsCQeZqRTPmqF5j1ClkqgGcOWHclm5radNYVIHaKB2O+NAqqA==
+"@weni/unnnic-system@1.16.35":
+  version "1.16.35"
+  resolved "https://registry.yarnpkg.com/@weni/unnnic-system/-/unnnic-system-1.16.35.tgz#7f00c7e5b149a798c4f5ace7e8ab4185fd6f2b7c"
+  integrity sha512-RAlPWVo9Px79g5P4B0lnV5kcFPYtfKY+vOHWWlH9mwrX4ceh8fP1M2/NJTAyZL1Vq0rmpqdDKw80GFzNJgXLTw==
   dependencies:
     core-js "^3.6.5"
     mime-types "^2.1.35"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2148,10 +2148,10 @@
     "@webassemblyjs/ast" "1.11.1"
     "@xtuc/long" "4.2.2"
 
-"@weni/unnnic-system@1.16.17":
-  version "1.16.17"
-  resolved "https://registry.yarnpkg.com/@weni/unnnic-system/-/unnnic-system-1.16.17.tgz#ec86cf8a4b1d416836e3a11c3c73231f8cd43dd1"
-  integrity sha512-9uCTAHPxKd/mTJVbcmG44nUoq/uZ2CcR1WBncPD4dW4YiMMgdWk7ULFRoB5pKGiy+AyHf86uT8nEbelWrdWzqA==
+"@weni/unnnic-system@1.16.31":
+  version "1.16.31"
+  resolved "https://registry.yarnpkg.com/@weni/unnnic-system/-/unnnic-system-1.16.31.tgz#2984c59846c52a51f933bc2fe9de31d21d9c6562"
+  integrity sha512-4zVG8P0qwhjTfz7g6UnDBOuf1ha5pxXR+qoecgsCQeZqRTPmqF5j1ClkqgGcOWHclm5radNYVIHaKB2O+NAqqA==
   dependencies:
     core-js "^3.6.5"
     mime-types "^2.1.35"


### PR DESCRIPTION
Most selects used in Chats have been switched to the new "SelectSmart" component, including:
- Filter by agent on the Dashboard
- Filter by tag on the Dashboard
- Addition of manager in sector creation/edit
- Addition of agents in the creation/editing of sector queues