### PR TITLE
feat: implement exponential backoff for WebSocket reconnections

### DIFF
--- a/src/services/api/websocket/setup.js
+++ b/src/services/api/websocket/setup.js
@@ -7,7 +7,7 @@ import { useRooms } from '@/store/modules/chats/rooms';
 import { useDiscussions } from '@/store/modules/chats/discussions';
 
 export default class WebSocketSetup {
-  FIVE_SECONDS = 5000;
+  THIRTY_SECONDS = 30000;
   BASE_RECONNECT_DELAY = 5000; // 5 seconds
   MAX_RECONNECT_DELAY = 60000; // 60 seconds
 
@@ -129,7 +129,7 @@ export default class WebSocketSetup {
 
     this.pingIntervalId = setInterval(() => {
       this.ping();
-    }, this.FIVE_SECONDS);
+    }, this.THIRTY_SECONDS);
   }
 
   clearPingInterval() {

--- a/src/services/api/websocket/setup.js
+++ b/src/services/api/websocket/setup.js
@@ -7,13 +7,15 @@ import { useRooms } from '@/store/modules/chats/rooms';
 import { useDiscussions } from '@/store/modules/chats/discussions';
 
 export default class WebSocketSetup {
-  THIRTY_SECONDS = 30000;
   FIVE_SECONDS = 5000;
+  BASE_RECONNECT_DELAY = 5000; // 5 seconds
+  MAX_RECONNECT_DELAY = 60000; // 60 seconds
 
   constructor({ app }) {
     this.app = app;
     this.pingIntervalId = null;
     this.isFirstReconnectAttempt = true;
+    this.reconnectAttempts = 0;
   }
 
   reloadRoomsAndDiscussions() {
@@ -50,6 +52,20 @@ export default class WebSocketSetup {
     });
   }
 
+  calculateReconnectDelay() {
+    // Exponential backoff: delay = baseDelay * (2 ^ attempts) + random jitter
+    const exponentialDelay =
+      this.BASE_RECONNECT_DELAY * Math.pow(2, this.reconnectAttempts);
+
+    // Add random jitter (0-1000ms) to prevent thundering herd
+    const jitter = Math.random() * 1000;
+
+    // Cap at maximum delay
+    const delay = Math.min(exponentialDelay + jitter, this.MAX_RECONNECT_DELAY);
+
+    return Math.floor(delay);
+  }
+
   buildUrl() {
     const dashboardStore = useDashboard();
     const { appToken, appProject } = this.app;
@@ -82,14 +98,26 @@ export default class WebSocketSetup {
         this.isFirstReconnectAttempt = false;
         this.reconnect();
       } else {
+        const delay = this.calculateReconnectDelay();
+        this.reconnectAttempts++;
+
+        console.warn(
+          timestamp,
+          `[WebSocket] Reconnect attempt ${this.reconnectAttempts}, waiting ${delay}ms...`,
+        );
+
         setTimeout(() => {
           this.reconnect();
-        }, this.FIVE_SECONDS);
+        }, delay);
       }
     };
 
     this.ws.ws.onopen = () => {
       this.isFirstReconnectAttempt = true;
+      this.reconnectAttempts = 0; // Reset attempts counter on successful connection
+
+      const timestamp = new Date().toISOString();
+      console.log(timestamp, '[WebSocket] Connection established successfully');
     };
 
     listeners({ ws, app: this.app });
@@ -101,7 +129,7 @@ export default class WebSocketSetup {
 
     this.pingIntervalId = setInterval(() => {
       this.ping();
-    }, this.THIRTY_SECONDS);
+    }, this.FIVE_SECONDS);
   }
 
   clearPingInterval() {
@@ -118,6 +146,8 @@ export default class WebSocketSetup {
         message: {},
       });
     } else {
+      // Reset first attempt flag so exponential backoff applies
+      this.isFirstReconnectAttempt = false;
       this.reconnect();
     }
   }


### PR DESCRIPTION
- Added a new method to calculate reconnect delay using exponential backoff with random jitter to improve connection stability.
- Introduced a maximum reconnect delay to prevent excessive wait times.
- Reset reconnect attempts counter upon successful connection to ensure proper delay calculation on subsequent failures.

## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
feat: implement exponential backoff for WebSocket reconnections

### Summary of Changes
<!--- Describe your changes in detail -->

adjst setup

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File 1](link_to_design_file_1)

### Demonstration <!--- (If not appropriate, remove this topic) -->
<!--- Include a screenshot or video showcasing a feature or fix implemented in this pull request. -->
