### PR TITLE
[ENGAGE-1273] - Hotfix loading bar and send button without visible file

### DIFF
--- a/src/components/chats/MessageManager/index.vue
+++ b/src/components/chats/MessageManager/index.vue
@@ -171,8 +171,10 @@ export default {
       default: '',
     },
     loadingFileValue: {
-      type: Number,
-      default: 0,
+      validator: (value) => {
+        return value === null || typeof value === 'number';
+      },
+      default: null,
     },
     showSkeletonLoading: {
       type: Boolean,


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Users were unable to see the send files and audio buttons.

### Summary of Changes
- Changed the default data for prop loadingFileValue to null;
- Added validator for loadingFileValue prop.
