### PR TITLE
[ENGAGE-1578] - Add sort to prevent out of order messages

### DIFF
--- a/src/utils/messages.js
+++ b/src/utils/messages.js
@@ -362,6 +362,7 @@ export function groupMessages(messagesReference, { message, addBefore }) {
   }
 
   const currentDateEntry = messagesReference[dateIndex];
+
   let minuteIndex = currentDateEntry.minutes.findIndex(
     (obj) => obj.minute === messageMinute,
   );
@@ -382,5 +383,11 @@ export function groupMessages(messagesReference, { message, addBefore }) {
 
   currentMinuteEntry.messages = removeDuplicatedMessagesByUuid(
     currentMinuteEntry.messages,
+  );
+
+  currentDateEntry.minutes.sort((a, b) => a.minute - b.minute);
+
+  currentMinuteEntry.messages.sort(
+    (a, b) => moment(a.created_on).unix() - moment(b.created_on).unix(),
   );
 }


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Some out-of-order messages were reported in chats. And this PR adds an ordering after the addition of each new message to prevent this case

### Summary of Changes
<!--- Describe your changes in detail -->
- Added sorting algorithm to prevent messages from being inserted out of their actual order