### PR TITLE
Fix of scroll to bottom when paginate in closed chats

### DIFF
--- a/src/components/chats/chat/ChatMessages.vue
+++ b/src/components/chats/chat/ChatMessages.vue
@@ -262,10 +262,13 @@ export default {
   },
 
   watch: {
-    messages() {
-      this.$nextTick(() => {
-        this.manageScrollForNewMessages();
-      });
+    messages: {
+      immediate: true,
+      handler() {
+        this.$nextTick(() => {
+          this.manageScrollForNewMessages();
+        });
+      },
     },
   },
 };

--- a/src/views/chats/ClosedChats.vue
+++ b/src/views/chats/ClosedChats.vue
@@ -287,7 +287,6 @@ export default {
         const response = await Message.getByContact(contact.uuid, offset, 20);
         let messages = response.results;
         this.hasNext = response.next;
-        this.scrollMessagesToBottom();
         if (concat) {
           messages = response.results.concat(this.messages);
         }
@@ -315,11 +314,6 @@ export default {
       this.page = 0;
       this.limit = 50;
       this.componentInAsideSlot = '';
-    },
-
-    scrollMessagesToBottom() {
-      if (!this.$refs.chatMessages) return;
-      this.$refs.chatMessages.$el.scrollTop = 15;
     },
 
     async getContacts() {
@@ -467,7 +461,6 @@ export default {
 
   .messages {
     overflow-y: auto;
-    scroll-behavior: smooth;
     padding-right: $unnnic-spacing-inset-sm;
     margin: $unnnic-spacing-inline-sm 0 $unnnic-spacing-inline-sm;
   }


### PR DESCRIPTION
The functionality responsible for maintaining the scroll in the message, ensuring that it remains at the end, was presenting problems in the chat history due to a function that inadvertently added a value of 15 pixels during the pagination process.