### PR TITLE
fix: Sound of transferring or forwarding a chat

### DIFF
--- a/src/services/api/websocket/listeners/room/update.js
+++ b/src/services/api/websocket/listeners/room/update.js
@@ -9,7 +9,8 @@ export default async (room, { app }) => {
     if (room.transfer_history?.action === 'transfer') {
       const notification = new SoundNotification('achievement-confirmation');
       notification.notify();
-    } else if (room.transfer_history?.action === 'foward') {
+    }
+    if (room.transfer_history?.action === 'forward') {
       const notification = new SoundNotification('select-sound');
       notification.notify();
     }

--- a/src/services/api/websocket/listeners/room/update.js
+++ b/src/services/api/websocket/listeners/room/update.js
@@ -6,7 +6,7 @@ export default async (room, { app }) => {
   ) {
     app.$store.dispatch('chats/rooms/addRoom', room);
 
-    const notification = new SoundNotification('select-sound');
+    const notification = new SoundNotification('achievement-confirmation');
     notification.notify();
   }
 

--- a/src/services/api/websocket/listeners/room/update.js
+++ b/src/services/api/websocket/listeners/room/update.js
@@ -6,8 +6,13 @@ export default async (room, { app }) => {
   ) {
     app.$store.dispatch('chats/rooms/addRoom', room);
 
-    const notification = new SoundNotification('achievement-confirmation');
-    notification.notify();
+    if (room.transfer_history?.action === 'transfer') {
+      const notification = new SoundNotification('achievement-confirmation');
+      notification.notify();
+    } else if (room.transfer_history?.action === 'foward') {
+      const notification = new SoundNotification('select-sound');
+      notification.notify();
+    }
   }
 
   app.$store.dispatch('chats/rooms/updateRoom', {


### PR DESCRIPTION
## Description
### Type of change
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Tests
- [ ] Other

### Motivation and Context
The sound when receiving a chat by a agent or the chat being sent to a queue should be a different sound. Maintaining the standard sound.

### Summary of Changes
Logic was added so that a type of sound would be emitted when transferring or forwarding a chat.

<br />
