### PR TITLE
[ENGAGE-4207] - Set to always display sector filter in room history

### DIFF
--- a/src/views/chats/ClosedChats/RoomsTableFilters.vue
+++ b/src/views/chats/ClosedChats/RoomsTableFilters.vue
@@ -27,7 +27,6 @@
         />
       </div>
       <div
-        v-if="sectorsToFilter.length > 2"
         class="rooms-table-filters__input"
         data-testid="sector-filter"
       >
@@ -350,10 +349,6 @@ export default {
           newSectors.push({ value: uuid, label: name }),
         );
         this.sectorsToFilter = newSectors;
-
-        if (results.length === 1) {
-          this.filterSector = [newSectors[1]];
-        }
       } catch (error) {
         console.error('The sectors could not be loaded at this time.', error);
       }
@@ -404,9 +399,9 @@ export default {
       }
 
       this.filterContact = '';
-      if (this.sectorsToFilter.length > 2) {
-        this.filterSector = [this.filterSectorsOptionAll];
-      }
+
+      this.filterSector = [this.filterSectorsOptionAll];
+
       this.filterTag = [];
       this.filterDate = this.filterDateDefault;
       if (!this.isMobile && this.filterDate) {

--- a/src/views/chats/ClosedChats/__tests__/RoomsTableFilters.spec.js
+++ b/src/views/chats/ClosedChats/__tests__/RoomsTableFilters.spec.js
@@ -212,19 +212,6 @@ describe('RoomsTableFilters.vue', () => {
         label: 'Tag 1',
       });
     });
-
-    it('sets filterSector to first sector when only one sector exists', async () => {
-      Sector.list.mockResolvedValue({
-        results: [{ uuid: 'sector1', name: 'Sector 1' }],
-      });
-
-      wrapper = createWrapper();
-      await flushPromises();
-
-      expect(wrapper.vm.filterSector).toEqual([
-        { value: 'sector1', label: 'Sector 1' },
-      ]);
-    });
   });
 
   describe('Filter interaction tests', () => {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In order to view rooms in excluded sectors, this filter must be visible and selected as all

### Summary of Changes
<!--- Describe your changes in detail -->
- Set to always display sector filter in room history