### PR TITLE
feat: New contact input mask

### DIFF
--- a/src/components/chats/FlowsTrigger/ModalAddNewContact.vue
+++ b/src/components/chats/FlowsTrigger/ModalAddNewContact.vue
@@ -14,7 +14,7 @@
       <unnnic-input
         v-model="contact.tel"
         label="WhatsApp"
-        placeholder="+99 (99) 9999 99999"
+        placeholder="+99 (99) 99999 9999"
         :mask="Object.values(telMask)"
       />
     </form>

--- a/src/components/chats/FlowsTrigger/ModalAddNewContact.vue
+++ b/src/components/chats/FlowsTrigger/ModalAddNewContact.vue
@@ -15,7 +15,7 @@
         v-model="contact.tel"
         label="WhatsApp"
         placeholder="+99 (99) 9999 99999"
-        :mask="telMask"
+        :mask="Object.values(telMask)"
       />
     </form>
 
@@ -44,14 +44,22 @@ export default {
       name: '',
       tel: '',
     },
-    telMask: '+## (##) #### #####',
+    telMask: {
+      telephone: '+## (##) #### ####',
+      cellphone: '+## (##) ##### ####',
+    },
     isLoading: false,
   }),
 
   computed: {
     isValidForm() {
       const { contact, telMask } = this;
-      return contact.name && contact.tel.length === telMask.length;
+
+      return (
+        contact.name &&
+        (contact.tel.length === telMask.telephone.length ||
+          contact.tel.length === telMask.cellphone.length)
+      );
     },
   },
 


### PR DESCRIPTION
## Description
### Type of change
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Tests
- [ ] Other

### Motivation and Context
It was necessary to add a cell phone mask in the add new contact field, as WhatsApp now accepts this type of data.

### Summary of Changes
An array of masks was added, so that either telephone or cell phone numbers could be accepted.

### Demonstration <!--- (If appropriate) -->
Mask for a telephone:
![image](https://github.com/weni-ai/chats-webapp/assets/30897764/39b5be0a-6daf-4050-a193-4e817b02aba2)

Mask for a cell phone:
![image](https://github.com/weni-ai/chats-webapp/assets/30897764/44a2e0c6-b2c5-4a15-b685-f9a78df22a80)