### PR TITLE
[ENGAGE-4019] Prevent duplicate rooms from being added in the rooms store

### DIFF
--- a/src/store/modules/chats/rooms.js
+++ b/src/store/modules/chats/rooms.js
@@ -49,6 +49,10 @@ export const useRooms = defineStore('rooms', {
 
     addRoom(room) {
       if (room.uuid) {
+        const isRoomAlreadyInList = this.rooms.some(
+          (mappedRoom) => mappedRoom.uuid === room.uuid,
+        );
+        if (isRoomAlreadyInList) return;
         this.rooms.unshift({ ...room });
       }
     },


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The add room method had no check to prevent duplicate rooms

### Summary of Changes
<!--- Describe your changes in detail -->
- Add check if room already existed before adding to list