### PR TITLE
[ENGAGE-1244] - Transfer rooms disclaimers

### DIFF
--- a/src/components/chats/__tests__/RoomsTransferFields.spec.js
+++ b/src/components/chats/__tests__/RoomsTransferFields.spec.js
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
-
 import { mount } from '@vue/test-utils';
 import { createTestingPinia } from '@pinia/testing';
+
 import UnnnicSystem from '@/plugins/UnnnicSystem';
 import i18n from '@/plugins/i18n';
+
+import QueueService from '@/services/api/resources/settings/queue';
 
 import RoomsTransferFields from '../RoomsTransferFields.vue';
 
@@ -100,6 +102,51 @@ describe('RoomsTransferField', () => {
 
       await wrapper.vm.$nextTick();
       expect(agentSelect.props('disabled')).toBe(true);
+    });
+
+    it('should show a disclaimer if no agent is found', async () => {
+      vi.mocked(QueueService.agentsToTransfer).mockImplementationOnce(() => []);
+
+      await wrapper.setProps({
+        modelValue: [{ value: 'queue_id', label: 'Queue' }],
+      });
+
+      const transferDisclaimer = wrapper.findComponent(
+        '[data-testid="transfer-disclaimer"]',
+      );
+
+      expect(transferDisclaimer.exists()).toBe(true);
+    });
+
+    it('should show a disclaimer if agent selected is offline', async () => {
+      vi.mocked(QueueService.agentsToTransfer).mockImplementationOnce(() => [
+        {
+          first_name: 'John',
+          last_name: 'Doe',
+          email: 'john@doe.com',
+          status: 'offline',
+        },
+      ]);
+
+      await wrapper.setProps({
+        modelValue: [{ value: 'queue_id', label: 'Queue' }],
+      });
+      await wrapper.setData({
+        selectedAgent: [
+          {
+            first_name: 'John',
+            last_name: 'Doe',
+            email: 'john@doe.com',
+            status: 'offline',
+          },
+        ],
+      });
+
+      const transferDisclaimer = wrapper.findComponent(
+        '[data-testid="transfer-disclaimer"]',
+      );
+
+      expect(transferDisclaimer.exists()).toBe(true);
     });
   });
 

--- a/src/components/chats/__tests__/RoomsTransferFields.spec.js
+++ b/src/components/chats/__tests__/RoomsTransferFields.spec.js
@@ -111,6 +111,8 @@ describe('RoomsTransferField', () => {
         modelValue: [{ value: 'queue_id', label: 'Queue' }],
       });
 
+      await wrapper.vm.$nextTick();
+
       const transferDisclaimer = wrapper.findComponent(
         '[data-testid="transfer-disclaimer"]',
       );
@@ -133,12 +135,7 @@ describe('RoomsTransferField', () => {
       });
       await wrapper.setData({
         selectedAgent: [
-          {
-            first_name: 'John',
-            last_name: 'Doe',
-            email: 'john@doe.com',
-            status: 'offline',
-          },
+          { label: 'John Doe', value: 'john@doe.com', status: 'offline' },
         ],
       });
 

--- a/src/locales/translations.json
+++ b/src/locales/translations.json
@@ -1084,6 +1084,18 @@
       "pt-br": "Não foi possível transferir os contatos, tente novamente",
       "en": "It was not possible to transfer the contacts, try again",
       "es": "No fue posible transferir los contactos, intente nuevamente"
+    },
+    "disclaimer": {
+      "selected_agent_offline": {
+        "pt-br": "O agente selecionado está offline no momento",
+        "en": "The selected agent is offline at the moment",
+        "es": "El agente seleccionado está actualmente desconectado"
+      },
+      "without_online_agents": {
+        "pt-br": "Nenhum agente online no momento",
+        "en": "No online agent at the moment",
+        "es": "No hay agentes en línea en este momento"
+      }
     }
   },
   "contact_info": {
@@ -1949,7 +1961,7 @@
         "switch_inactive": {
           "pt-br": "Permitir transferências para agentes offline",
           "en": "Allow transfers to offline agents",
-          "es": "Permitir transferencias a agentes offline"
+          "es": "Permitir transferencias a agentes fuera de línea"
         }
       }
     },

--- a/src/locales/translations.json
+++ b/src/locales/translations.json
@@ -1939,6 +1939,18 @@
           "en": "Queue selection by agents inactive",
           "es": "Selección de cola por agentes inactivo"
         }
+      },
+      "block_transfer_to_off_agents": {
+        "switch_active": {
+          "pt-br": "Bloquear transferências para agentes offline",
+          "en": "Block transfers to offline agents",
+          "es": "Bloquear transferencias a agentes offline"
+        },
+        "switch_inactive": {
+          "pt-br": "Permitir transferências para agentes offline",
+          "en": "Allow transfers to offline agents",
+          "es": "Permitir transferencias a agentes offline"
+        }
       }
     },
     "new_sector": {

--- a/src/views/Settings/index.vue
+++ b/src/views/Settings/index.vue
@@ -53,6 +53,12 @@
           />
         </UnnnicToolTip>
       </section>
+      <section class="project-configs__config">
+        <UnnnicSwitch
+          v-model="projectConfig.filter_offline_agents"
+          :textRight="configBlockTransferToOffAgentsTranslation"
+        />
+      </section>
     </section>
 
     <section class="sectors">
@@ -123,6 +129,7 @@ export default {
     projectConfig: {
       can_use_bulk_transfer: false,
       can_use_queue_prioritization: false,
+      filter_offline_agents: false,
     },
   }),
 
@@ -143,6 +150,14 @@ export default {
       return this.$t(
         `config_chats.project_configs.queue_prioritization.switch_${
           canQueuePrioritization ? 'active' : 'inactive'
+        }`,
+      );
+    },
+    configBlockTransferToOffAgentsTranslation() {
+      const canBulkTransfer = this.projectConfig.filter_offline_agents;
+      return this.$t(
+        `config_chats.project_configs.block_transfer_to_off_agents.switch_${
+          canBulkTransfer ? 'active' : 'inactive'
         }`,
       );
     },
@@ -182,11 +197,15 @@ export default {
     },
 
     async updateProjectConfig() {
-      const { can_use_bulk_transfer, can_use_queue_prioritization } =
-        this.projectConfig;
+      const {
+        can_use_bulk_transfer,
+        can_use_queue_prioritization,
+        filter_offline_agents,
+      } = this.projectConfig;
       Project.update({
         can_use_bulk_transfer,
         can_use_queue_prioritization,
+        filter_offline_agents,
       });
     },
 


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
Managers needed a feature to block the transfer of rooms to offline users. With the opportunity, we also added the disclaimer to notify when the transfer is allowed, informing that the user is offline.

### Summary of Changes
- Added tests to verify this at RoomsTransferFields.spec.js;
- Added disclaimer to inform if no contact is online or to inform that the user selected for the transfer is offline;
- Added config at project to enable and disable this feature.

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Transfer rooms disclaimers and config to block transfers to offline agents](https://www.figma.com/design/acYQeQACRxh3bXmniwYbwI/Bloquear-transfer%C3%AAncia-para-agente-offline?node-id=2-3132&t=mN1k5j19U7dY3hPG-0)

### Demonstration <!--- (If not appropriate, remove this topic) -->
https://github.com/user-attachments/assets/d2ca4266-44fa-430a-824a-c2ee9598938e

