### PR TITLE
[ENGAGE-769] - Order dashboard agent chats by status and alphabetically

### DIFF
--- a/src/components/dashboard/metrics/BySector/HistoryMetrics.vue
+++ b/src/components/dashboard/metrics/BySector/HistoryMetrics.vue
@@ -16,7 +16,7 @@
     />
     <TableMetrics
       :headers="agentsLabel"
-      :items="this.agents.project_agents"
+      :items="this.agents"
       title="Chats por agente"
       icon="indicator"
       class="grid-3"
@@ -104,15 +104,30 @@ export default {
   },
 
   methods: {
+    orderAgents(agents) {
+      const onlineAgents = agents.filter(
+        (agent) => agent.agent_status === 'ONLINE',
+      );
+      const offlineAgents = agents.filter(
+        (agent) => agent.agent_status === 'OFFLINE',
+      );
+
+      onlineAgents.sort((a, b) => a.first_name.localeCompare(b.first_name));
+      offlineAgents.sort((a, b) => a.first_name.localeCompare(b.first_name));
+
+      return onlineAgents.concat(offlineAgents);
+    },
+
     async agentInfo() {
       try {
-        this.agents = await DashboardManagerApi.getAgentInfo(
+        const response = await DashboardManagerApi.getAgentInfo(
           this.filter.sector,
           this.filter.agent,
           this.filter.tags,
           this.filter.filterDate.start,
           this.filter.filterDate.end,
         );
+        this.agents = this.orderAgents(response.project_agents);
       } catch (error) {
         console.log(error);
       }


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Users with many agents missed listing ordering to improve the search for agents.

### Summary of Changes
Added the function that orders project agents by status and alphabetically

### Demonstration <!--- (If not appropriate, remove this topic) -->
![image](https://github.com/weni-ai/chats-webapp/assets/69015179/cba69fde-040e-499a-87a1-8f36f2a5de63)
