### PR TITLE
Fixed integrity of messages in rooms

### DIFF
--- a/src/store/modules/roomMessages.js
+++ b/src/store/modules/roomMessages.js
@@ -194,9 +194,7 @@ export default {
 
   actions: {
     async getRoomMessages({ commit, state }, { offset = null, concat = false, limit = null }) {
-      const { activeRoom } = Rooms.state;
-
-      if (!activeRoom) {
+      if (!Rooms.state.activeRoom?.uuid) {
         return;
       }
 
@@ -207,12 +205,17 @@ export default {
 
       async function fetchData() {
         try {
-          const response = await Message.getByRoom({ nextReq }, activeRoom.uuid, offset, limit);
+          const response = await Message.getByRoom(
+            { nextReq },
+            Rooms.state.activeRoom.uuid,
+            offset,
+            limit,
+          );
 
           const { results: messages, next: hasNext } = response;
           let newMessages = messages;
 
-          if (!messages?.[0] || !activeRoom?.uuid || messages?.[0]?.room !== activeRoom.uuid) {
+          if (messages?.[0]?.room !== Rooms.state.activeRoom.uuid) {
             return;
           }
 


### PR DESCRIPTION
**Goal**: Maintain the integrity of messages and ensure they are displayed in the correct rooms.

**Solution**: In the previous code, validation was being done based on the activeRoom constant, which no longer reflected the current value of the active room variable. As a result, messages were being associated with the wrong rooms. To solve this problem, I updated the code so that validation is done directly with the activeRoom.uuid property of Rooms.state. Messages are now correctly compared to the active room, ensuring they are in the correct room.