### PR TITLE
[ENGAGE-424] - Fixed redirection to home and removal of room when it is transferred

### DIFF
--- a/src/services/api/websocket/listeners/room/update.js
+++ b/src/services/api/websocket/listeners/room/update.js
@@ -19,7 +19,7 @@ export default async (room, { app }) => {
   app.$store.dispatch('chats/rooms/updateRoom', {
     room,
     userEmail: app.me.email,
-    routerReplace: () => app.router.replace({ name: 'home' }),
+    routerReplace: () => app.$router.replace({ name: 'home' }),
     viewedAgentEmail: app.viewedAgent.email,
   });
 

--- a/src/store/modules/chats/rooms.js
+++ b/src/store/modules/chats/rooms.js
@@ -129,7 +129,9 @@ export default {
         }
 
         if (isActiveRoom && !viewedAgentEmail) {
+          commit(mutations.SET_ACTIVE_ROOM, null);
           routerReplace();
+          return;
         }
       }
 

--- a/src/views/chats/Home/index.vue
+++ b/src/views/chats/Home/index.vue
@@ -4,8 +4,8 @@
     :class="['home-chats-layout', { 'has-discussion': !!discussion }]"
     @select-quick-message="(quickMessage) => updateTextBoxMessage(quickMessage.text)"
   >
-    <chats-background v-if="!room && !discussion && !isChatSkeletonActive" />
-    <section v-if="!!room || !!discussion" class="active-chat">
+    <chats-background v-if="!room?.uuid && !discussion?.uuid && !isChatSkeletonActive" />
+    <section v-if="room?.uuid || discussion?.uuid" class="active-chat">
       <home-chat-headers
         :isLoading="isChatSkeletonActive"
         @openRoomContactInfo="openRoomContactInfo"


### PR DESCRIPTION
## Description
### Type of change
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Tests
- [ ] Other

### Motivation and Context
Users were reporting that more than one agent was able to answer the same room.

### Summary of Changes
The function that redirects to the home screen when the active room is transferred has been adjusted. Furthermore, along with the redirection to the home screen, the room is reset if the owner is no longer the user or is no longer on hold.
