### PR TITLE
[ENGAGE-4754] Limit socket connection attempts and room listing optimizations

### DIFF
--- a/src/components/settings/forms/__tests__/__snapshots__/ExtraOptions.spec.js.snap
+++ b/src/components/settings/forms/__tests__/__snapshots__/ExtraOptions.spec.js.snap
@@ -19,9 +19,9 @@ exports[`SectorExtraOptions > Should match the snapshot 1`] = `
         </svg><span data-v-8c61d974="" class="unnnic-tooltip-label unnnic-tooltip-label-right" style="max-width: 23rem; left: 8px; top: 0px;" data-testid="tooltip-label">Tags are used to classify service characteristics and make it possible to search and filter chats from them, define tags that are relevant to your context <br data-v-8c61d974=""><!----></span></div>
     </h2>
     <section data-v-85728205="" class="tags-form">
-      <div data-v-24f2d284="" data-v-85728205="" class="unnnic-form md tags-form__input" data-testid="tags-input-tag-name">
-        <p data-v-24f2d284="" class="unnnic-form__label">Tag name</p>
-        <div data-v-c1401a33="" data-v-24f2d284="" class="text-input size--md text-input--icon-right-size-sm tags-form__input unnnic-form-input" data-testid="tags-input-tag-name" mask=""><input data-v-0caa2ccb="" data-v-c1401a33="" class="tags-form__input unnnic-form-input input-itself input size-md normal tags-form__input unnnic-form-input input-itself" data-testid="tags-input-tag-name" placeholder="Example: Doubts" iconrightsize="sm" hascloudycolor="false" type="text" value="">
+      <div data-v-fefd47bc="" data-v-85728205="" class="unnnic-form md tags-form__input" data-testid="tags-input-tag-name">
+        <p data-v-fefd47bc="" class="unnnic-form__label">Tag name</p>
+        <div data-v-c1401a33="" data-v-fefd47bc="" class="text-input size--md text-input--icon-right-size-sm tags-form__input unnnic-form-input" data-testid="tags-input-tag-name" mask=""><input data-v-0caa2ccb="" data-v-c1401a33="" class="tags-form__input unnnic-form-input input-itself input size-md normal tags-form__input unnnic-form-input input-itself" data-testid="tags-input-tag-name" placeholder="Example: Doubts" iconrightsize="sm" hascloudycolor="false" type="text" value="">
           <!---->
           <!---->
         </div>

--- a/src/layouts/ChatsLayout/components/TheCardGroups/index.vue
+++ b/src/layouts/ChatsLayout/components/TheCardGroups/index.vue
@@ -198,7 +198,7 @@ export default {
         discussion: 0,
         search: 0,
       },
-      limit: 100,
+      limit: 30,
       nameOfContact: '',
       timerId: 0,
       showLoadingRooms: false,

--- a/src/layouts/ChatsLayout/components/TheCardGroups/tests/TheCardGroups.spec.js
+++ b/src/layouts/ChatsLayout/components/TheCardGroups/tests/TheCardGroups.spec.js
@@ -896,7 +896,7 @@ describe('TheCardGroups.vue', () => {
         offset: 0,
         concat: undefined,
         order: '-last_interaction',
-        limit: 100,
+        limit: 30,
         contact: '',
         viewedAgent: 'test-agent',
         roomsType: '',

--- a/src/services/api/websocket/setup.js
+++ b/src/services/api/websocket/setup.js
@@ -10,6 +10,7 @@ export default class WebSocketSetup {
   THIRTY_SECONDS = 30000;
   BASE_RECONNECT_DELAY = 5000; // 5 seconds
   MAX_RECONNECT_DELAY = 60000; // 60 seconds
+  MAX_RECONNECT_ATTEMPTS = 5;
 
   constructor({ app }) {
     this.app = app;
@@ -23,10 +24,12 @@ export default class WebSocketSetup {
     const discussionsStore = useDiscussions();
     const dashboardStore = useDashboard();
     const { viewedAgent } = dashboardStore;
+    const limit = 30;
+
     roomsStore.getAll({
       offset: 0,
       concat: true,
-      limit: 100,
+      limit,
       roomsType: 'ongoing',
       order: roomsStore.orderBy.ongoing,
       viewedAgent: viewedAgent?.email,
@@ -34,7 +37,7 @@ export default class WebSocketSetup {
     roomsStore.getAll({
       offset: 0,
       concat: true,
-      limit: 100,
+      limit,
       roomsType: 'waiting',
       order: roomsStore.orderBy.waiting,
       viewedAgent: viewedAgent?.email,
@@ -42,7 +45,7 @@ export default class WebSocketSetup {
     roomsStore.getAll({
       offset: 0,
       concat: true,
-      limit: 100,
+      limit,
       roomsType: 'flow_start',
       order: roomsStore.orderBy.flow_start,
       viewedAgent: viewedAgent?.email,
@@ -89,12 +92,12 @@ export default class WebSocketSetup {
       if (this.ws.ws.readyState === this.ws.ws.OPEN) return;
 
       const timestamp = new Date().toISOString();
-      console.warn(
-        timestamp,
-        '[WebSocket] Connection closed, attempting to reconnect...',
-      );
 
       if (this.isFirstReconnectAttempt) {
+        console.warn(
+          timestamp,
+          '[WebSocket] Connection closed, attempting to reconnect...',
+        );
         this.isFirstReconnectAttempt = false;
         this.reconnect();
       } else {
@@ -153,14 +156,20 @@ export default class WebSocketSetup {
   }
 
   reconnect() {
+    if (this.reconnectAttempts >= this.MAX_RECONNECT_ATTEMPTS) {
+      console.warn(
+        '[WebSocket] Max reconnect attempts reached, stopping reconnect attempts',
+      );
+      return;
+    }
+
     if (this.ws && this.ws.ws.readyState !== this.ws.ws.CLOSED) {
       this.ws.ws.close();
     }
 
     this.connect();
 
-    // temporarily disabled to avoid reloading rooms and discussions
-    // this.reloadRoomsAndDiscussions();
+    this.reloadRoomsAndDiscussions();
 
     const sessionStorageStatus = sessionStorage.getItem(
       `statusAgent-${this.app.appProject}`,

--- a/src/views/__tests__/__snapshots__/Settings.spec.js.snap
+++ b/src/views/__tests__/__snapshots__/Settings.spec.js.snap
@@ -66,13 +66,13 @@ exports[`SettingView.vue > should match the snapshot 1`] = `
     <div
       class="unnnic-form md"
       data-v-1088b44f=""
-      data-v-24f2d284=""
+      data-v-fefd47bc=""
     >
       <!---->
       <div
         class="text-input size--md text-input--icon-right-size-sm unnnic-form-input"
-        data-v-24f2d284=""
         data-v-c1401a33=""
+        data-v-fefd47bc=""
         mask=""
       >
         <input

--- a/src/views/__tests__/__snapshots__/SettingsSectors.spec.js.snap
+++ b/src/views/__tests__/__snapshots__/SettingsSectors.spec.js.snap
@@ -33,13 +33,13 @@ exports[`SettingsHeader.vue > should match the snapshot 1`] = `
     <div
       class="unnnic-form md"
       data-v-1088b44f=""
-      data-v-24f2d284=""
+      data-v-fefd47bc=""
     >
       <!---->
       <div
         class="text-input size--md text-input--icon-right-size-sm unnnic-form-input"
-        data-v-24f2d284=""
         data-v-c1401a33=""
+        data-v-fefd47bc=""
         mask=""
       >
         <input


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [x] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Prevent reconnection attempts that could lead to high resource consumption

### Summary of Changes
<!--- Describe your changes in detail -->
- Changed the default limit for room retrieval from 100 to 30 in WebSocket setup and related components.
- Limit total socket reconnection attemps to 6