### PR TITLE
feat: Load more sectors when scroll to bottom on page Settings

### DIFF
--- a/src/services/api/resources/settings/sector.js
+++ b/src/services/api/resources/settings/sector.js
@@ -1,8 +1,18 @@
 import http from '@/services/api/http';
 import { getProject } from '@/utils/config';
 
+function getURLParams({ URL, endpoint }) {
+  return URL?.split(endpoint)?.[1];
+}
+
 export default {
-  async list() {
+  async list(nextReq) {
+    if (nextReq) {
+      const endpoint = '/sector/';
+      const paramsNextReq = getURLParams({ URL: nextReq, endpoint });
+      const response = await http.get(`${endpoint}${paramsNextReq}`);
+      return response.data;
+    }
     const response = await http.get('/sector/', {
       params: { project: getProject() },
     });

--- a/src/views/Settings/index.vue
+++ b/src/views/Settings/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <main class="settings-chats">
+  <main class="settings-chats" ref="sectorsSection" @scroll="onScroll">
     <header>
       <h1 class="title">Gerenciar Chats</h1>
       <p class="description">
@@ -55,6 +55,7 @@ export default {
   data: () => ({
     sectors: [],
     isLoading: true,
+    nextPage: null,
   }),
 
   methods: {
@@ -68,12 +69,45 @@ export default {
       try {
         this.isLoading = true;
         const sectors = await Sector.list();
+        this.nextPage = sectors.next;
         this.sectors = sectors.results;
+        this.next = sectors.next;
         this.isLoading = false;
       } catch (error) {
         this.isLoading = false;
       }
     },
+
+    async listMoreSectors() {
+      if (this.isLoading || !this.nextPage) {
+        return;
+      }
+
+      try {
+        this.isLoading = true;
+        const newSectors = await Sector.list(this.nextPage);
+        this.nextPage = newSectors.next;
+        this.sectors = [...this.sectors, ...newSectors.results];
+        if (newSectors) {
+          this.isLoading = false;
+        }
+      } catch (error) {
+        this.isLoading = false;
+      }
+    },
+
+    onScroll() {
+      if (
+        this.$refs.sectorsSection.scrollTop + this.$refs.sectorsSection.clientHeight >=
+        this.$refs.sectorsSection.scrollHeight
+      ) {
+        this.listMoreSectors();
+      }
+    },
+  },
+
+  mounted() {
+    window.addEventListener('scroll', this.onScroll);
   },
 };
 </script>

--- a/src/views/Settings/index.vue
+++ b/src/views/Settings/index.vue
@@ -1,7 +1,7 @@
 <template>
   <main class="settings-chats" ref="sectorsSection" @scroll="onScroll">
     <header>
-      <h1 class="title">Gerenciar Chatshfsdfhdu</h1>
+      <h1 class="title">Gerenciar Chats</h1>
       <p class="description">
         Adicione, visualize e gerencie os setores, filas, gestores e agentes dentro da sua
         organização.

--- a/src/views/Settings/index.vue
+++ b/src/views/Settings/index.vue
@@ -1,7 +1,7 @@
 <template>
   <main class="settings-chats" ref="sectorsSection" @scroll="onScroll">
     <header>
-      <h1 class="title">Gerenciar Chats</h1>
+      <h1 class="title">Gerenciar Chatshfsdfhdu</h1>
       <p class="description">
         Adicione, visualize e gerencie os setores, filas, gestores e agentes dentro da sua
         organização.
@@ -97,17 +97,13 @@ export default {
     },
 
     onScroll() {
-      if (
-        this.$refs.sectorsSection.scrollTop + this.$refs.sectorsSection.clientHeight >=
-        this.$refs.sectorsSection.scrollHeight
-      ) {
+      const sectorSection = this.$refs.sectorsSection;
+      const isScrollInBottom =
+        sectorSection.scrollTop + sectorSection.clientHeight >= sectorSection.scrollHeight;
+      if (isScrollInBottom) {
         this.listMoreSectors();
       }
     },
-  },
-
-  mounted() {
-    window.addEventListener('scroll', this.onScroll);
   },
 };
 </script>


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
If users had more than 20 sectors, they were unable to see the next sectors.

### Summary of Changes
A feature was added that when there are more than 20 sectors, a new sector page with a limit of 20 is created from the request. It is possible to view the new sectors while scrolling to the end of the page.