### PR TITLE
Fix UX of contact info transfer section

### DIFF
--- a/src/components/chats/ContactInfo/index.vue
+++ b/src/components/chats/ContactInfo/index.vue
@@ -121,16 +121,16 @@
           <p class="title-transfer-chat">
             {{ $t('contact_info.transfer_contact') }}
           </p>
-          <div style="margin-top: 20px; margin-bottom: 20px">
-            <unnnic-radio size="sm" v-model="transferRadio" value="agent" :disabled="isViewMode">
-              {{ $t('agent') }}
-            </unnnic-radio>
-
-            <unnnic-radio size="sm" v-model="transferRadio" value="queue" :disabled="isViewMode">
-              {{ $t('queue') }}
-            </unnnic-radio>
-          </div>
           <section class="transfer-section">
+            <section class="transfer__radios">
+              <unnnic-radio size="sm" v-model="transferRadio" value="agent" :disabled="isViewMode">
+                {{ $t('agent') }}
+              </unnnic-radio>
+
+              <unnnic-radio size="sm" v-model="transferRadio" value="queue" :disabled="isViewMode">
+                {{ $t('queue') }}
+              </unnnic-radio>
+            </section>
             <unnnic-select-smart
               v-model="transferContactTo"
               :options="transferOptions"
@@ -143,7 +143,7 @@
             <unnnic-button
               class="transfer__button"
               :text="$t('transfer')"
-              type="secondary"
+              type="primary"
               size="small"
               @click="transferContact"
               :disabled="transferContactTo.length === 0 || isViewMode"
@@ -800,8 +800,12 @@ export default {
   }
 
   .transfer-section {
+    .transfer__radios {
+      margin-top: $unnnic-spacing-ant;
+      margin-bottom: $unnnic-spacing-xs;
+    }
     .transfer__button {
-      margin-top: $unnnic-spacing-inline-sm;
+      margin-top: $unnnic-spacing-xs;
       width: 100%;
     }
   }

--- a/src/components/chats/ContactInfo/index.vue
+++ b/src/components/chats/ContactInfo/index.vue
@@ -146,7 +146,7 @@
               type="secondary"
               size="small"
               @click="transferContact"
-              :disabled="isViewMode"
+              :disabled="transferContactTo.length === 0 || isViewMode"
             />
           </section>
         </aside-slot-template-section>


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [x] Other

### Motivation and Context
The contact transfer session had some inconsistencies for the UX.

### Summary of Changes
- Changed the type of transfer button to the primary
- Added check to disable the transfer button if the transfer option is not already selected
- Adjusted spacing between radio and queue/agent select buttons

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design with adjustments to the contact transfer design](https://www.figma.com/file/EKDuFFZYBOXei5BNzGCQyB/Redesign-Chats?type=design&node-id=2854%3A10199&mode=design&t=LbFGlPfAkuz7BRmZ-1)

### Demonstration <!--- (If not appropriate, remove this topic) -->
![image](https://github.com/weni-ai/chats-webapp/assets/69015179/289fdcc9-1ec9-4989-a086-2aef3a543dad)
![image](https://github.com/weni-ai/chats-webapp/assets/69015179/551e0803-8660-42f8-b2c4-2a7ca6c3c2f5)
