### PR TITLE
[ENGAGE-1206] - Persistence of views filters

### DIFF
--- a/src/router/routes/dashboard.js
+++ b/src/router/routes/dashboard.js
@@ -12,7 +12,7 @@ const routes = [
   {
     path: '/dashboard/view-mode/:viewedAgent',
     name: 'dashboard.view-mode',
-    component: () => import('@/views/Dashboard/ViewMode/index.vue'),
+    component: () => import('@/views/Dashboard/Manager/index.vue'),
   },
 ];
 

--- a/src/views/Dashboard/Manager/index.vue
+++ b/src/views/Dashboard/Manager/index.vue
@@ -1,5 +1,7 @@
 <template>
-  <DashboardLayout>
+  <ViewMode v-show="viewedAgent?.email" />
+
+  <DashboardLayout v-show="!viewedAgent?.email">
     <template #header> {{ header }}</template>
     <template
       v-if="!this.showData"
@@ -39,10 +41,13 @@
 <script>
 import { mapState } from 'pinia';
 import { useConfig } from '@/store/modules/config';
+import { useDashboard } from '@/store/modules/dashboard';
 
 import Sector from '@/services/api/resources/settings/sector';
 
 import DashboardLayout from '@/layouts/DashboardLayout/index.vue';
+
+import ViewMode from '@/views/Dashboard/ViewMode/index.vue';
 
 import DashboardFilters from '@/components/dashboard/Filters.vue';
 import HistoryMetricsBySector from '@/components/dashboard/metrics/BySector/HistoryMetrics.vue';
@@ -54,6 +59,7 @@ export default {
     DashboardFilters,
     DashboardLayout,
     HistoryMetricsBySector,
+    ViewMode,
   },
 
   data: () => ({
@@ -78,6 +84,8 @@ export default {
   },
   computed: {
     ...mapState(useConfig, ['project']),
+    ...mapState(useDashboard, ['viewedAgent']),
+
     visualization() {
       const filter = this.filters;
       return filter;

--- a/src/views/Dashboard/ViewMode/index.vue
+++ b/src/views/Dashboard/ViewMode/index.vue
@@ -115,14 +115,6 @@ export default {
     this.setActiveDiscussion(null);
   },
 
-  mounted() {
-    this.getViewedAgentData(this.$route.params.viewedAgent);
-  },
-
-  beforeDestroy() {
-    this.setViewedAgent({ name: '', email: '' });
-  },
-
   computed: {
     ...mapState(useRooms, { room: (store) => store.activeRoom }),
     ...mapState(useDiscussions, {
@@ -177,6 +169,16 @@ export default {
     async room() {
       this.isContactInfoOpened = false;
     },
+    '$route.params.viewedAgent': {
+      immediate: true,
+      handler(newViewdAgentEmail) {
+      if (newViewdAgentEmail) {
+        this.getViewedAgentData(this.$route.params.viewedAgent);
+      } else {
+        this.setViewedAgent({ name: '', email: '' });
+      }
+    },
+    }
   },
 };
 </script>

--- a/src/views/chats/ClosedChats/RoomsTable.vue
+++ b/src/views/chats/ClosedChats/RoomsTable.vue
@@ -69,6 +69,10 @@
               <a
                 v-else
                 :href="`/closed-chats/${item.uuid}`"
+                @click.prevent.stop="$router.push({
+                  name: 'closed-rooms.selected',
+                  params: { roomId: item.uuid },
+                })"
               >
                 <UnnnicButton
                   class="closed-chats__rooms-table__table__visualize-button"

--- a/src/views/chats/ClosedChats/index.vue
+++ b/src/views/chats/ClosedChats/index.vue
@@ -21,7 +21,7 @@
     </header>
     <main>
       <section
-        v-if="roomId"
+        v-show="roomId"
         class="closed-chats__selected-chat"
       >
         <RoomMessages />
@@ -32,7 +32,7 @@
         />
       </section>
 
-      <ClosedChatsRoomsTable v-else />
+      <ClosedChatsRoomsTable v-show="!roomId" />
     </main>
   </div>
 </template>


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Users complained that when changing routes on the dashboard and in the room history, the filter applied to these views was reset.

### Summary of Changes
- Replaced v-if with v-show to remain the mounted history view;
- Centralized the dashboard and view mode route in one component and used the same logic as above.

