### PR TITLE
Disable http method if not GET in nginx

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,6 +32,7 @@ ARG OLD_IMAGE=${OLD_IMAGE}
 ARG KEEP_DAYS=${KEEP_DAYS}
 
 COPY --chown=nginx:nginx docker/nginx/nginx.conf /etc/nginx/nginx.conf
+COPY --chown=nginx:nginx docker/nginx/headers /usr/share/nginx/html/headers
 COPY --from=builder --chown=nginx:nginx /app/dist /usr/share/nginx/html/chats/
 COPY --from=old_css --chown=nginx:nginx /usr/share/nginx/html/chats/assets/*.css /usr/share/nginx/html/chats/assets/
 #COPY --from=old_css --chown=nginx:nginx /tmp/old_css/*.css /usr/share/nginx/html/chats/assets/

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -38,16 +38,25 @@ http {
     server_tokens               off;
 
     location / {
+      limit_except GET {
+        deny  all;
+      }
       expires                   1s;
       try_files $uri $uri/ /index.html;
     }
 
     location ~ ^/static {
+      limit_except GET {
+        deny  all;
+      }
       expires                 365d;
     }
 
     error_page                  500 502 503 504 /50x.html;
     location = /50x.html {
+      limit_except GET {
+        deny  all;
+      }
       root                      /var/lib/nginx/html;
     }
   }


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context

Disable http method if not GET in nginx, as requested by compliance.

### Summary of Changes

Modify the nginx config file to limit_except to deny all requests to respond 403 to all requests made by non GET method.
