### PR TITLE
[ENGAGE-4212] - Update message status handling in ChatMessages component and related services

### DIFF
--- a/src/components/chats/chat/ChatMessages/__tests__/ChatMessages.spec.js
+++ b/src/components/chats/chat/ChatMessages/__tests__/ChatMessages.spec.js
@@ -117,11 +117,6 @@ describe('ChatMessages', () => {
 
     // Mock store state
     dashboardStore.viewedAgent = { email: 'agent@example.com' };
-    roomMessagesStore.roomMessagesStatusMapper = {
-      sent: 'sent',
-      delivered: 'delivered',
-      read: 'read',
-    };
 
     wrapper = mount(ChatMessages, {
       props: defaultProps,

--- a/src/components/chats/chat/ChatMessages/index.vue
+++ b/src/components/chats/chat/ChatMessages/index.vue
@@ -344,7 +344,6 @@ export default {
 
   computed: {
     ...mapState(useDashboard, ['viewedAgent']),
-    ...mapState(useRoomMessages, ['roomMessagesStatusMapper']),
     ...mapWritableState(useRoomMessages, ['replyMessage']),
     medias() {
       return this.messages
@@ -432,12 +431,18 @@ export default {
         if (this.messagesSendingUuids.includes(message.uuid)) {
           return 'sending';
         }
+
         if (this.messagesFailedUuids.includes(message.uuid)) {
           return 'failed';
         }
 
-        if (message.status)
-          return this.roomMessagesStatusMapper[message.status] || 'default';
+        if (message.is_read) {
+          return 'read';
+        }
+
+        if (message.is_delivered) {
+          return 'received';
+        }
 
         if (media && this.isAudio(media)) {
           return 'default';

--- a/src/services/api/websocket/listeners/room/message/changeStatus.js
+++ b/src/services/api/websocket/listeners/room/message/changeStatus.js
@@ -2,15 +2,8 @@ import { useRoomMessages } from '@/store/modules/chats/roomMessages';
 
 export default async (message) => {
   const roomMessagesStore = useRoomMessages();
-
-  const findedMessage = roomMessagesStore.roomMessages.find(
-    ({ uuid }) => uuid === message.uuid,
-  );
-
-  if (findedMessage) {
-    roomMessagesStore.updateMessageStatus({
-      message: findedMessage,
-      status: message.status,
-    });
-  }
+  roomMessagesStore.updateMessageStatus({
+    messageUuid: message.uuid,
+    status: message.status,
+  });
 };

--- a/src/store/modules/chats/roomMessages.js
+++ b/src/store/modules/chats/roomMessages.js
@@ -26,10 +26,6 @@ export const useRoomMessages = defineStore('roomMessages', {
     roomMessagesFailedUuids: [],
     roomMessagesNext: '',
     roomMessagesPrevious: '',
-    roomMessagesStatusMapper: {
-      delivered: 'received',
-      read: 'read',
-    },
     replyMessage: null,
   }),
   actions: {
@@ -97,20 +93,24 @@ export const useRoomMessages = defineStore('roomMessages', {
       }
     },
 
-    updateMessageStatus({ message, status }) {
+    updateMessageStatus({ messageUuid, status }) {
       const findedMessage = this.roomMessages.find(
-        (mappedMessage) => mappedMessage.uuid === message.uuid,
+        (mappedMessage) => mappedMessage.uuid === messageUuid,
       );
 
-      if (findedMessage.status === 'read') return;
+      if (!findedMessage) return;
 
-      if (findedMessage) {
-        findedMessage.status = status;
-        updateMessageStatusInGroupedMessages(this.roomMessagesSorted, {
-          message,
-          status,
-        });
+      if (status === 'delivered') {
+        findedMessage.is_delivered = true;
       }
+
+      if (status === 'read') {
+        findedMessage.is_read = true;
+      }
+
+      updateMessageStatusInGroupedMessages(this.roomMessagesSorted, {
+        message: findedMessage,
+      });
     },
 
     updateMessage({

--- a/src/utils/messages.js
+++ b/src/utils/messages.js
@@ -401,7 +401,7 @@ export function groupMessages(messagesReference, { message, addBefore }) {
 
 export function updateMessageStatusInGroupedMessages(
   messagesReference,
-  { message, status },
+  { message },
 ) {
   const messageTimestamp = moment(message.created_on);
   const messageDate = messageTimestamp.format('L');
@@ -428,7 +428,13 @@ export function updateMessageStatusInGroupedMessages(
   const currentMinuteEntry = currentDateEntry.minutes[minuteIndex];
 
   currentMinuteEntry.messages = currentMinuteEntry.messages.map((obj) =>
-    obj.uuid === message.uuid ? { ...obj, status } : obj,
+    obj.uuid === message.uuid
+      ? {
+          ...obj,
+          is_read: message.is_read,
+          is_delivered: message.is_delivered,
+        }
+      : obj,
   );
 }
 


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Adjustment to support new message read status indication format and improvements

### Summary of Changes
<!--- Describe your changes in detail -->
- Removed roomMessagesStatusMapper from state management.
- Updated message status logic to use is_read and is_delivered flags.
- Simplified updateMessageStatus function to directly modify message properties.
- Adjusted tests to reflect changes in message status handling.