### PR TITLE
fix: comment out reloadRoomsAndDiscussions call in WebSocket setup

### DIFF
--- a/src/services/api/websocket/setup.js
+++ b/src/services/api/websocket/setup.js
@@ -159,7 +159,8 @@ export default class WebSocketSetup {
 
     this.connect();
 
-    this.reloadRoomsAndDiscussions();
+    // temporarily disabled to avoid reloading rooms and discussions
+    // this.reloadRoomsAndDiscussions();
 
     const sessionStorageStatus = sessionStorage.getItem(
       `statusAgent-${this.app.appProject}`,


### PR DESCRIPTION
- Temporarily disabled the reloadRoomsAndDiscussions method call to prevent unnecessary room and discussion reloads during WebSocket connection setup.
