### PR TITLE
Fixed contact info tab redirect to history

### DIFF
--- a/src/components/chats/ContactInfo/index.vue
+++ b/src/components/chats/ContactInfo/index.vue
@@ -294,7 +294,7 @@ export default {
     contactNumber() {
       const plataform = (this.closedRoom || this.room).urn.split(':').at(0);
       const number = (this.closedRoom || this.room).urn.split(':').at(-1);
-      const whatsapp = `+${number.substr(-20, 20)} `;
+      const whatsapp = `+${number.substr(-20, 20)}`;
       const infoNumber = {
         plataform,
         contactNum: plataform === 'whatsapp' ? whatsapp : number,
@@ -349,7 +349,18 @@ export default {
   methods: {
     moment,
     openHistory() {
-      window.open(`/closed-chats/${this.room.contact.uuid}`);
+      const { plataform, contactNum } = this.contactNumber;
+      const contactUrn = plataform === 'whatsapp' ? contactNum.replace('+', '') : contactNum;
+
+      const A_YEAR_AGO = moment().subtract(12, 'month').format('YYYY-MM-DD');
+
+      this.$router.push({
+        name: 'closed-rooms',
+        query: {
+          contactUrn,
+          startDate: A_YEAR_AGO,
+        },
+      });
     },
 
     handleModalStartDiscussion() {

--- a/src/router/routes/chats.js
+++ b/src/router/routes/chats.js
@@ -35,7 +35,11 @@ const routes = [
     name: 'closed-rooms',
     component: () => import('@/views/chats/ClosedChats/index'),
     props: (route) => ({
-      tag: route.query.tag,
+      contactUrn: route.query.contactUrn,
+      sector: route.query.sector,
+      tags: route.query.tags,
+      startDate: route.query.startDate,
+      endDate: route.query.endDate,
     }),
   },
   {

--- a/src/views/chats/ClosedChats/RoomsTable.vue
+++ b/src/views/chats/ClosedChats/RoomsTable.vue
@@ -156,6 +156,9 @@ export default {
     this.filterSector = [this.filterSectorsOptionAll];
     this.filterDate = this.filterDateDefault;
     this.tagsToFilter = this.filterTagDefault;
+
+    this.setFiltersByQueryParams();
+
     await this.getSectors();
 
     this.isFiltersLoading = false;
@@ -231,6 +234,20 @@ export default {
   },
 
   methods: {
+    setFiltersByQueryParams() {
+      const { contactUrn, startDate, endDate } = this.$route.query;
+
+      this.filterContact = contactUrn || '';
+
+      if (startDate) {
+        this.filterDate.start = startDate;
+      }
+
+      if (endDate) {
+        this.filterDate.end = endDate;
+      }
+    },
+
     async getHistoryRooms(paginate) {
       this.isTableLoading = true;
       this.isPagesLoading = true;


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The redirect button for contact history was not working as it should after the history restructuring and users were missing it.

### Summary of Changes
The functionality of history filters to receive the query params of the route was added and with this the button to redirect the contact's history makes a push passing the contact's urn as the query param (resulting in the filter only of the histories of that contact).

### Demonstration <!--- (If not appropriate, remove this topic) -->

https://github.com/weni-ai/chats-webapp/assets/69015179/bb598c2e-70b8-48c4-b15a-15fc155e3de5


