### PR TITLE
[ENGAGE-568] - Add the protocol number in the contact info

### DIFF
--- a/src/components/chats/ContactInfo/index.vue
+++ b/src/components/chats/ContactInfo/index.vue
@@ -45,9 +45,9 @@
                     <h3 class="title">{{ contactNumber.plataform }}:</h3>
                     <h4 class="description">{{ contactNumber.contactNum }}</h4>
                   </hgroup>
-                  <hgroup class="info">
+                  <hgroup class="info" v-if="contactProtocol.length > 0">
                     <h3 class="title">Protocolo:</h3>
-                    <h4 class="description">00000000000000000</h4>
+                    <h4 class="description">{{ contactProtocol }}</h4>
                   </hgroup>
                 </section>
               </template>
@@ -307,6 +307,9 @@ export default {
       };
       return infoNumber;
     },
+    contactProtocol() {
+      return (this.closedRoom || this.room).protocol;
+    },
   },
 
   async created() {
@@ -356,6 +359,7 @@ export default {
     moment,
     openHistory() {
       const { plataform, contactNum } = this.contactNumber;
+      const protocol = this.contactProtocol;
       const contactUrn = plataform === 'whatsapp' ? contactNum.replace('+', '') : contactNum;
 
       const A_YEAR_AGO = moment().subtract(12, 'month').format('YYYY-MM-DD');
@@ -364,6 +368,7 @@ export default {
         name: 'closed-rooms',
         query: {
           contactUrn,
+          protocol,
           startDate: A_YEAR_AGO,
         },
       });

--- a/src/components/chats/ContactInfo/index.vue
+++ b/src/components/chats/ContactInfo/index.vue
@@ -45,7 +45,7 @@
                     <h3 class="title">{{ contactNumber.plataform }}:</h3>
                     <h4 class="description">{{ contactNumber.contactNum }}</h4>
                   </hgroup>
-                  <hgroup class="info" v-if="contactProtocol.length > 0">
+                  <hgroup class="info" v-if="contactProtocol?.length > 0">
                     <h3 class="title">{{ $t('protocol') }}:</h3>
                     <h4 class="description">{{ contactProtocol }}</h4>
                   </hgroup>

--- a/src/components/chats/ContactInfo/index.vue
+++ b/src/components/chats/ContactInfo/index.vue
@@ -46,7 +46,7 @@
                     <h4 class="description">{{ contactNumber.contactNum }}</h4>
                   </hgroup>
                   <hgroup class="info" v-if="contactProtocol.length > 0">
-                    <h3 class="title">Protocolo:</h3>
+                    <h3 class="title">{{ $t('protocol') }}:</h3>
                     <h4 class="description">{{ contactProtocol }}</h4>
                   </hgroup>
                 </section>

--- a/src/components/chats/ContactInfo/index.vue
+++ b/src/components/chats/ContactInfo/index.vue
@@ -40,10 +40,16 @@
                 }}
               </p>
               <template>
-                <hgroup class="info">
-                  <h3 class="title">{{ contactNumber.plataform }}:</h3>
-                  <h4 class="description">{{ contactNumber.contactNum }}</h4>
-                </hgroup>
+                <section class="infos">
+                  <hgroup class="info">
+                    <h3 class="title">{{ contactNumber.plataform }}:</h3>
+                    <h4 class="description">{{ contactNumber.contactNum }}</h4>
+                  </hgroup>
+                  <hgroup class="info">
+                    <h3 class="title">Protocolo:</h3>
+                    <h4 class="description">00000000000000000</h4>
+                  </hgroup>
+                </section>
               </template>
               <template v-if="!isHistory && !!room.custom_fields">
                 <custom-field
@@ -680,14 +686,20 @@ export default {
         justify-content: space-between;
       }
 
-      .info {
+      .infos {
         display: flex;
-        align-items: center;
+        flex-direction: column;
         gap: $unnnic-spacing-inline-nano;
 
         &:not(.custom) {
           margin-bottom: $unnnic-spacing-inline-ant;
         }
+      }
+
+      .info {
+        display: flex;
+        align-items: center;
+        gap: $unnnic-spacing-inline-nano;
 
         .title {
           font-weight: $unnnic-font-weight-bold;

--- a/src/locales/translations.json
+++ b/src/locales/translations.json
@@ -745,6 +745,11 @@
     "en-us": "Name or telephone",
     "es": "Nombre o teléfono"
   },
+  "name_or_phone_or_protocol": {
+    "pt-br": "Nome, telefone ou procotolo",
+    "en-us": "Name, telephone or protocol",
+    "es": "Nombre, teléfono o protocolo"
+  },
   "tags": {
     "title": {
       "pt-br": "Tags",

--- a/src/locales/translations.json
+++ b/src/locales/translations.json
@@ -750,6 +750,11 @@
     "en-us": "Name, telephone or protocol",
     "es": "Nombre, teléfono o protocolo"
   },
+  "protocol": {
+    "pt-br": "Protocolo",
+    "en-us": "Protocol",
+    "es": "Protocolo"
+  },
   "tags": {
     "title": {
       "pt-br": "Tags",

--- a/src/views/chats/ClosedChats/RoomsTable.vue
+++ b/src/views/chats/ClosedChats/RoomsTable.vue
@@ -7,7 +7,7 @@
         <unnnic-input
           v-model="filterContact"
           icon-left="search-1"
-          :placeholder="$t('name_or_phone')"
+          :placeholder="$t('name_or_phone_or_protocol')"
         />
       </div>
       <div class="closed-chats__rooms-table__handlers__input" v-if="sectorsToFilter.length > 2">

--- a/src/views/chats/ClosedChats/RoomsTable.vue
+++ b/src/views/chats/ClosedChats/RoomsTable.vue
@@ -55,7 +55,7 @@
           <template #contactName>
             <div class="closed-chats__rooms-table__table__contact">
               <unnnic-chats-user-avatar :username="item.contact.name" />
-              <p class="closed-chats__rooms-table__table__contact__name">
+              <p class="closed-chats__rooms-table__table__contact__name" :title="item.contact.name">
                 {{ item.contact.name }}
               </p>
             </div>


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The protocol number was required because in some cases in a flow it is necessary to have a protocol number and make it visible in the contact information.

### Summary of Changes
- A functionality has been added that gets this protocol number
- The protocol was added in the html but so that it will only be visible if there really is a number
- The style was changed so that when there is a protocol number it is grouped with the contact number
- Some translations have been added
- The history search placeholder has been changed
- A title was added when hovering the mouse over the contact in the history

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File 1](https://www.figma.com/file/EKDuFFZYBOXei5BNzGCQyB/Redesign-Chats?node-id=2905%3A5588&mode=dev)

### Demonstration <!--- (If not appropriate, remove this topic) -->
![image](https://github.com/weni-ai/chats-webapp/assets/30897764/2919fadb-0bbe-4763-88c6-c9cd233a5c61)
![image](https://github.com/weni-ai/chats-webapp/assets/30897764/8cb6f18c-8e32-4b9e-8e51-8bd9bc6126dd)
![image](https://github.com/weni-ai/chats-webapp/assets/30897764/6f05fd9b-f167-4f80-9d4d-929ca3bcbaed)

