### PR TITLE
[ENGAGE-7494] Feat: can use sector name in rooms settings

### DIFF
--- a/src/layouts/ChatsLayout/components/TheCardGroups/CardGroup/RoomCard.vue
+++ b/src/layouts/ChatsLayout/components/TheCardGroups/CardGroup/RoomCard.vue
@@ -111,7 +111,7 @@ export default {
     }),
     ...mapState(useConfig, {
       enableAutomaticRoomRouting: 'enableAutomaticRoomRouting',
-      enableGroupsMode: 'enableGroupsMode',
+      project: 'project',
     }),
     hideContactMessageInfo() {
       return this.roomType === 'waiting' && this.enableAutomaticRoomRouting;
@@ -154,7 +154,10 @@ export default {
       return this.roomType === 'waiting' ? this.$t('since') : '';
     },
     handleProjectName() {
-      if (this.enableGroupsMode) {
+      const canUseNameSectorInRooms =
+        this.project.config?.can_use_name_sector_in_rooms;
+
+      if (canUseNameSectorInRooms) {
         return this.room.queue?.sector_name;
       }
       return null;

--- a/src/layouts/ChatsLayout/components/TheCardGroups/CardGroup/tests/RoomCard.spec.js
+++ b/src/layouts/ChatsLayout/components/TheCardGroups/CardGroup/tests/RoomCard.spec.js
@@ -315,9 +315,13 @@ describe('RoomCard.vue', () => {
       wrapper.unmount();
     });
 
-    it('returns queue sector_name when enableGroupsMode is true', () => {
+    it('returns queue sector_name when canUseNameSectorInRooms is true', () => {
       const configStore = useConfig();
-      configStore.enableGroupsMode = true;
+      configStore.project = {
+        config: {
+          can_use_name_sector_in_rooms: true,
+        },
+      };
 
       const wrapper = createWrapper();
 
@@ -326,9 +330,13 @@ describe('RoomCard.vue', () => {
       wrapper.unmount();
     });
 
-    it('returns null when enableGroupsMode is false', () => {
+    it('returns null when canUseNameSectorInRooms is false', () => {
       const configStore = useConfig();
-      configStore.enableGroupsMode = false;
+      configStore.project = {
+        config: {
+          can_use_name_sector_in_rooms: false,
+        },
+      };
 
       const wrapper = createWrapper();
 
@@ -337,9 +345,13 @@ describe('RoomCard.vue', () => {
       wrapper.unmount();
     });
 
-    it('returns undefined when enableGroupsMode is true but room has no queue', () => {
+    it('returns undefined when canUseNameSectorInRooms is true but room has no queue', () => {
       const configStore = useConfig();
-      configStore.enableGroupsMode = true;
+      configStore.project = {
+        config: {
+          can_use_name_sector_in_rooms: true,
+        },
+      };
 
       const roomWithoutQueue = { ...mockRoom, queue: undefined };
       const wrapper = createWrapper({ room: roomWithoutQueue });
@@ -566,7 +578,11 @@ describe('RoomCard.vue', () => {
 
     it('handles room without queue gracefully', () => {
       const configStore = useConfig();
-      configStore.enableGroupsMode = true;
+      configStore.project = {
+        config: {
+          can_use_name_sector_in_rooms: true,
+        },
+      };
 
       const roomWithoutQueue = { ...mockRoom, queue: null };
       const wrapper = createWrapper({ room: roomWithoutQueue });

--- a/src/layouts/ChatsLayout/components/TheCardGroups/CardGroup/tests/RoomCard.spec.js
+++ b/src/layouts/ChatsLayout/components/TheCardGroups/CardGroup/tests/RoomCard.spec.js
@@ -99,7 +99,7 @@ describe('RoomCard.vue', () => {
 
     vi.stubGlobal(
       'setInterval',
-      vi.fn((callback, delay) => {
+      vi.fn(() => {
         const id = Math.random();
         return id;
       }),

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -908,6 +908,9 @@
       },
       "show_waiting_rooms_count": {
         "switch_label": "Show the counter with the number of chats waiting for human support"
+      },
+      "use_name_sector_in_rooms": {
+        "switch_label": "Use the sector name in the room name"
       }
     },
     "custom_sector": "Customize new sector (recommended)",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -904,6 +904,9 @@
       },
       "show_waiting_rooms_count": {
         "switch_label": "Mostrar el contador con el número de chats esperando soporte humano"
+      },
+      "use_name_sector_in_rooms": {
+        "switch_label": "Usar el nombre del sector en el nombre de la conversa"
       }
     },
     "custom_sector": "Personalizar nuevo sector (recomendado)",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -906,6 +906,9 @@
       },
       "show_waiting_rooms_count": {
         "switch_label": "Exibir o contador com o número de chats esperando atendimento humano"
+      },
+      "use_name_sector_in_rooms": {
+        "switch_label": "Usar o nome do setor no nome da conversa"
       }
     },
     "custom_sector": "Personalizar novo setor (recomendado)",

--- a/src/views/Settings/SettingsProjectOptions/index.vue
+++ b/src/views/Settings/SettingsProjectOptions/index.vue
@@ -100,6 +100,7 @@ export default {
         can_use_queue_prioritization: false,
         can_see_timer: false,
         can_see_waiting_rooms_count: true,
+        can_use_name_sector_in_rooms: false,
       },
       hasAgentBuilder: false,
       aiTransferConfig: {
@@ -159,6 +160,11 @@ export default {
         `config_chats.project_configs.bulk_close.switch_${
           canBulkClose ? 'active' : 'inactive'
         }`,
+      );
+    },
+    configUseNameSectorInRoomsTranslation() {
+      return this.$t(
+        `config_chats.project_configs.use_name_sector_in_rooms.switch_label`,
       );
     },
     configBlockCloseChatsInQueueTranslation() {
@@ -269,6 +275,12 @@ export default {
           visible: true,
           name: this.configShowWaitingRoomsCountTranslation,
         },
+        {
+          key: 'can_use_name_sector_in_rooms',
+          type: 'flag',
+          visible: true,
+          name: this.configUseNameSectorInRoomsTranslation,
+        },
       ];
 
       return items.filter((item) => item.visible);
@@ -351,6 +363,7 @@ export default {
         can_use_queue_prioritization,
         can_see_timer,
         can_see_waiting_rooms_count,
+        can_use_name_sector_in_rooms,
       } = this.projectConfig;
 
       Project.update({
@@ -362,6 +375,7 @@ export default {
         can_use_queue_prioritization,
         can_see_timer,
         can_see_waiting_rooms_count,
+        can_use_name_sector_in_rooms,
       });
     },
   },


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Add new config to helpe users if need the sector name in the room

### Summary of Changes
<!--- Describe your changes in detail -->
- Add settings logic dynamic
- Ajust if to render sector name to see the new config

