### PR TITLE
[ENGAGE-2304] - Add auto open room logic in view mode

### DIFF
--- a/src/views/Dashboard/ViewMode/index.vue
+++ b/src/views/Dashboard/ViewMode/index.vue
@@ -111,7 +111,10 @@ export default {
   }),
 
   computed: {
-    ...mapState(useRooms, { room: (store) => store.activeRoom }),
+    ...mapState(useRooms, {
+      room: (store) => store.activeRoom,
+      rooms: (store) => store.rooms,
+    }),
     ...mapState(useDiscussions, {
       discussion: (store) => store.activeDiscussion,
     }),
@@ -131,6 +134,19 @@ export default {
           this.getViewedAgentData(this.$route.params.viewedAgent);
         } else {
           this.setViewedAgent({ name: '', email: '' });
+        }
+      },
+    },
+    rooms: {
+      once: true,
+      async handler() {
+        const { room_uuid } = this.$route.query;
+        if (room_uuid) {
+          const activeRoom = this.rooms.find((room) => room.uuid === room_uuid);
+
+          if (activeRoom) await this.setActiveRoom(activeRoom);
+
+          this.$router.replace({ query: {} });
         }
       },
     },


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allow managers to directly access a room via view mode

### Summary of Changes
<!--- Describe your changes in detail -->
- Added to make room active if the route query has room_uuid
