### PR TITLE
Fixes of flows trigger contacts

### DIFF
--- a/src/layouts/ChatsLayout/components/FlowsTrigger/index.vue
+++ b/src/layouts/ChatsLayout/components/FlowsTrigger/index.vue
@@ -89,7 +89,7 @@
         </p>
 
         <section v-show="!isContactsLoading">
-          <template v-for="(element, letter) in letras">
+          <template v-for="(element, letter) in letters">
             <UnnnicCollapse
               class="flows-trigger__groups__group"
               :key="letter"
@@ -244,21 +244,23 @@ export default {
   }),
 
   computed: {
-    letras() {
-      const letras = {};
+    letters() {
+      const letters = {};
       this.listOfContacts
-        .filter((item) =>
-          item.name?.toUpperCase().includes(this.search.toUpperCase()),
+        .filter(
+          (item) =>
+            item.name?.toUpperCase().includes(this.search.toUpperCase()) &&
+            item.urns?.[0],
         )
         .forEach((element) => {
           const l = element.name[0].toUpperCase();
           const removeAccent = l
             .normalize('NFD')
             .replace(/[\u0300-\u036f]/g, '');
-          letras[removeAccent] = letras[removeAccent] || [];
-          letras[removeAccent].push(element);
+          letters[removeAccent] = letters[removeAccent] || [];
+          letters[removeAccent].push(element);
         });
-      return letras;
+      return letters;
     },
     searchGroup() {
       return this.listOfGroups.filter((item) =>
@@ -395,9 +397,8 @@ export default {
     },
 
     getContactUrn(item) {
-      return item.urns
-        ? `${item.urns?.[0]?.scheme}:${item.urns?.[0]?.path}`
-        : '';
+      const urn = item.urns?.[0];
+      return urn ? `${urn?.scheme}:${urn?.path}` : '';
     },
 
     async groupList() {

--- a/src/services/api/resources/flows/flowsTrigger.js
+++ b/src/services/api/resources/flows/flowsTrigger.js
@@ -4,7 +4,12 @@ import { getProject, getToken } from '@/utils/config';
 
 const http = axios.create({
   baseURL: env('VUE_APP_FLOWS_API_URL'),
-  headers: { Authorization: `Bearer ${getToken()}` },
+});
+
+http.interceptors.request.use((config) => {
+  // eslint-disable-next-line no-param-reassign
+  config.headers.Authorization = `Bearer ${getToken()}`;
+  return config;
 });
 
 let cancelTokenSource = null;


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The first requests for listing contacts when triggering flows were sending the old token, generating the 401 http code. Also, users without urns were being listed.

### Summary of Changes
- Adjusted the token sent in the first contact list request;
- Corrected the name of the computed variable "letras" to the English standard;
- Removed the list of users without URN.
