### PR TITLE
[ENGAGE-1244] - Fix of text in the transfer blocking configuration for offline agents

### DIFF
--- a/src/locales/translations.json
+++ b/src/locales/translations.json
@@ -1954,14 +1954,14 @@
       },
       "block_transfer_to_off_agents": {
         "switch_active": {
-          "pt-br": "Bloquear transferências para agentes offline",
-          "en": "Block transfers to offline agents",
-          "es": "Bloquear transferencias a agentes offline"
+          "pt-br": "Bloqueio de transferências para agentes offline ativo",
+          "en": "Blocking transfers to offline agents active",
+          "es": "Bloqueo de transferencias a agentes fuera de línea activo"
         },
         "switch_inactive": {
-          "pt-br": "Permitir transferências para agentes offline",
-          "en": "Allow transfers to offline agents",
-          "es": "Permitir transferencias a agentes fuera de línea"
+          "pt-br": "Bloqueio de transferências para agentes offline inativo",
+          "en": "Blocking transfers to offline agents inactive",
+          "es": "Bloqueo de transferencias a agentes fuera de línea inactivo"
         }
       }
     },


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [x] Other

### Motivation and Context
Users were confused about whether the blocking setting for offline agents was active or inactive.

### Summary of Changes
- Replaced translation block transfer to offline agents.

### Demonstration <!--- (If not appropriate, remove this topic) -->
![image](https://github.com/user-attachments/assets/a6af07de-af62-41ea-977e-530506b8e97a)
