### PR TITLE
[ENGAGE-1219] - Added text overflow ellipsis at chat feedback

### DIFF
--- a/src/components/chats/chat/ChatFeedback.vue
+++ b/src/components/chats/chat/ChatFeedback.vue
@@ -49,6 +49,8 @@ $scheme-colors: 'blue' $unnnic-color-aux-blue-100,
 .chat-feedback__container {
   margin-top: $unnnic-spacing-md;
 
+  overflow: hidden;
+
   display: flex;
 
   &.divisor {
@@ -60,11 +62,15 @@ $scheme-colors: 'blue' $unnnic-color-aux-blue-100,
     margin: 0 auto;
     border-radius: $unnnic-border-radius-lg;
 
+    overflow: hidden;
+
     padding: $unnnic-spacing-nano $unnnic-spacing-sm;
 
     font-size: $unnnic-font-size-body-md;
     color: $unnnic-color-neutral-black;
     font-weight: $unnnic-font-weight-regular;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 
     @each $name, $color in $scheme-colors {
       &--#{$name} {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
When setting a custom field with many characters, the feedback went beyond the room container, preventing the user from closing the room and accessing the contact information.

### Summary of Changes
Added text overflow ellipsis at chat feedback.

### Demonstration <!--- (If not appropriate, remove this topic) -->
![image](https://github.com/weni-ai/chats-webapp/assets/69015179/e72751ce-36e1-4071-9981-6bf4f4e228f7)
