### PR TITLE
[ENGAGE-603] - Alert if there is already a contact with the same number

### DIFF
--- a/src/components/chats/FlowsTrigger/ModalAddNewContact.vue
+++ b/src/components/chats/FlowsTrigger/ModalAddNewContact.vue
@@ -87,8 +87,22 @@ export default {
 
         this.$emit('close', response);
       } catch (error) {
-        this.isLoading = false;
+        if (error?.response?.status === 400) {
+          const prepareTel = this.contact.tel.replace(/[^0-9]/g, '');
+          const contact = [`${prepareTel}`];
+          unnnicCallAlert({
+            props: {
+              text: this.$t('flows_trigger.contact_already_exists', { contact }),
+              type: 'error',
+            },
+            seconds: 5,
+          });
+        } else {
+          throw error;
+        }
 
+        this.isLoading = false;
+        this.$emit('close');
         console.log(error);
       }
     },

--- a/src/locales/translations.json
+++ b/src/locales/translations.json
@@ -1327,6 +1327,11 @@
       "pt-br": "Contato adicionado com sucesso",
       "en-us": "Contact added successfully",
       "es": "Contacto agregado exitosamente"
+    },
+    "contact_already_exists": {
+      "pt-br": "O número {contact} já está salvo em sua lista de contatos",
+      "en-us": "The number {contact} is already saved in your contact list",
+      "es": "El número {contact} ya está guardado en tu lista de contactos"
     }
   },
   "quick_messages": {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
When we add a new contact but enter a phone number that has already been used, no feedback appears on the screen.

### Summary of Changes
- Added a function that checks the response from the endpoint, and if there is already a contact with the same phone number, an alert will appear on the screen.
- Added translation for alert text

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File 1](https://www.figma.com/file/05cXobrT3hSvqZyQc3DuFn/Disparo-de-fluxos?type=design&node-id=1725-24115&mode=design&t=RrDY9UBBaV9Fy8R4-0)

### Demonstration <!--- (If not appropriate, remove this topic) -->
![image](https://github.com/weni-ai/chats-webapp/assets/30897764/0decf439-f962-4cf6-b520-9d17cd511f07)
