### PR TITLE
Fix/Flows trigger contact lists broken in null/undefined values

### DIFF
--- a/src/layouts/ChatsLayout/components/FlowsTrigger/index.vue
+++ b/src/layouts/ChatsLayout/components/FlowsTrigger/index.vue
@@ -360,9 +360,10 @@ export default {
         this.isContactsLoading = true;
         try {
           const response = await FlowsAPI.getContacts(this.searchUrn);
-          this.listOfContacts = this.listOfContacts.concat(
-            response.data.results || [],
-          );
+          // Array filter to prevent 'null' or 'undefined' values in contact response
+          this.listOfContacts = this.listOfContacts
+            .concat(response.data.results || [])
+            .filter((contact) => contact);
           this.hasNext = response.next;
           this.listOfContacts.sort((a, b) => a.name?.localeCompare(b.name));
 


### PR DESCRIPTION
## Description
### Type of Change
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Flow trigger contact list in infinite loading because of `null` values

### Summary of Changes
Add array filter to prevent `null` or `undefined` values in listOfContacts

### Demonstration
![2024-05-16_08-46](https://github.com/weni-ai/chats-webapp/assets/25366317/a1b9e35f-4d62-457f-aa62-187e7da12b3d)

