### PR TITLE
[ENGAGE-2206] - Fix wrong project name in chats dashboard and history

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -21,9 +21,10 @@ import { useRooms } from './store/modules/chats/rooms';
 import { useDashboard } from './store/modules/dashboard';
 
 import initHotjar from '@/plugins/Hotjar';
-import { getProject } from '@/utils/config';
-
-import { setProject as setProjectLocalStorage } from '@/utils/config';
+import {
+  getProject,
+  setProject as setProjectLocalStorage,
+} from '@/utils/config';
 
 import moment from 'moment';
 export default {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Due to an asynchronism problem, in some cases of changing projects, when accessing the dashboard or chat history, the name of the previously accessed project happened to be displayed instead of the current one viewed.

### Summary of Changes
<!--- Describe your changes in detail -->
- Fixed problem with incorrect display of the project name on the dashboard and chat history