### PR TITLE
[ENGAGE-2483] - Fix i18n in media notifications

### DIFF
--- a/src/services/api/websocket/listeners/discussion/message/create.js
+++ b/src/services/api/websocket/listeners/discussion/message/create.js
@@ -28,11 +28,15 @@ export default (message, { app }) => {
 
     if (document.hidden) {
       const { first_name, last_name } = message.user;
-      sendWindowNotification({
-        title: `${first_name} ${last_name}`,
-        message: message.text,
-        image: message.media?.[0]?.url,
-      });
+      try {
+        sendWindowNotification({
+          title: `${first_name} ${last_name}`,
+          message: message.text,
+          image: message.media?.[0]?.url,
+        });
+      } catch (error) {
+        console.log(error);
+      }
     }
 
     const isCurrentDiscussion = activeDiscussion?.uuid === message.discussion;

--- a/src/services/api/websocket/listeners/room/message/create.js
+++ b/src/services/api/websocket/listeners/room/message/create.js
@@ -22,11 +22,15 @@ export default async (message, { app }) => {
     notification.notify();
 
     if (document.hidden) {
-      sendWindowNotification({
-        title: message.contact.name,
-        message: message.text,
-        image: message.media?.[0]?.url,
-      });
+      try {
+        sendWindowNotification({
+          title: message.contact.name,
+          message: message.text,
+          image: message.media?.[0]?.url,
+        });
+      } catch (error) {
+        console.log(error);
+      }
     }
 
     const isCurrentRoom =

--- a/src/utils/__tests__/notifications.spec.js
+++ b/src/utils/__tests__/notifications.spec.js
@@ -6,7 +6,7 @@ import isMobile from 'is-mobile';
 
 vi.mock('@/plugins/i18n', () => ({
   default: {
-    t: vi.fn((key) => key),
+    global: { t: vi.fn((key) => key) },
   },
 }));
 
@@ -98,7 +98,7 @@ describe('sendWindowNotification', () => {
       image: 'Test Image',
     });
 
-    expect(i18n.t).toHaveBeenCalledWith('media');
+    expect(i18n.global.t).toHaveBeenCalledWith('media');
     expect(iframessa.emit).toHaveBeenCalledWith('notification', [
       'Test Title',
       {

--- a/src/utils/notifications.js
+++ b/src/utils/notifications.js
@@ -14,7 +14,7 @@ export function sendWindowNotification({
     silent: true,
     badge: logo,
     icon: logo,
-    body: image ? `${i18n.t('media')}\n${message}` : message,
+    body: image ? `${i18n.global.t('media')}\n${message}` : message,
     tag: title,
   };
 


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When receiving media in the background, the message was not displayed when opening the chats screen due to a problem with the i18n call from chats

### Summary of Changes
<!--- Describe your changes in detail -->
- Fix i18n method
- Added trycatch to prevent the block from stopping execution in case of notification failure