### PR TITLE
[ENGAGE-572] - Added the listing of custom fields in closed chats

### DIFF
--- a/src/components/chats/ContactInfo/index.vue
+++ b/src/components/chats/ContactInfo/index.vue
@@ -45,13 +45,13 @@
                   <h4 class="description">{{ contactNumber.contactNum }}</h4>
                 </hgroup>
               </template>
-              <template v-if="!isHistory && !!room.custom_fields">
+              <template v-if="!!room.custom_fields">
                 <custom-field
                   v-for="(value, key) in customFields"
                   :key="key"
                   :title="key"
                   :description="value"
-                  :is-editable="room.can_edit_custom_fields"
+                  :is-editable="!isHistory && room.can_edit_custom_fields"
                   :is-current="isCurrentCustomField(key)"
                   :value="currentCustomField?.[key]"
                   @update-current-custom-field="updateCurrentCustomField"
@@ -304,16 +304,16 @@ export default {
   },
 
   async created() {
+    const { closedRoom, room } = this;
+
+    this.customFields = (closedRoom || room)?.custom_fields;
+
     if (this.isHistory) {
       return;
     }
 
-    const { room } = this;
-
-    this.customFields = room.custom_fields;
-
     if (
-      moment((this.closedRoom || room).contact.created_on).format('YYYY-MM-DD') <
+      moment((closedRoom || room).contact.created_on).format('YYYY-MM-DD') <
       moment().format('YYYY-MM-DD')
     ) {
       this.contactHaveHistory = true;
@@ -601,9 +601,7 @@ export default {
   },
   watch: {
     room(newRoom) {
-      if (!this.isHistory) {
-        this.customFields = newRoom.custom_fields;
-      }
+      this.customFields = newRoom.custom_fields;
     },
     transferRadio: {
       handler() {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Users complained that the chat's custom fields were not appearing in the history after the room was closed.

### Summary of Changes
Validations for showing custom fields only in active chats have been removed.

### Demonstration <!--- (If not appropriate, remove this topic) -->
![image](https://github.com/weni-ai/chats-webapp/assets/69015179/b3499ccc-54ca-4ebc-8907-9443716015d3)
