### PR TITLE
[ENGAGE-1171] - Addition of agent/queue information if the contact has an open room in the flow trigger

### DIFF
--- a/src/layouts/ChatsLayout/components/FlowsTrigger/index.vue
+++ b/src/layouts/ChatsLayout/components/FlowsTrigger/index.vue
@@ -76,7 +76,13 @@
               filled
               scheme="feedback-yellow"
             />
-            {{ $t('flows_trigger.already_open_room', { contact }) }}
+            {{ $t('flows_trigger.already_open_room.open', { contact: contact.contactName }) }}
+            <template v-if="contact.agent">
+              {{ $t('flows_trigger.already_open_room.with_agent', { agent: contact.agent, queue: contact.queue }) }}
+            </template>
+            <template v-else>
+              {{ $t('flows_trigger.already_open_room.in_queue_awaiting', { queue: contact.queue }) }}
+            </template>
           </strong>
         </section>
 
@@ -302,7 +308,7 @@ export default {
 
         this.openedRoomsAlerts = this.openedRoomsAlerts.filter(
           (mappedContactName) => {
-            return mappedContactName !== contact.name;
+            return mappedContactName.contactName !== contact.name;
           },
         );
       } else {
@@ -310,7 +316,7 @@ export default {
         FlowsTrigger.checkContact(contact.uuid)
           .then((response) => {
             if (response.show_warning) {
-              this.openedRoomsAlerts.push(contact.name);
+              this.openedRoomsAlerts.push({ contactName: contact.name, queue: response.queue, agent: response.agent });
             }
           })
           .catch(

--- a/src/locales/translations.json
+++ b/src/locales/translations.json
@@ -1585,9 +1585,21 @@
       }
     },
     "already_open_room": {
-      "pt-br": "{contact} já possui uma sala aberta",
-      "en": "{contact} already has an open room",
-      "es": "{contact} ya tiene sala abierta"
+      "open": {
+        "pt-br": "{contact} já possui um chat",
+        "en": "{contact} already have a chat",
+        "es": "{contact} ya tiene sala"
+      },
+      "with_agent": {
+        "pt-br": "em andamento com agente {agent} na fila {queue}",
+        "en": "in progress with agent {agent} in queue {queue}",
+        "es": "en progreso con el agente {agente} en fila {queue}"
+      },
+      "in_queue_awaiting": {
+        "pt-br": "aguardando na fila {queue}",
+        "en": "waiting in queue {queue}",
+        "es": "esperando en fila {queue}"
+      }
     },
     "send": {
       "pt-br": "Enviar fluxo",


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Inform the agent that a flow will be triggered if the contact already has a room waiting or being attended to by another agent

### Summary of Changes
* Addition of agent/queue information if the contact has an open room in the flow trigger

### Demonstration <!--- (If not appropriate, remove this topic) -->
<!--- Include a screenshot or video showcasing a feature or fix implemented in this pull request. -->

![image](https://github.com/weni-ai/chats-webapp/assets/25366317/fb86e7a1-576e-48ad-b05e-e9dbdfaf26b4)

