### PR TITLE
[ENGAGE-4558] Fixing incorrect display of rooms in view mode

### DIFF
--- a/src/layouts/ChatsLayout/components/TheCardGroups/index.vue
+++ b/src/layouts/ChatsLayout/components/TheCardGroups/index.vue
@@ -210,6 +210,7 @@ export default {
     };
   },
   computed: {
+    ...mapWritableState(useRooms, { allRooms: 'rooms' }),
     ...mapState(useRooms, {
       rooms_ongoing: 'agentRooms',
       rooms_queue: 'waitingQueue',
@@ -345,6 +346,7 @@ export default {
     },
   },
   async created() {
+    this.allRooms = [];
     await Promise.all([
       this.listRoom(true, this.orderBy.waiting, 'waiting'),
       this.listRoom(true, this.orderBy.ongoing, 'ongoing'),

--- a/src/views/Dashboard/ViewMode/index.vue
+++ b/src/views/Dashboard/ViewMode/index.vue
@@ -153,7 +153,7 @@ export default {
     rooms: {
       once: true,
       async handler() {
-        const { room_uuid } = this.$route.query;
+        const { room_uuid } = this.$route.query || {};
         if (room_uuid) {
           const activeRoom = this.rooms.find((room) => room.uuid === room_uuid);
 


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In some cases, when going to the manager's view mode, the agent's rooms could be mixed up with the manager's due to the lack of empty initialization of the room array.

### Summary of Changes
<!--- Describe your changes in detail -->
- Initialized allRooms to an empty array in the created lifecycle hook.
