### PR TITLE
[ENGAGE-7728] Fix: race condition summary problem and css adjusts

### DIFF
--- a/src/components/chats/chat/RoomMessages.vue
+++ b/src/components/chats/chat/RoomMessages.vue
@@ -178,12 +178,12 @@ export default {
       }
     },
 
-    setRoomSummary(text, feedback, status) {
+    setRoomSummary(text, feedback, status = '') {
       this.isLoadingActiveRoomSummary = false;
       if (this.room) {
         this.roomsSummary[this.room.uuid] = {
           summary: text,
-          feedback,
+          feedback: feedback ?? { liked: null },
           status,
         };
       }
@@ -192,10 +192,12 @@ export default {
 
     async getRoomSummary() {
       if (!this.room) return;
+      const roomUuid = this.room.uuid;
       try {
         const { status, summary, feedback } = await RoomService.getSummary({
-          roomUuid: this.room.uuid,
+          roomUuid,
         });
+        if (this.room?.uuid !== roomUuid) return;
         if (['DONE', 'UNAVAILABLE'].includes(status)) {
           const unavailableText = this.$t('chats.summary.unavailable');
           this.setRoomSummary(
@@ -205,9 +207,10 @@ export default {
           );
         }
       } catch (error) {
+        if (this.room?.uuid !== roomUuid) return;
         console.log(error);
         const errorText = i18n.global.t('chats.summary.error');
-        this.setRoomSummary(errorText);
+        this.setRoomSummary(errorText, { liked: null }, 'ERROR');
       }
     },
 

--- a/src/components/chats/chat/__tests__/RoomMessages.spec.js
+++ b/src/components/chats/chat/__tests__/RoomMessages.spec.js
@@ -432,7 +432,11 @@ describe('RoomMessages.vue', () => {
       await wrapper.vm.getRoomSummary();
 
       const errorText = i18n.global.t('chats.summary.error');
-      expect(wrapper.vm.setRoomSummary).toHaveBeenCalledWith(errorText);
+      expect(wrapper.vm.setRoomSummary).toHaveBeenCalledWith(
+        errorText,
+        { liked: null },
+        'ERROR',
+      );
     });
 
     it('does not call API when room is null', async () => {

--- a/src/layouts/ChatsLayout/components/ChatSummary/index.vue
+++ b/src/layouts/ChatsLayout/components/ChatSummary/index.vue
@@ -188,8 +188,8 @@ export default {
 
         if (newValue && !this.skipAnimation) {
           await this.typeWriter(newValue, 10);
-        } else if (newValue) {
-          this.animatedText = newValue;
+        } else {
+          this.animatedText = newValue || '';
         }
       },
     },
@@ -291,11 +291,11 @@ export default {
 .chat-summary {
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
   background: $unnnic-color-bg-purple-plain;
   box-shadow: $unnnic-shadow-1;
   padding: $unnnic-spacing-sm;
   gap: $unnnic-spacing-nano;
+  flex-shrink: 0;
 
   &--open {
     margin-left: v-bind(marginLeft);


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [X] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [X] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Users reported that the ChatSummary component intermittently displayed a large empty purple area, with "Resumo feito por IA" at the top and the summary text pushed far to the bottom, separated by a huge gap. This occurred when the .chat-summary section was stretched by the parent grid layout (e.g., ViewMode's grid-template-rows: auto 1fr auto), and justify-content: space-between distributed the children to opposite ends of the container.

Additionally, a race condition in getRoomSummary() could write stale API responses to the wrong room's summary state when the user switched rooms while a request was in-flight, and the error handling path left feedback and status as undefined in the store.

### Summary of Changes
<!--- Describe your changes in detail -->

ChatSummary/index.vue

Removed justify-content: space-between from .chat-summary — this was the direct cause of the visual gap. The existing gap property already provides the correct spacing between children. Without space-between, even if the section is stretched by a parent layout, the children stay packed at the top instead of being pushed apart.
Added flex-shrink: 0 to .chat-summary to prevent the section from being compressed below its content size by flex parent containers.
Changed the summaryText watcher from else if (newValue) to else with a fallback (newValue || ''), ensuring animatedText stays in sync even when the text is empty or falsy.
RoomMessages.vue

Captured roomUuid before the async getSummary API call and added if (this.room?.uuid !== roomUuid) return guards on both the success and error paths, preventing stale responses from overwriting the active room's summary state.
Used feedback ?? { liked: null } in setRoomSummary to guarantee feedback is never stored as undefined.
Updated the error catch path to pass explicit defaults ({ liked: null }, 'ERROR') instead of calling setRoomSummary with a single argument.
RoomMessages.spec.js

Updated the error handling test assertion to match the new setRoomSummary call signature with explicit feedback and status arguments.
