### PR TITLE
[ENGAGE-3058] - Remove save and cancel button and update tags on editing sector

### DIFF
--- a/src/components/settings/forms/__tests__/ExtraOptions.spec.js
+++ b/src/components/settings/forms/__tests__/ExtraOptions.spec.js
@@ -62,6 +62,7 @@ describe('SectorExtraOptions', () => {
   it('should render switches and switches title', async () => {
     await wrapper.setProps({ isEditing: true });
     const switchesTitle = wrapper.find('[data-testid="switchs-title"]');
+
     expect(switchesTitle.text()).toBe(
       wrapper.vm.$t('sector.additional_options.title'),
     );
@@ -81,11 +82,6 @@ describe('SectorExtraOptions', () => {
     expect(switchs[2].props().textRight).toContain(
       wrapper.vm.$t('sector.additional_options.edit_custom_fields'),
     );
-
-    const actions = wrapper.find(
-      '[data-testid="sector-extra-options-actions"]',
-    );
-    expect(actions.exists()).toBe(true);
   });
 
   it('should render tags section (without tags)', () => {
@@ -155,46 +151,12 @@ describe('SectorExtraOptions', () => {
     const tagGroup = wrapper.findComponent('[data-testid="sector-tag-group"]');
     tagGroup.vm.close(defaultTags[0]);
     expect(removeTagSpy).toHaveBeenCalledWith(defaultTags[0]);
-    expect(wrapper.vm.toRemoveTags[0].name).toBe('Financeiro');
 
     const toAddTagsNames = wrapper.vm.toAddTags.map((tag) => tag.name);
     const tagssNames = wrapper.vm.tags.map((tag) => tag.name);
 
     expect(toAddTagsNames.includes('Financeiro')).toBe(false);
     expect(tagssNames.includes('Financeiro')).toBe(false);
-  });
-
-  it('should save configs on click save button if isEditing is true', async () => {
-    const saveSpy = vi.spyOn(wrapper.vm, 'save');
-    const updateSectorTagsSpy = vi.spyOn(wrapper.vm, 'updateSectorTags');
-    const updateSectorExtraConfigsSpy = vi.spyOn(
-      wrapper.vm,
-      'updateSectorExtraConfigs',
-    );
-
-    await wrapper.setProps({
-      sector: { ...wrapper.vm.sector, can_trigger_flows: true },
-      isEditing: true,
-    });
-
-    await wrapper.setData({
-      currentTags: [{ uuid: 'remove', name: 'remove' }],
-      toAddTags: defaultTags,
-      tags: [...defaultTags, { uuid: 'remove', name: 'remove' }],
-      toRemoveTags: [{ uuid: 'remove', name: 'remove' }],
-    });
-
-    const saveButton = wrapper.findComponent('[data-testid="save-button"]');
-
-    await saveButton.trigger('click');
-    await flushPromises();
-    expect(saveSpy).toHaveBeenCalled();
-    expect(updateSectorExtraConfigsSpy).toHaveBeenCalled();
-    expect(updateSectorTagsSpy).toHaveBeenCalled();
-
-    saveSpy.mockClear();
-    updateSectorExtraConfigsSpy.mockClear();
-    updateSectorTagsSpy.mockClear();
   });
 
   it('should show alert on error in save configs', async () => {

--- a/src/components/settings/forms/__tests__/__snapshots__/ExtraOptions.spec.js.snap
+++ b/src/components/settings/forms/__tests__/__snapshots__/ExtraOptions.spec.js.snap
@@ -35,16 +35,5 @@ exports[`SectorExtraOptions > Should match the snapshot 1`] = `
     </section>
     <!--v-if-->
   </section>
-  <section data-v-85728205="" data-testid="sector-extra-options-actions" class="actions" style="display: none;"><button data-v-d127031e="" data-v-85728205="" class="unnnic-button unnnic-button--size-large unnnic-button--tertiary">
-      <!---->
-      <!---->
-      <!----><span data-v-d127031e="" class="unnnic-button__label" data-testid="button-label"> Cancel</span>
-      <!---->
-    </button><button data-v-d127031e="" data-v-85728205="" data-testid="save-button" class="unnnic-button unnnic-button--size-large unnnic-button--primary">
-      <!---->
-      <!---->
-      <!----><span data-v-d127031e="" class="unnnic-button__label" data-testid="button-label"> Save</span>
-      <!---->
-    </button></section>
 </section>"
 `;


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
to improve user experience, tags will be added or removed in their own actions, without the need to save in a separate button (previously at the bottom of the screen)

### Summary of Changes
<!--- Describe your changes in detail -->
- Remove save and cancel button from tags sector config page
- Add handling to add and remove tags along with actions performed on the input