### PR TITLE
[ENGAGE-1195] - Change the view room history button to a link to open in a new tab

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -19,19 +19,19 @@ afterEachMiddlewares.forEach((middleware) => router.afterEach(middleware));
 
 router.beforeEach(async (to, from, next) => {
   const configStore = useConfig();
-  // const authenticated = await Keycloak.isAuthenticated();
-  // if (authenticated) {
-  //   // const { token } = Keycloak.keycloak;
-  //   await configStore.setToken(token);
+  const authenticated = await Keycloak.isAuthenticated();
+  if (authenticated) {
+    const { token } = Keycloak.keycloak;
+    await configStore.setToken(token);
 
-  if (to.hash.startsWith('#state=')) {
-    next({ ...to, hash: '' });
+    if (to.hash.startsWith('#state=')) {
+      next({ ...to, hash: '' });
+    } else {
+      next();
+    }
   } else {
-    next();
+    Keycloak.keycloak.login();
   }
-  // } else {
-  //   Keycloak.keycloak.login();
-  // }
 });
 
 router.afterEach(() => {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -19,19 +19,19 @@ afterEachMiddlewares.forEach((middleware) => router.afterEach(middleware));
 
 router.beforeEach(async (to, from, next) => {
   const configStore = useConfig();
-  const authenticated = await Keycloak.isAuthenticated();
-  if (authenticated) {
-    const { token } = Keycloak.keycloak;
-    await configStore.setToken(token);
+  // const authenticated = await Keycloak.isAuthenticated();
+  // if (authenticated) {
+  //   // const { token } = Keycloak.keycloak;
+  //   await configStore.setToken(token);
 
-    if (to.hash.startsWith('#state=')) {
-      next({ ...to, hash: '' });
-    } else {
-      next();
-    }
+  if (to.hash.startsWith('#state=')) {
+    next({ ...to, hash: '' });
   } else {
-    Keycloak.keycloak.login();
+    next();
   }
+  // } else {
+  //   Keycloak.keycloak.login();
+  // }
 });
 
 router.afterEach(() => {

--- a/src/views/chats/ClosedChats/RoomsTable.vue
+++ b/src/views/chats/ClosedChats/RoomsTable.vue
@@ -66,19 +66,17 @@
                   icon="open_in_new"
                 />
               </div>
-              <UnnnicButton
+              <a
                 v-else
-                class="closed-chats__rooms-table__table__visualize-button"
-                :text="$t('see')"
-                type="secondary"
-                size="small"
-                @click="
-                  $router.push({
-                    name: 'closed-rooms.selected',
-                    params: { roomId: item.uuid },
-                  })
-                "
-              />
+                :href="`/closed-chats/${item.uuid}`"
+              >
+                <UnnnicButton
+                  class="closed-chats__rooms-table__table__visualize-button"
+                  :text="$t('see')"
+                  type="secondary"
+                  size="small"
+                />
+              </a>
             </template>
           </UnnnicTableRow>
         </section>


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Users feel the need to open room histories in a new tab.

### Summary of Changes
- Encapsulated see history button into an anchor.

### Demonstration <!--- (If not appropriate, remove this topic) -->
https://github.com/weni-ai/chats-webapp/assets/69015179/e7f2120a-d316-4ab2-893f-22dc8a4734fb

