### PR TITLE
[ENGAGE-2005] - Fix broken case response data undefined in search contact list

### DIFF
--- a/src/layouts/ChatsLayout/components/FlowsTrigger/index.vue
+++ b/src/layouts/ChatsLayout/components/FlowsTrigger/index.vue
@@ -423,20 +423,19 @@ export default {
         this.isContactsLoading = true;
         try {
           const response = await FlowsAPI.getContacts(this.searchUrn);
+
           // Array filter to prevent 'null' or 'undefined' values in contact response
           this.listOfContacts = this.listOfContacts
-            .concat(response.data.results || [])
+            .concat(response.data?.results || [])
             .filter((contact) => contact);
+
           this.hasNext = response.next;
 
           this.listOfContacts.sort((a, b) => a.name?.localeCompare(b.name));
-
-          if (response.status !== 'canceled') {
-            this.isContactsLoading = false;
-          }
         } catch (error) {
-          this.isContactsLoading = false;
           console.log(error);
+        } finally {
+          this.isContactsLoading = false;
         }
       }
     },


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When searching in a sequence of contacts to trigger a flow, some requests are canceled but end up continuing the flow after the call and causing an error in the method due to the lack of the 'results' key in its data.

### Summary of Changes
<!--- Describe your changes in detail -->
- Prevent broken case if data not exist