### PR TITLE
[ENGAGE-5038] Improve WebSocket reconnection logic and alert handling

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -75,7 +75,7 @@ export default {
       return (
         ['room', 'discussion', 'home'].includes(this.$route.name) &&
         ['closed', 'connecting'].includes(this.socketStatus) &&
-        this.socketRetryCount >= 5
+        this.socketRetryCount >= (this.ws.MAX_RECONNECT_ATTEMPTS || 5)
       );
     },
 

--- a/src/layouts/ChatsLayout/components/SocketAlertBanner.vue
+++ b/src/layouts/ChatsLayout/components/SocketAlertBanner.vue
@@ -34,22 +34,19 @@
 import { useConfig } from '@/store/modules/config';
 import { mapState } from 'pinia';
 import unnnic from '@weni/unnnic-system';
+import i18n from '@/plugins/i18n';
 export default {
   name: 'AlertBanner',
   computed: {
     ...mapState(useConfig, ['socketStatus']),
   },
-  watch: {
-    socketStatus(status, oldStatus) {
-      if (oldStatus === 'connecting' && status === 'open') {
-        unnnic.unnnicCallAlert({
-          props: {
-            type: 'success',
-            text: this.$t('socket_alert_banner.connected'),
-          },
-        });
-      }
-    },
+  unmounted() {
+    unnnic.unnnicCallAlert({
+      props: {
+        type: 'success',
+        text: i18n.global.t('socket_alert_banner.connected'),
+      },
+    });
   },
   methods: {
     reconnect() {

--- a/src/services/api/websocket/setup.js
+++ b/src/services/api/websocket/setup.js
@@ -76,6 +76,7 @@ export default class WebSocketSetup {
     configStore.socketStatus = 'connecting';
 
     this.ws = ws;
+
     this.ws.ws.onclose = () => {
       configStore.socketStatus = 'closed';
       if (this.ws.ws.readyState === this.ws.ws.OPEN) return;


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Summary of Changes
<!--- Describe your changes in detail -->
- Updated the reconnection attempt condition in App.vue to use a configurable maximum retry count.
- Refactored SocketAlertBanner to trigger success alerts upon component unmount instead of during socket status changes, ensuring consistent user feedback on connection status.
- Added i18n support for localization in the success alert message.
