### PR TITLE
[ENGAGE-1216] - Fix switching projects when opening a new tab

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -83,7 +83,7 @@ export default {
       immediate: true,
       handler(newAppProject) {
         if (newAppProject && this.appToken) {
-          this.restoreLocalStorageUserStatus();
+          this.restoreSessionStorageUserStatus();
           this.getUserStatus();
           this.loadQuickMessages();
           this.loadQuickMessagesShared();
@@ -114,10 +114,10 @@ export default {
     ...mapActions(useQuickMessageShared, {
       getAllQuickMessagesShared: 'getAll',
     }),
-    restoreLocalStorageUserStatus() {
-      const userStatus = localStorage.getItem('statusAgent');
+    restoreSessionStorageUserStatus() {
+      const userStatus = sessionStorage.getItem('statusAgent');
       if (!['OFFLINE', 'ONLINE'].includes(userStatus)) {
-        localStorage.setItem('statusAgent', 'OFFLINE');
+        sessionStorage.setItem('statusAgent', 'OFFLINE');
       }
       this.setStatus(userStatus);
     },
@@ -179,10 +179,10 @@ export default {
 
     async onboarding() {
       const onboarded =
-        localStorage.getItem('CHATS_USER_ONBOARDED') ||
+        sessionStorage.getItem('CHATS_USER_ONBOARDED') ||
         (await Profile.onboarded());
       if (onboarded) {
-        localStorage.setItem('CHATS_USER_ONBOARDED', true);
+        sessionStorage.setItem('CHATS_USER_ONBOARDED', true);
         return;
       }
 
@@ -190,7 +190,7 @@ export default {
     },
 
     async getUserStatus() {
-      const userStatus = localStorage.getItem('statusAgent');
+      const userStatus = sessionStorage.getItem('statusAgent');
       const projectUuid = this.project.uuid;
       const {
         data: { connection_status: responseStatus },
@@ -214,7 +214,7 @@ export default {
         status,
       });
       useConfig().$patch({ status: connection_status });
-      localStorage.setItem('statusAgent', connection_status);
+      sessionStorage.setItem('statusAgent', connection_status);
     },
 
     async wsConnect() {

--- a/src/components/PreferencesBar.vue
+++ b/src/components/PreferencesBar.vue
@@ -115,7 +115,7 @@ export default {
       open: false,
       loadingStatus: false,
       sound: false,
-      statusAgent: localStorage.getItem('statusAgent'),
+      statusAgent: sessionStorage.getItem('statusAgent'),
     };
   },
 
@@ -133,7 +133,7 @@ export default {
 
   async created() {
     await this.handlingGetStatus();
-    this.sound = (localStorage.getItem(PREFERENCES_SOUND) || 'yes') === 'yes';
+    this.sound = (sessionStorage.getItem(PREFERENCES_SOUND) || 'yes') === 'yes';
     window.dispatchEvent(
       new CustomEvent(`${this.help ? 'show' : 'hide'}BottomRightOptions`),
     );
@@ -162,7 +162,7 @@ export default {
         status: online ? 'ONLINE' : 'OFFLINE',
       });
 
-      localStorage.setItem('statusAgent', connection_status);
+      sessionStorage.setItem('statusAgent', connection_status);
 
       this.loadingStatus = false;
       this.showStatusAlert(connection_status.toLowerCase());
@@ -176,7 +176,7 @@ export default {
     },
 
     changeSound() {
-      localStorage.setItem(PREFERENCES_SOUND, this.sound ? 'yes' : 'no');
+      sessionStorage.setItem(PREFERENCES_SOUND, this.sound ? 'yes' : 'no');
     },
 
     showStatusAlert(connectionStatus) {

--- a/src/components/chats/Mobile/ModalPreferences.vue
+++ b/src/components/chats/Mobile/ModalPreferences.vue
@@ -72,7 +72,7 @@ export default {
     this.getStatus();
 
     this.configStatus = this.storeStatus === 'ONLINE';
-    this.configSound = localStorage.getItem(PREFERENCES_SOUND) === 'yes';
+    this.configSound = sessionStorage.getItem(PREFERENCES_SOUND) === 'yes';
   },
 
   computed: {
@@ -101,7 +101,7 @@ export default {
     },
 
     updateSound() {
-      localStorage.setItem(PREFERENCES_SOUND, this.configSound ? 'yes' : 'no');
+      sessionStorage.setItem(PREFERENCES_SOUND, this.configSound ? 'yes' : 'no');
     },
 
     async updateStatus(status) {

--- a/src/services/api/websocket/listeners/status/update.js
+++ b/src/services/api/websocket/listeners/status/update.js
@@ -1,16 +1,16 @@
 import { useConfig } from '@/store/modules/config';
 
 export default (content, { app }) => {
-  const localStorageStatus = localStorage.getItem('statusAgent');
+  const sessionStorageStatus = sessionStorage.getItem('statusAgent');
   const { from, status } = content;
 
-  if (localStorageStatus !== status) {
+  if (sessionStorageStatus !== status) {
     if (from === 'system') {
-      app.updateStatus(localStorageStatus);
+      app.updateStatus(sessionStorageStatus);
     } else if (from === 'user') {
       const configStore = useConfig();
       configStore.setStatus(status);
-      localStorage.setItem('statusAgent', status);
+      sessionStorage.setItem('statusAgent', status);
     }
   }
 };

--- a/src/services/api/websocket/setup.js
+++ b/src/services/api/websocket/setup.js
@@ -62,7 +62,7 @@ export default class WebSocketSetup {
     this.ws.ws.close();
     this.connect();
 
-    const localStorageStatus = localStorage.getItem('statusAgent');
-    this.app.updateUserStatus(localStorageStatus);
+    const sessionStorageStatus = sessionStorage.getItem('statusAgent');
+    this.app.updateUserStatus(sessionStorageStatus);
   }
 }

--- a/src/services/api/websocket/soundNotification.js
+++ b/src/services/api/websocket/soundNotification.js
@@ -11,7 +11,7 @@ export default class SoundNotification {
   }
 
   notify() {
-    const soundPreference = localStorage.getItem(PREFERENCES_SOUND);
+    const soundPreference = sessionStorage.getItem(PREFERENCES_SOUND);
     if (soundPreference === 'no') {
       return;
     }

--- a/src/services/keycloak.js
+++ b/src/services/keycloak.js
@@ -8,7 +8,7 @@ const keycloak = new Keycloak({
 });
 
 keycloak.logout = () => {
-  localStorage.removeItem('keycloak:user');
+  sessionStorage.removeItem('keycloak:user');
   window.location.replace(
     `${keycloak.createLogoutUrl()}&client_id=${encodeURIComponent(
       getEnv('KEYCLOAK_CLIENT_ID'),
@@ -41,7 +41,7 @@ export default {
     let savedKeycloakUser = {};
 
     try {
-      savedKeycloakUser = JSON.parse(localStorage.getItem('keycloak:user'));
+      savedKeycloakUser = JSON.parse(sessionStorage.getItem('keycloak:user'));
     } catch (error) {
       console.log(error);
     }
@@ -55,7 +55,7 @@ export default {
       ...toInsert,
     });
 
-    localStorage.setItem('keycloak:user', JSON.stringify(keycloak));
+    sessionStorage.setItem('keycloak:user', JSON.stringify(keycloak));
 
     hasInitialized = true;
 

--- a/src/store/modules/config.js
+++ b/src/store/modules/config.js
@@ -1,9 +1,9 @@
 import { defineStore } from 'pinia';
 
 import {
-  setToken as setLocalToken,
-  setProject as setLocalProjectUuid,
-  setStatus as setLocalStatus,
+  setToken as setSessionToken,
+  setProject as setSessionProjectUuid,
+  setStatus as setSessionStatus,
 } from '@/utils/config';
 
 import Profile from '@/services/api/resources/profile';
@@ -21,11 +21,11 @@ export const useConfig = defineStore('config', {
   }),
   actions: {
     async setToken(token) {
-      setLocalToken(token);
+      setSessionToken(token);
       this.token = token;
     },
     async setProjectUuid(projectUuid) {
-      setLocalProjectUuid(projectUuid);
+      setSessionProjectUuid(projectUuid);
       this.project.uuid = projectUuid;
     },
     async setProject(project) {
@@ -56,7 +56,7 @@ export const useConfig = defineStore('config', {
       });
       const newStatus = data.connection_status || 'OFFLINE';
       this.status = newStatus;
-      setLocalStatus(newStatus);
+      setSessionStatus(newStatus);
     },
     setCopilotActive(active) {
       this.copilot.active = active;

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -3,23 +3,23 @@ const PROJECT_ITEM_LOCAL_STORAGE = 'WENICHATS_PROJECT_UUID';
 const STATUS_AGENT = 'statusAgent';
 
 export function getToken() {
-  const token = localStorage.getItem(TOKEN_ITEM_LOCAL_STORAGE) || '';
+  const token = sessionStorage.getItem(TOKEN_ITEM_LOCAL_STORAGE) || '';
   return token;
 }
 
 export async function setToken(token) {
-  localStorage.setItem(TOKEN_ITEM_LOCAL_STORAGE, token);
+  sessionStorage.setItem(TOKEN_ITEM_LOCAL_STORAGE, token);
 }
 
 export function getProject() {
-  const project = localStorage.getItem(PROJECT_ITEM_LOCAL_STORAGE) || '';
+  const project = sessionStorage.getItem(PROJECT_ITEM_LOCAL_STORAGE) || '';
   return project;
 }
 
 export async function setProject(projectUuid) {
-  localStorage.setItem(PROJECT_ITEM_LOCAL_STORAGE, projectUuid);
+  sessionStorage.setItem(PROJECT_ITEM_LOCAL_STORAGE, projectUuid);
 }
 
 export async function setStatus(status) {
-  localStorage.setItem(STATUS_AGENT, status);
+  sessionStorage.setItem(STATUS_AGENT, status);
 }

--- a/src/utils/nilo.js
+++ b/src/utils/nilo.js
@@ -20,7 +20,7 @@ function setNiloDisplay(value) {
     l.async = true;
     h.parentNode.insertBefore(l, k.nextSibling);
     l.onload = () => {
-      if ((localStorage.getItem(PREFERENCES_NILO) || 'yes') === 'no') {
+      if ((sessionStorage.getItem(PREFERENCES_NILO) || 'yes') === 'no') {
         setNiloDisplay('none');
       }
     };

--- a/src/views/onboarding/Agent.vue
+++ b/src/views/onboarding/Agent.vue
@@ -164,7 +164,7 @@ export default {
       }
     },
     async close() {
-      localStorage.setItem('CHATS_USER_ONBOARDED', true);
+      sessionStorage.setItem('CHATS_USER_ONBOARDED', true);
       await Profile.onboard();
       this.$router.push({ name: 'home' });
     },


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Users could not use two applications at the same time because when they opened a new application, the old one took the project and the token from the new one, due to storage sharing because we used localStorage logic.

### Summary of Changes
Changed all localStorage code to sessionStorage, which keeps the storage divided between tabs.

