### PR TITLE
refactor: update translations for sector name usage in chat titles

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -910,7 +910,7 @@
         "switch_label": "Show the counter with the number of chats waiting for human support"
       },
       "use_name_sector_in_rooms": {
-        "switch_label": "Use the sector name in the room name"
+        "switch_label": "Display the department name in the chat title"
       }
     },
     "custom_sector": "Customize new sector (recommended)",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -906,7 +906,7 @@
         "switch_label": "Mostrar el contador con el número de chats esperando soporte humano"
       },
       "use_name_sector_in_rooms": {
-        "switch_label": "Usar el nombre del sector en el nombre de la conversa"
+        "switch_label": "Mostrar el nombre del sector en el título del chat."
       }
     },
     "custom_sector": "Personalizar nuevo sector (recomendado)",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -908,7 +908,7 @@
         "switch_label": "Exibir o contador com o número de chats esperando atendimento humano"
       },
       "use_name_sector_in_rooms": {
-        "switch_label": "Usar o nome do setor no nome da conversa"
+        "switch_label": "Mostrar o nome do setor no título do chat"
       }
     },
     "custom_sector": "Personalizar novo setor (recomendado)",


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

- Revised the switch label translations in English, Spanish, and Portuguese to clarify that the department name will be displayed in the chat title instead of the sector name.
- Improved user understanding of the feature in localization files.

### Summary of Changes
<!--- Describe your changes in detail -->

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File 1](link_to_design_file_1)

### Demonstration <!--- (If not appropriate, remove this topic) -->
<!--- Include a screenshot or video showcasing a feature or fix implemented in this pull request. -->
