### PR TITLE
[ENGAGE-641] - Fix sector list limit

### DIFF
--- a/src/components/dashboard/Filters.vue
+++ b/src/components/dashboard/Filters.vue
@@ -213,7 +213,7 @@ export default {
 
     async getSectors() {
       try {
-        const { results } = await Sector.list();
+        const { results } = await Sector.list({ limit: 50 });
 
         const newSectors = [this.filterSectorsOptionAll];
         results.forEach(({ uuid, name }) => newSectors.push({ value: uuid, label: name }));

--- a/src/services/api/resources/settings/sector.js
+++ b/src/services/api/resources/settings/sector.js
@@ -6,16 +6,19 @@ function getURLParams({ URL, endpoint }) {
 }
 
 export default {
-  async list(nextReq) {
-    if (nextReq) {
-      const endpoint = '/sector/';
-      const paramsNextReq = getURLParams({ URL: nextReq, endpoint });
-      const response = await http.get(`${endpoint}${paramsNextReq}`);
-      return response.data;
+  async list({ nextReq, limit } = {}) {
+    const endpoint = '/sector/';
+    const paramsNextReq = getURLParams({ URL: nextReq, endpoint });
+    const params = { project: getProject(), limit };
+
+    let response;
+
+    if (nextReq && paramsNextReq) {
+      response = await http.get(`${endpoint}${paramsNextReq}`);
+    } else {
+      response = await http.get(endpoint, { params });
     }
-    const response = await http.get('/sector/', {
-      params: { project: getProject() },
-    });
+
     return response.data;
   },
 

--- a/src/views/Settings/index.vue
+++ b/src/views/Settings/index.vue
@@ -85,7 +85,7 @@ export default {
 
       try {
         this.isLoading = true;
-        const newSectors = await Sector.list(this.nextPage);
+        const newSectors = await Sector.list({ nextReq: this.nextPage });
         this.nextPage = newSectors.next;
         this.sectors = [...this.sectors, ...newSectors.results];
         if (newSectors) {

--- a/src/views/chats/ClosedChats/RoomsTableFilters.vue
+++ b/src/views/chats/ClosedChats/RoomsTableFilters.vue
@@ -180,7 +180,7 @@ export default {
   methods: {
     async getSectors() {
       try {
-        const { results } = await Sector.list();
+        const { results } = await Sector.list({ limit: 50 });
 
         const newSectors = [this.filterSectorsOptionAll];
         results.forEach(({ uuid, name }) => newSectors.push({ value: uuid, label: name }));


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The listing of sectors in the dashboard and chat history selects was limited to 20 items (backend default), while it is not possible to add pagination, an increase in this limit became necessary.

### Summary of Changes
- Refactored list sectors requisition and added limit param;
- Adjusted limit of sector listing requests that are listed in selects.
