### PR TITLE
[ENGAGE-824] - Redirectable non-editable custom fields

### DIFF
--- a/src/components/chats/ContactInfo/CustomField.vue
+++ b/src/components/chats/ContactInfo/CustomField.vue
@@ -1,23 +1,22 @@
 <!-- eslint-disable vuejs-accessibility/form-control-has-label -->
 <template>
-  <div class="custom-field">
+  <section class="custom-field">
     <component
       :is="isEditable && isCurrent ? 'label' : 'h3'"
       class="title"
       tabindex="0"
       >{{ title }}:
     </component>
-    <div
-      :class="['description', isEditable && 'editable', isCurrent && 'current']"
-    >
+    <section :class="descriptionClasses">
       <a
-        v-if="!isEditable && isAUrl"
+        v-if="showLink"
         :href="description"
         target="_blank"
         >{{ description }}</a
       >
+
       <UnnnicToolTip
-        v-show="!isCurrent && (isEditable || !isAUrl)"
+        v-show="showEditTooltip"
         class="tooltip"
         side="bottom"
         :enabled="isEditable"
@@ -26,35 +25,25 @@
       >
         <h4
           tabindex="0"
-          @click="
-            isEditable &&
-              updateCurrentCustomField({ key: title, value: description })
-          "
-          @keypress.enter="
-            isEditable &&
-              updateCurrentCustomField({ key: title, value: description })
-          "
+          @click="updateField"
+          @keypress.enter="updateField"
         >
           {{ description }}
         </h4>
       </UnnnicToolTip>
+
       <input
-        v-show="isEditable && isCurrent"
+        v-show="showInput"
         :ref="'custom_field_input_' + title"
         type="text"
         :value="value"
-        @input="
-          updateCurrentCustomField({
-            key: title,
-            value: $event.target.value || '',
-          })
-        "
+        @input="updateValue"
         @blur="saveValue"
         @keypress.enter="saveValue"
         maxlength="50"
       />
-    </div>
-  </div>
+    </section>
+  </section>
 </template>
 
 <script>
@@ -89,13 +78,44 @@ export default {
   },
 
   computed: {
-    isAUrl() {
+    isDescriptionAUrl() {
       const urlRegex = /(https?:\/\/[^\s]+)/g;
       return urlRegex.test(this.description);
+    },
+
+    descriptionClasses() {
+      return [
+        'description',
+        this.isEditable && 'editable',
+        this.isCurrent && 'current',
+      ];
+    },
+    showLink() {
+      return !this.isEditable && this.isDescriptionAUrl;
+    },
+    showEditTooltip() {
+      return !this.isCurrent && (this.isEditable || !this.isDescriptionAUrl);
+    },
+    showInput() {
+      return this.isEditable && this.isCurrent;
     },
   },
 
   methods: {
+    updateField() {
+      if (this.isEditable) {
+        this.updateCurrentCustomField({
+          key: this.title,
+          value: this.description,
+        });
+      }
+    },
+    updateValue(event) {
+      this.updateCurrentCustomField({
+        key: this.title,
+        value: event.target.value || '',
+      });
+    },
     updateCurrentCustomField(customField) {
       this.$emit('update-current-custom-field', customField);
     },

--- a/src/components/chats/ContactInfo/CustomField.vue
+++ b/src/components/chats/ContactInfo/CustomField.vue
@@ -110,7 +110,6 @@ export default {
         this.$nextTick(() => {
           const inputRef = `custom_field_input_${this.title}`;
           const input = this.$refs[inputRef];
-          console.log(this.$refs[inputRef]);
 
           if (input) {
             input.focus();

--- a/src/components/chats/ContactInfo/CustomField.vue
+++ b/src/components/chats/ContactInfo/CustomField.vue
@@ -10,8 +10,14 @@
     <div
       :class="['description', isEditable && 'editable', isCurrent && 'current']"
     >
+      <a
+        v-if="!isEditable && isAUrl"
+        :href="description"
+        target="_blank"
+        >{{ description }}</a
+      >
       <UnnnicToolTip
-        v-show="!isCurrent"
+        v-show="!isCurrent && (isEditable || !isAUrl)"
         class="tooltip"
         side="bottom"
         :enabled="isEditable"
@@ -79,6 +85,13 @@ export default {
       type: String,
       default: '',
       required: true,
+    },
+  },
+
+  computed: {
+    isAUrl() {
+      const urlRegex = /(https?:\/\/[^\s]+)/g;
+      return urlRegex.test(this.description);
     },
   },
 

--- a/src/components/chats/__tests__/CustomField.spec.js
+++ b/src/components/chats/__tests__/CustomField.spec.js
@@ -6,9 +6,9 @@ import defaultProps from './mocks/customFieldMock.js';
 
 const localVue = createLocalVue();
 
-function createWrapper() {
+function createWrapper(propsData) {
   const wrapper = mount(CustomField, {
-    propsData: defaultProps,
+    propsData,
     stubs: {
       UnnnicToolTip: true,
     },
@@ -23,7 +23,7 @@ describe('CustomField', () => {
   let wrapper;
 
   beforeEach(() => {
-    wrapper = createWrapper();
+    wrapper = createWrapper(defaultProps);
   });
 
   it('should renders the title and description', () => {
@@ -31,6 +31,21 @@ describe('CustomField', () => {
     expect(wrapper.find('.description h4').text()).toBe(
       defaultProps.description,
     );
+  });
+
+  it('should show a anchor with target="_blank" if description is a url and is not editable', () => {
+    const newProps = { ...defaultProps };
+    newProps.description = 'https://example.com';
+    newProps.isEditable = false;
+
+    const wrapperWithURL = createWrapper(newProps);
+
+    const anchorElement = wrapperWithURL.find('.description a');
+    expect(anchorElement.exists()).toBe(true);
+    expect(anchorElement.attributes().href).toBe(newProps.description);
+    expect(anchorElement.attributes().target).toBe('_blank');
+
+    wrapper.destroy();
   });
 
   it('should shows the input field when isCurrent prop is true', async () => {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
Users missed a redirection to the link that was exposed as a non-editable custom field.

### Summary of Changes
- Added anchor to custom fields non-editables if are a url
- Added test to anchor at custom field
- Refactored CustomField component

### Demonstration <!--- (If not appropriate, remove this topic) -->
![image](https://github.com/weni-ai/chats-webapp/assets/69015179/56599d25-ee1d-4579-b2a0-6da84af4cf7d)
