### PR TITLE
[ENGAGE-7741] Fix: bulk close re render modal after closed rooms

### DIFF
--- a/src/layouts/ChatsLayout/components/FooterButton/__tests__/FooterButton.spec.js
+++ b/src/layouts/ChatsLayout/components/FooterButton/__tests__/FooterButton.spec.js
@@ -336,6 +336,74 @@ describe('FooterButton', () => {
       wrapper.vm.handleModalTakeOverRooms();
       expect(wrapper.vm.isModalTakeOverRoomsOpened).toBe(false);
     });
+
+    it('should reset all modal states when selected rooms become empty (ongoing)', async () => {
+      const wrapper = createWrapper(['room1'], 'ongoing', {
+        can_use_bulk_transfer: true,
+        can_use_bulk_close: true,
+        activeFeatures: ['weniChatsBulkClose'],
+      });
+
+      await wrapper.setData({
+        isModalTransferRoomsOpened: true,
+        isModalCloseRoomsOpened: true,
+      });
+
+      const roomsStore = useRooms();
+      roomsStore.selectedOngoingRooms = [];
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.isModalTransferRoomsOpened).toBe(false);
+      expect(wrapper.vm.isModalCloseRoomsOpened).toBe(false);
+    });
+
+    it('should reset all modal states when selected rooms become empty (waiting)', async () => {
+      const wrapper = createWrapper(['room1'], 'waiting', {
+        can_use_bulk_take: true,
+        can_use_bulk_transfer: true,
+        can_use_bulk_close: true,
+        activeFeatures: [
+          'weniChatsBulkTake',
+          'weniChatsBulkTransfer',
+          'weniChatsBulkClose',
+        ],
+      });
+
+      await wrapper.setData({
+        isModalTakeOverRoomsOpened: true,
+        isModalTransferRoomsOpened: true,
+        isModalCloseRoomsOpened: true,
+      });
+
+      const roomsStore = useRooms();
+      roomsStore.selectedWaitingRooms = [];
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.isModalTakeOverRoomsOpened).toBe(false);
+      expect(wrapper.vm.isModalTransferRoomsOpened).toBe(false);
+      expect(wrapper.vm.isModalCloseRoomsOpened).toBe(false);
+    });
+
+    it('should not reopen close modal when selecting a new room after bulk close', async () => {
+      const wrapper = createWrapper(['room1', 'room2'], 'ongoing', {
+        can_use_bulk_close: true,
+        activeFeatures: ['weniChatsBulkClose'],
+      });
+
+      await wrapper.setData({ isModalCloseRoomsOpened: true });
+      expect(wrapper.vm.isModalCloseRoomsOpened).toBe(true);
+
+      const roomsStore = useRooms();
+      roomsStore.selectedOngoingRooms = [];
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.isModalCloseRoomsOpened).toBe(false);
+
+      roomsStore.selectedOngoingRooms = ['room3'];
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.isModalCloseRoomsOpened).toBe(false);
+    });
   });
 
   describe('Transfer button on waiting tab', () => {

--- a/src/layouts/ChatsLayout/components/FooterButton/index.vue
+++ b/src/layouts/ChatsLayout/components/FooterButton/index.vue
@@ -199,6 +199,13 @@ export default {
       this.isModalTransferRoomsOpened = false;
       this.isModalCloseRoomsOpened = false;
     },
+    currentSelectedRooms(newVal) {
+      if (newVal.length === 0) {
+        this.isModalTakeOverRoomsOpened = false;
+        this.isModalTransferRoomsOpened = false;
+        this.isModalCloseRoomsOpened = false;
+      }
+    },
   },
 
   methods: {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- solve re-render bulk modal problem

### Summary of Changes
<!--- Describe your changes in detail -->
- Add logic to kill the re-render modal bulk-close after recent closed