### PR TITLE
[ENGAGE-2960] Add new toasts to status bar

### DIFF
--- a/src/components/__tests__/StatusBar.spec.js
+++ b/src/components/__tests__/StatusBar.spec.js
@@ -352,7 +352,89 @@ describe('StatusBar', () => {
   });
 
   describe('Status Alerts', () => {
-    it('should show status alert when changing status', async () => {
+    it('should show success alert when changing to online status', async () => {
+      wrapper = createWrapper();
+      await wrapper.vm.$nextTick();
+
+      const onlineStatus = { value: 'active', label: 'Online', color: 'green' };
+      wrapper.vm.showStatusAlert(onlineStatus, true);
+
+      expect(unnnic.unnnicCallAlert).toHaveBeenCalledWith({
+        props: {
+          text: 'Status updated to Online',
+          icon: 'indicator',
+          scheme: 'feedback-green',
+          closeText: 'Close',
+          position: 'bottom-right',
+        },
+        seconds: 15,
+      });
+    });
+
+    it('should show success alert when changing to offline status', async () => {
+      wrapper = createWrapper();
+      await wrapper.vm.$nextTick();
+
+      const offlineStatus = {
+        value: 'inactive',
+        label: 'Offline',
+        color: 'gray',
+      };
+      wrapper.vm.showStatusAlert(offlineStatus, true);
+
+      expect(unnnic.unnnicCallAlert).toHaveBeenCalledWith({
+        props: {
+          text: 'Status updated to Offline',
+          icon: 'indicator',
+          scheme: '$unnnic-color-neutral-black',
+          closeText: 'Close',
+          position: 'bottom-right',
+        },
+        seconds: 15,
+      });
+    });
+
+    it('should show success alert when changing to custom status', async () => {
+      wrapper = createWrapper();
+      await wrapper.vm.$nextTick();
+
+      const customStatus = { value: 'lunch', label: 'Lunch', color: 'brown' };
+      wrapper.vm.showStatusAlert(customStatus, true);
+
+      expect(unnnic.unnnicCallAlert).toHaveBeenCalledWith({
+        props: {
+          text: 'Status updated to Lunch',
+          icon: 'indicator',
+          scheme: 'feedback-green',
+          closeText: 'Close',
+          position: 'bottom-right',
+        },
+        seconds: 15,
+      });
+    });
+
+    it('should show error alert when status update fails', async () => {
+      wrapper = createWrapper();
+      await wrapper.vm.$nextTick();
+
+      const status = { value: 'active', label: 'Online', color: 'green' };
+      wrapper.vm.showStatusAlert(status, false);
+
+      expect(unnnic.unnnicCallAlert).toHaveBeenCalledWith({
+        props: {
+          text: 'Unable to update status, please try again.',
+          icon: 'indicator',
+          scheme: 'feedback-red',
+          closeText: 'Close',
+          position: 'bottom-right',
+        },
+        seconds: 15,
+      });
+    });
+
+    it('should show error alert when API request fails', async () => {
+      Profile.updateStatus.mockRejectedValueOnce(new Error('API Error'));
+
       wrapper = createWrapper();
       await wrapper.vm.$nextTick();
 
@@ -361,12 +443,37 @@ describe('StatusBar', () => {
 
       const items = wrapper.findAll('[data-testid="status-bar-item"]');
       await items[0].trigger('click');
+      await flushPromises();
 
       expect(unnnic.unnnicCallAlert).toHaveBeenCalledWith({
         props: {
-          text: 'You are online',
+          text: 'Unable to update status, please try again.',
           icon: 'indicator',
-          scheme: 'feedback-green',
+          scheme: 'feedback-red',
+          closeText: 'Close',
+          position: 'bottom-right',
+        },
+        seconds: 15,
+      });
+    });
+
+    it('should show error alert when custom status creation fails', async () => {
+      api.createCustomStatus.mockRejectedValueOnce(new Error('API Error'));
+
+      wrapper = createWrapper();
+      await wrapper.vm.fetchCustomStatuses();
+      wrapper.vm.toggleDropdown();
+      await wrapper.vm.$nextTick();
+
+      const items = wrapper.findAll('[data-testid="status-bar-item"]');
+      await items[2].trigger('click');
+      await flushPromises();
+
+      expect(unnnic.unnnicCallAlert).toHaveBeenCalledWith({
+        props: {
+          text: 'Unable to update status, please try again.',
+          icon: 'indicator',
+          scheme: 'feedback-red',
           closeText: 'Close',
           position: 'bottom-right',
         },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -4,6 +4,10 @@
     "offline": "Offline",
     "set_status": "Set status"
   },
+  "status-bar": {
+    "success": "Status updated to {status}",
+    "error": "Unable to update status, please try again."
+  },
   "view-option": "View Options",
   "preferences": {
     "title": "Preferences",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -4,6 +4,10 @@
     "offline": "Desconectada",
     "set_status": "Establecer estado"
   },
+  "status-bar": {
+    "success": "Estado actualizado a {status}",
+    "error": "No se puede actualizar el estado, por favor, inténtelo de nuevo"
+  },
   "view-option": "Opciones",
   "preferences": {
     "title": "Preferencias",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -4,6 +4,10 @@
     "offline": "Offline",
     "set_status": "Definir status"
   },
+  "status-bar": {
+    "success": "Status atualizado para {status}",
+    "error": "Não foi possível atualizar o seu status, por favor tente novamente"
+  },
   "view-option": "Opções", 
   "preferences": {
     "title": "Preferências",


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

- add new feedback alert to users

### Summary of Changes
<!--- Describe your changes in detail -->

- adjust status bar to use new alerts

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File 1](https://www.figma.com/design/q3ze1CoLGa8Att0fownmcj/Infracommerce?node-id=4827-777&m=dev)

### Demonstration <!--- (If not appropriate, remove this topic) -->
![image](https://github.com/user-attachments/assets/f9caeb01-8e0a-48b6-8890-5c9a04ee24ea)
