### PR TITLE
[ENGAGE-1373] - Fix keycloak redirect at desktop devices

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,4 +1,5 @@
 import { createRouter, createWebHistory } from 'vue-router';
+import isMobile from 'is-mobile';
 
 import { getProject, getToken } from '@/utils/config';
 import Keycloak from '@/services/keycloak';
@@ -18,8 +19,14 @@ const router = createRouter({
 afterEachMiddlewares.forEach((middleware) => router.afterEach(middleware));
 
 router.beforeEach(async (to, from, next) => {
+  if (!isMobile()) {
+    next();
+    return;
+  }
+
   const configStore = useConfig();
   const authenticated = await Keycloak.isAuthenticated();
+
   if (authenticated) {
     const { token } = Keycloak.keycloak;
     await configStore.setToken(token);


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
When the user token expired with chats being used as an iframe in connect, the module redirected to keycloak, which cannot be used within an iframe, thus generating an error when loading the module in connect.

### Summary of Changes
- Added validation to only call keycloak routes if is mobile.