### PR TITLE
[ENGAGE-1270] - Fix opening history in new tab

### DIFF
--- a/src/components/PreferencesBar.vue
+++ b/src/components/PreferencesBar.vue
@@ -134,7 +134,7 @@ export default {
 
   async created() {
     await this.handlingGetStatus();
-    this.sound = (sessionStorage.getItem(PREFERENCES_SOUND) || 'yes') === 'yes';
+    this.sound = (localStorage.getItem(PREFERENCES_SOUND) || 'yes') === 'yes';
     window.dispatchEvent(
       new CustomEvent(`${this.help ? 'show' : 'hide'}BottomRightOptions`),
     );
@@ -177,7 +177,7 @@ export default {
     },
 
     changeSound() {
-      sessionStorage.setItem(PREFERENCES_SOUND, this.sound ? 'yes' : 'no');
+      localStorage.setItem(PREFERENCES_SOUND, this.sound ? 'yes' : 'no');
     },
 
     showStatusAlert(connectionStatus) {

--- a/src/components/chats/Mobile/ModalPreferences.vue
+++ b/src/components/chats/Mobile/ModalPreferences.vue
@@ -79,7 +79,7 @@ export default {
     this.getStatus();
 
     this.configStatus = this.storeStatus === 'ONLINE';
-    this.configSound = sessionStorage.getItem(PREFERENCES_SOUND) === 'yes';
+    this.configSound = localStorage.getItem(PREFERENCES_SOUND) === 'yes';
   },
 
   methods: {
@@ -102,7 +102,7 @@ export default {
     },
 
     updateSound() {
-      sessionStorage.setItem(PREFERENCES_SOUND, this.configSound ? 'yes' : 'no');
+      localStorage.setItem(PREFERENCES_SOUND, this.configSound ? 'yes' : 'no');
     },
 
     async updateStatus(status) {

--- a/src/services/api/websocket/soundNotification.js
+++ b/src/services/api/websocket/soundNotification.js
@@ -11,7 +11,7 @@ export default class SoundNotification {
   }
 
   notify() {
-    const soundPreference = sessionStorage.getItem(PREFERENCES_SOUND);
+    const soundPreference = localStorage.getItem(PREFERENCES_SOUND);
     if (soundPreference === 'no') {
       return;
     }

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -3,21 +3,29 @@ const PROJECT_ITEM_LOCAL_STORAGE = 'WENICHATS_PROJECT_UUID';
 const STATUS_AGENT = 'statusAgent';
 
 export function getToken() {
-  const token = sessionStorage.getItem(TOKEN_ITEM_LOCAL_STORAGE) || '';
+  const token =
+    sessionStorage.getItem(TOKEN_ITEM_LOCAL_STORAGE) ||
+    localStorage.getItem(TOKEN_ITEM_LOCAL_STORAGE) ||
+    '';
   return token;
 }
 
 export async function setToken(token) {
   sessionStorage.setItem(TOKEN_ITEM_LOCAL_STORAGE, token);
+  localStorage.setItem(TOKEN_ITEM_LOCAL_STORAGE, token);
 }
 
 export function getProject() {
-  const project = sessionStorage.getItem(PROJECT_ITEM_LOCAL_STORAGE) || '';
+  const project =
+    sessionStorage.getItem(PROJECT_ITEM_LOCAL_STORAGE) ||
+    localStorage.getItem(PROJECT_ITEM_LOCAL_STORAGE) ||
+    '';
   return project;
 }
 
 export async function setProject(projectUuid) {
   sessionStorage.setItem(PROJECT_ITEM_LOCAL_STORAGE, projectUuid);
+  localStorage.setItem(PROJECT_ITEM_LOCAL_STORAGE, projectUuid);
 }
 
 export async function setStatus(status) {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
With the project changing to sessionStorage, when opening the history in a new tab, the user was unable to make requests because sessionStorage handles data by tab.

### Summary of Changes
- Used localStorage again for the project, but as an alternative to sessionStorage;
- `PREFERENCES_SOUND` has also been turned to localStorage for a better user experience.
