### PR TITLE
[ENGAGE-1260] - Fix RoomsTable columns size

### DIFF
--- a/src/views/chats/ClosedChats/RoomsTable.vue
+++ b/src/views/chats/ClosedChats/RoomsTable.vue
@@ -310,6 +310,13 @@ export default {
     &__table {
       overflow: hidden;
 
+      :deep(.table-row) {
+        $rowSpacing: $unnnic-spacing-lg;
+
+        display: grid;
+        grid-template-columns: 1fr $rowSpacing 0.5fr $rowSpacing 0.8fr $rowSpacing 0.4fr $rowSpacing 0.3fr;
+      }
+
       &__no-results {
         color: $unnnic-color-neutral-cloudy;
         font-size: $unnnic-font-size-body-gt;


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [x] Other

### Motivation and Context
Users needed an IU improvement where they could not see the full name of contact in the history of this column in the table.

### Summary of Changes
- Changed to `display: grid` Table Row Stylization, separating the columns to improve the IU.

### Demonstration <!--- (If not appropriate, remove this topic) -->
![image](https://github.com/user-attachments/assets/53c403ff-d05f-46cd-af32-67471d6cc869)
