### PR TITLE
Added geolocation media message variation

### DIFF
--- a/src/components/chats/MediaMessage/index.vue
+++ b/src/components/chats/MediaMessage/index.vue
@@ -1,5 +1,6 @@
 <template>
-  <section v-if="isDocument">
+  <p v-if="isGeolocation">{{ media.url }}</p>
+  <section v-else-if="isDocument">
     <document-preview
       @download="download"
       :fullFilename="fullFilename"
@@ -79,6 +80,10 @@ export default {
     isAudio() {
       const audio = /(mpeg3|wav|ogg)/;
       return audio.test(this.media.content_type);
+    },
+    isGeolocation() {
+      const geolocation = /(geo)/;
+      return geolocation.test(this.media.content_type);
     },
   },
 


### PR DESCRIPTION
**Solved**: When a geolocation message is received in the chat, it was empty, because the message had not been previously handled.