### PR TITLE
fix: update holiday and worktime retrieval logic in General.vue

### DIFF
--- a/src/components/settings/forms/General.vue
+++ b/src/components/settings/forms/General.vue
@@ -570,6 +570,9 @@ export default {
 
     if (!this.isEditing) {
       this.handleSelectAllCountryHolidays(true);
+    } else {
+      this.getSectorAllHolidays();
+      this.getSectorWorktimes(this.sector.uuid);
     }
 
     const isDefaultSector =
@@ -577,8 +580,6 @@ export default {
 
     if (this.isEditing && !this.enableGroupsMode) {
       this.getSectorManagers();
-      this.getSectorAllHolidays();
-      this.getSectorWorktimes(this.sector.uuid);
     } else if (isDefaultSector) {
       this.useDefaultSector = 1;
     }


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Summary of Changes
<!--- Describe your changes in detail -->
- Adjusted the logic for retrieving sector holidays and worktimes based on the editing state.
- Ensured that holidays and worktimes are fetched when editing a sector, improving the accuracy of displayed data.