### PR TITLE
[ENGAGE-7400] Feat: improvement messages with ai feature

### DIFF
--- a/src/components/chats/MessageManagerV2/TextBox/Actions.vue
+++ b/src/components/chats/MessageManagerV2/TextBox/Actions.vue
@@ -1,31 +1,38 @@
 <template>
   <section class="text-box__actions">
     <section class="text-box__actions__items">
-      <section
+      <template
         v-for="(action, index) in enabledActions"
         :key="index"
-        class="text-box__actions__item"
       >
-        <UnnnicToolTip
-          :enabled="!!action.tooltip"
-          :text="action.tooltip"
-          side="top"
-        >
-          <UnnnicButton
-            :iconCenter="action.icon"
-            :tooltip="action.tooltip"
-            :disabled="action.disabled"
-            type="tertiary"
-            size="small"
-            :pressed="action.pressed"
-            @click.stop="action.action()"
+        <section class="text-box__actions__item">
+          <UnnnicToolTip
+            :enabled="!!action.tooltip"
+            :text="action.tooltip"
+            side="top"
+          >
+            <UnnnicButton
+              :iconCenter="action.icon"
+              :tooltip="action.tooltip"
+              :disabled="action.disabled || isAiLoading"
+              type="tertiary"
+              size="small"
+              :pressed="action.pressed"
+              @click.stop="action.action()"
+            />
+          </UnnnicToolTip>
+          <hr
+            v-if="action.showDivider"
+            class="text-box__actions__divider"
           />
-        </UnnnicToolTip>
-        <hr
-          v-if="action.showDivider"
-          class="text-box__actions__divider"
+        </section>
+
+        <AiTextImprovement
+          v-if="action.insertAiAfter && showAiTextImprovement"
+          @improvement-received="emit('improvementReceived', $event)"
+          @improvement-cancelled="emit('improvementCancelled')"
         />
-      </section>
+      </template>
     </section>
     <UnnnicButton
       :iconLeft="isInternalNote ? '' : 'send'"
@@ -33,7 +40,7 @@
       :type="isInternalNote ? 'attention' : 'primary'"
       size="small"
       :text="isInternalNote ? $t('add') : $t('send')"
-      :disabled="disableSendButton"
+      :disabled="disableSendButton || isAiLoading"
       @click="emit('send')"
     />
   </section>
@@ -45,6 +52,10 @@ import { storeToRefs } from 'pinia';
 
 import { useMessageManager } from '@/store/modules/chats/messageManager';
 import { useDiscussions } from '@/store/modules/chats/discussions';
+import { useAiTextImprovement } from '@/store/modules/chats/aiTextImprovement';
+import { useFeatureFlag } from '@/store/modules/featureFlag';
+
+import AiTextImprovement from './AiTextImprovement.vue';
 
 import i18n from '@/plugins/i18n';
 
@@ -56,6 +67,8 @@ defineOptions({
 
 const discussionsStore = useDiscussions();
 const { activeDiscussion } = storeToRefs(discussionsStore);
+
+const featureFlagStore = useFeatureFlag();
 
 const messageManager = useMessageManager();
 const { clearInputs } = messageManager;
@@ -70,15 +83,29 @@ const {
   isSuggestionBoxOpen,
 } = storeToRefs(messageManager);
 
+const aiTextImprovementStore = useAiTextImprovement();
+const { isLoading: isAiLoading } = storeToRefs(aiTextImprovementStore);
+
+const showAiTextImprovement = computed(() => {
+  return (
+    featureFlagStore.featureFlags?.active_features?.includes(
+      'weniChatsAiTextImprovement',
+    ) && !activeDiscussion.value?.uuid
+  );
+});
+
 const emit = defineEmits<{
   startAudioRecording: [void];
   focusInput: [void];
   openUploadFiles: [void];
   send: [void];
+  improvementReceived: [text: string];
+  improvementCancelled: [void];
 }>();
 
 interface TextBoxAction {
   hideInDiscussion?: boolean;
+  insertAiAfter?: boolean;
   icon: string;
   tooltip?: string;
   disabled?: boolean;
@@ -86,10 +113,12 @@ interface TextBoxAction {
   pressed?: boolean;
   action: () => void;
 }
+
 const actions = computed<TextBoxAction[]>(() => {
   return [
     {
       hideInDiscussion: true,
+      insertAiAfter: true,
       icon: 'bolt',
       tooltip: t('quick_message'),
       pressed: isSuggestionBoxOpen.value,
@@ -226,20 +255,20 @@ const checkDisabledAction = (action: string) => {
 .text-box {
   &__actions {
     display: flex;
-    gap: $unnnic-space-1;
+    gap: $unnnic-space-2;
     align-items: center;
     justify-content: space-between;
     &__items {
       display: flex;
       flex-direction: row;
       align-items: center;
-      gap: $unnnic-space-1;
+      gap: $unnnic-space-2;
     }
     &__item {
       display: flex;
       flex-direction: row;
       align-items: center;
-      gap: $unnnic-space-1;
+      gap: $unnnic-space-2;
     }
     &__divider {
       height: stretch;

--- a/src/components/chats/MessageManagerV2/TextBox/Actions.vue
+++ b/src/components/chats/MessageManagerV2/TextBox/Actions.vue
@@ -89,7 +89,7 @@ const { isLoading: isAiLoading } = storeToRefs(aiTextImprovementStore);
 const showAiTextImprovement = computed(() => {
   return (
     featureFlagStore.featureFlags?.active_features?.includes(
-      'weniChatsAiTextImprovement',
+      'weniChatsAITextImprovement',
     ) && !activeDiscussion.value?.uuid
   );
 });

--- a/src/components/chats/MessageManagerV2/TextBox/AiTextImprovement.vue
+++ b/src/components/chats/MessageManagerV2/TextBox/AiTextImprovement.vue
@@ -163,7 +163,7 @@ function handleCancel() {
 
   &__new-tag {
     position: absolute;
-    top: -8px;
+    top: -$unnnic-space-2;
     left: 50%;
     transform: translateX(-50%);
     z-index: 1;

--- a/src/components/chats/MessageManagerV2/TextBox/AiTextImprovement.vue
+++ b/src/components/chats/MessageManagerV2/TextBox/AiTextImprovement.vue
@@ -31,7 +31,7 @@
           </section>
         </UnnnicPopoverTrigger>
         <UnnnicPopoverContent
-          size="small"
+          size="medium"
           side="top"
           align="start"
         >

--- a/src/components/chats/MessageManagerV2/TextBox/AiTextImprovement.vue
+++ b/src/components/chats/MessageManagerV2/TextBox/AiTextImprovement.vue
@@ -1,0 +1,208 @@
+<template>
+  <section
+    class="ai-text-improvement"
+    @mouseenter="handleMouseEnter"
+  >
+    <UnnnicToolTip
+      v-if="!isLoading"
+      :enabled="true"
+      :text="tooltipText"
+      side="top"
+    >
+      <UnnnicPopover
+        :open="isPopoverOpen"
+        @update:open="isPopoverOpen = $event"
+      >
+        <UnnnicPopoverTrigger>
+          <section class="ai-text-improvement__button-wrapper">
+            <span
+              v-if="showNewTag"
+              class="ai-text-improvement__new-tag"
+            >
+              {{ $t('ai_text_improvement.new') }}
+            </span>
+            <UnnnicButton
+              iconCenter="wand_shine"
+              type="tertiary"
+              size="small"
+              :disabled="isDisabled"
+              @click.stop="handleButtonClick"
+            />
+          </section>
+        </UnnnicPopoverTrigger>
+        <UnnnicPopoverContent
+          size="small"
+          side="top"
+          align="start"
+        >
+          <section class="ai-text-improvement__popover">
+            <section
+              v-for="option in improvementOptions"
+              :key="option.type"
+              class="ai-text-improvement__popover-item"
+              @click="selectOption(option.type)"
+            >
+              <p class="ai-text-improvement__popover-item-text">
+                {{ option.label }}
+              </p>
+            </section>
+          </section>
+        </UnnnicPopoverContent>
+      </UnnnicPopover>
+    </UnnnicToolTip>
+
+    <UnnnicToolTip
+      v-else
+      :enabled="true"
+      :text="$t('ai_text_improvement.tooltip_cancel')"
+      side="top"
+    >
+      <UnnnicButton
+        type="secondary"
+        size="small"
+        iconLeft="close"
+        :text="$t('ai_text_improvement.improvement')"
+        @click="handleCancel"
+      />
+    </UnnnicToolTip>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { storeToRefs } from 'pinia';
+
+import { useAiTextImprovement } from '@/store/modules/chats/aiTextImprovement';
+import { useMessageManager } from '@/store/modules/chats/messageManager';
+
+import type { AiTextImprovementType } from '@/services/api/resources/chats/aiTextImprovement';
+
+import i18n from '@/plugins/i18n';
+
+const { t } = i18n.global;
+
+defineOptions({
+  name: 'AiTextImprovement',
+});
+
+const emit = defineEmits<{
+  improvementReceived: [text: string];
+  improvementCancelled: [void];
+}>();
+
+const aiTextImprovement = useAiTextImprovement();
+const { isLoading, isPopoverOpen, showNewTag } = storeToRefs(aiTextImprovement);
+
+const messageManager = useMessageManager();
+const { inputMessage } = storeToRefs(messageManager);
+
+const isDisabled = computed(() => !inputMessage.value.trim());
+
+const tooltipText = computed(() =>
+  isDisabled.value
+    ? t('ai_text_improvement.tooltip_disabled')
+    : t('ai_text_improvement.tooltip_enabled'),
+);
+
+const improvementOptions = computed(() => [
+  {
+    type: 'GRAMMAR_AND_SPELLING' as AiTextImprovementType,
+    label: t('ai_text_improvement.fix_grammar_and_spelling'),
+  },
+  {
+    type: 'MORE_EMPATHY' as AiTextImprovementType,
+    label: t('ai_text_improvement.make_more_empathetic'),
+  },
+  {
+    type: 'CLARITY' as AiTextImprovementType,
+    label: t('ai_text_improvement.rewrite_for_clarity'),
+  },
+]);
+
+function handleMouseEnter() {
+  if (showNewTag.value) {
+    aiTextImprovement.hideNewTag();
+  }
+}
+
+function handleButtonClick() {
+  if (!isDisabled.value) {
+    isPopoverOpen.value = !isPopoverOpen.value;
+  }
+}
+
+async function selectOption(type: AiTextImprovementType) {
+  isPopoverOpen.value = false;
+
+  const text = inputMessage.value.trim();
+  if (!text) return;
+
+  const improvedText = await aiTextImprovement.requestImprovement(text, type);
+
+  if (improvedText) {
+    emit('improvementReceived', improvedText);
+  } else if (!aiTextImprovement.isLoading) {
+    emit('improvementCancelled');
+  }
+}
+
+function handleCancel() {
+  aiTextImprovement.cancelImprovement();
+  emit('improvementCancelled');
+}
+</script>
+
+<style scoped lang="scss">
+.ai-text-improvement {
+  position: relative;
+
+  &__button-wrapper {
+    position: relative;
+    display: inline-flex;
+  }
+
+  &__new-tag {
+    position: absolute;
+    top: -8px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 1;
+
+    background-color: $unnnic-color-bg-purple-plain;
+    color: $unnnic-color-fg-emphasized;
+    // TODO: not exists in unnnic design system
+    font-size: 8px;
+    font-weight: $unnnic-font-weight-medium;
+    line-height: 12px;
+    padding: $unnnic-space-05 $unnnic-space-2;
+    border-radius: $unnnic-radius-4;
+    white-space: nowrap;
+    pointer-events: none;
+  }
+
+  &__popover {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-2;
+  }
+
+  &__popover-item {
+    display: flex;
+    align-items: center;
+    gap: $unnnic-space-2;
+    padding: $unnnic-space-2 $unnnic-space-4;
+    border-radius: $unnnic-radius-2;
+    cursor: pointer;
+
+    &:hover {
+      background-color: $unnnic-color-bg-muted;
+    }
+  }
+
+  &__popover-item-text {
+    font: $unnnic-font-emphasis;
+    color: $unnnic-color-fg-emphasized;
+    white-space: nowrap;
+  }
+}
+</style>

--- a/src/components/chats/MessageManagerV2/TextBox/BackToOriginal.vue
+++ b/src/components/chats/MessageManagerV2/TextBox/BackToOriginal.vue
@@ -1,0 +1,57 @@
+<template>
+  <section class="back-to-original">
+    <UnnnicToolTip
+      :enabled="true"
+      :text="$t('ai_text_improvement.back_to_original_tooltip')"
+      side="left"
+    >
+      <UnnnicButton
+        type="tertiary"
+        iconLeft="undo"
+        size="small"
+        :text="$t('ai_text_improvement.back_to_original')"
+        class="back-to-original__button"
+        @click="handleClick"
+      />
+    </UnnnicToolTip>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { useAiTextImprovement } from '@/store/modules/chats/aiTextImprovement';
+import { useMessageManager } from '@/store/modules/chats/messageManager';
+
+defineOptions({
+  name: 'BackToOriginal',
+});
+
+const emit = defineEmits<{
+  reverted: [void];
+}>();
+
+const aiTextImprovementStore = useAiTextImprovement();
+const messageManager = useMessageManager();
+
+function handleClick() {
+  messageManager.inputMessage = aiTextImprovementStore.originalText;
+  aiTextImprovementStore.feedbackStatus = 'DISCARDED';
+  aiTextImprovementStore.improvedText = '';
+  emit('reverted');
+}
+</script>
+
+<style scoped lang="scss">
+.back-to-original {
+  flex-shrink: 0;
+  display: flex;
+
+  :deep(.unnnic-tooltip) {
+    display: flex;
+  }
+
+  &__button {
+    height: auto;
+    align-self: stretch;
+  }
+}
+</style>

--- a/src/components/chats/MessageManagerV2/TextBox/TextArea.vue
+++ b/src/components/chats/MessageManagerV2/TextBox/TextArea.vue
@@ -13,7 +13,18 @@
     />
   </button>
   <section
-    v-if="!isAudioRecorderVisible && mediaUploadFiles.length === 0"
+    v-if="isAiImproving"
+    class="text-box__textarea-container"
+  >
+    <p class="text-box__ai-loading-text">
+      {{ $t('ai_text_improvement.improving_response')
+      }}<span class="text-box__ai-loading-dots"
+        ><span>.</span><span>.</span><span>.</span></span
+      >
+    </p>
+  </section>
+  <section
+    v-else-if="!isAudioRecorderVisible && mediaUploadFiles.length === 0"
     class="text-box__textarea-container"
   >
     <p
@@ -44,6 +55,7 @@ import { onMounted, useTemplateRef, watch, nextTick } from 'vue';
 import { storeToRefs } from 'pinia';
 
 import { useMessageManager } from '@/store/modules/chats/messageManager';
+import { useAiTextImprovement } from '@/store/modules/chats/aiTextImprovement';
 
 defineOptions({
   name: 'MessageManagerTextBoxTextArea',
@@ -61,6 +73,9 @@ const {
   isAudioRecorderVisible,
   inputMessageFocused,
 } = storeToRefs(messageManager);
+
+const aiTextImprovementStore = useAiTextImprovement();
+const { isLoading: isAiImproving } = storeToRefs(aiTextImprovementStore);
 
 const MAX_TEXTAREA_ROWS = 5;
 
@@ -185,6 +200,41 @@ defineExpose({
   max-height: 104px;
   &::placeholder {
     color: $unnnic-color-fg-muted;
+  }
+}
+
+.text-box__ai-loading-text {
+  font: $unnnic-font-body;
+  color: $unnnic-color-fg-muted;
+}
+
+.text-box__ai-loading-dots {
+  span {
+    opacity: 0;
+    animation: dot-blink 1.4s infinite;
+
+    &:nth-child(1) {
+      animation-delay: 0s;
+    }
+    &:nth-child(2) {
+      animation-delay: 0.2s;
+    }
+    &:nth-child(3) {
+      animation-delay: 0.4s;
+    }
+  }
+}
+
+@keyframes dot-blink {
+  0%,
+  20% {
+    opacity: 0;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
   }
 }
 

--- a/src/components/chats/MessageManagerV2/TextBox/TextArea.vue
+++ b/src/components/chats/MessageManagerV2/TextBox/TextArea.vue
@@ -17,11 +17,13 @@
     class="text-box__textarea-container"
   >
     <p class="text-box__ai-loading-text">
-      {{ $t('ai_text_improvement.improving_response')
-      }}<span class="text-box__ai-loading-dots"
-        ><span>.</span><span>.</span><span>.</span></span
-      >
+      {{ $t('ai_text_improvement.improving_response') }}
     </p>
+    <span class="text-box__ai-loading-dots">
+      <span class="text-box__ai-loading-dot" />
+      <span class="text-box__ai-loading-dot" />
+      <span class="text-box__ai-loading-dot" />
+    </span>
   </section>
   <section
     v-else-if="!isAudioRecorderVisible && mediaUploadFiles.length === 0"
@@ -209,32 +211,37 @@ defineExpose({
 }
 
 .text-box__ai-loading-dots {
-  span {
-    opacity: 0;
-    animation: dot-blink 1.4s infinite;
+  display: inline-flex;
+  align-items: flex-end;
+  gap: 3px;
+  margin-left: $unnnic-space-1;
+  padding-bottom: $unnnic-space-1;
+}
 
-    &:nth-child(1) {
-      animation-delay: 0s;
-    }
-    &:nth-child(2) {
-      animation-delay: 0.2s;
-    }
-    &:nth-child(3) {
-      animation-delay: 0.4s;
-    }
+.text-box__ai-loading-dot {
+  display: inline-block;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background-color: $unnnic-color-fg-muted;
+  animation: dot-jump 1.4s ease-in-out infinite;
+
+  &:nth-child(2) {
+    animation-delay: 0.16s;
+  }
+  &:nth-child(3) {
+    animation-delay: 0.32s;
   }
 }
 
-@keyframes dot-blink {
+@keyframes dot-jump {
   0%,
-  20% {
-    opacity: 0;
-  }
-  50% {
-    opacity: 1;
-  }
+  60%,
   100% {
-    opacity: 0;
+    transform: translateY(0);
+  }
+  30% {
+    transform: translateY(-6px);
   }
 }
 

--- a/src/components/chats/MessageManagerV2/TextBox/__tests__/Actions.spec.js
+++ b/src/components/chats/MessageManagerV2/TextBox/__tests__/Actions.spec.js
@@ -45,7 +45,7 @@ vi.spyOn(i18n.global, 't').mockImplementation((key) => key);
 
 const createWrapper = (options = {}) => {
   const {
-    featureFlags = { active_features: ['weniChatsAiTextImprovement'] },
+    featureFlags = { active_features: ['weniChatsAITextImprovement'] },
     activeDiscussion = null,
     inputMessage = '',
     isAiLoading = false,
@@ -131,27 +131,27 @@ describe('Actions', () => {
   describe('AI text improvement visibility', () => {
     it('should show AiTextImprovement when feature flag is active', () => {
       const wrapper = createWrapper();
-      expect(
-        wrapper.find('[data-testid="ai-text-improvement"]').exists(),
-      ).toBe(true);
+      expect(wrapper.find('[data-testid="ai-text-improvement"]').exists()).toBe(
+        true,
+      );
     });
 
     it('should hide AiTextImprovement when feature flag is off', () => {
       const wrapper = createWrapper({
         featureFlags: { active_features: [] },
       });
-      expect(
-        wrapper.find('[data-testid="ai-text-improvement"]').exists(),
-      ).toBe(false);
+      expect(wrapper.find('[data-testid="ai-text-improvement"]').exists()).toBe(
+        false,
+      );
     });
 
     it('should hide AiTextImprovement in discussion mode', () => {
       const wrapper = createWrapper({
         activeDiscussion: { uuid: 'disc-1' },
       });
-      expect(
-        wrapper.find('[data-testid="ai-text-improvement"]').exists(),
-      ).toBe(false);
+      expect(wrapper.find('[data-testid="ai-text-improvement"]').exists()).toBe(
+        false,
+      );
     });
   });
 

--- a/src/components/chats/MessageManagerV2/TextBox/__tests__/Actions.spec.js
+++ b/src/components/chats/MessageManagerV2/TextBox/__tests__/Actions.spec.js
@@ -1,0 +1,166 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  beforeAll,
+  afterAll,
+} from 'vitest';
+import { mount, config } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+
+import Actions from '../Actions.vue';
+import i18n from '@/plugins/i18n';
+
+vi.mock('@/services/api/resources/chats/aiTextImprovement', () => ({
+  default: { improve: vi.fn() },
+}));
+
+vi.mock('@/utils/callUnnnicAlert', () => ({ default: vi.fn() }));
+
+vi.mock('../AiTextImprovement.vue', () => ({
+  default: {
+    name: 'AiTextImprovement',
+    template:
+      '<div data-testid="ai-text-improvement" @click="$emit(\'improvementReceived\', \'improved\')" />',
+    emits: ['improvementReceived', 'improvementCancelled'],
+  },
+}));
+
+beforeAll(() => {
+  config.global.plugins = (config.global.plugins || []).filter(
+    (plugin) => plugin !== i18n,
+  );
+});
+
+afterAll(() => {
+  if (config.global.plugins && !config.global.plugins.includes(i18n)) {
+    config.global.plugins.push(i18n);
+  }
+});
+
+vi.spyOn(i18n.global, 't').mockImplementation((key) => key);
+
+const createWrapper = (options = {}) => {
+  const {
+    featureFlags = { active_features: ['weniChatsAiTextImprovement'] },
+    activeDiscussion = null,
+    inputMessage = '',
+    isAiLoading = false,
+    audioRecorderStatus = 'idle',
+  } = options;
+
+  const pinia = createTestingPinia({
+    createSpy: vi.fn,
+    stubActions: false,
+    initialState: {
+      messageManager: {
+        inputMessage,
+        isInternalNote: false,
+        isEmojiPickerOpen: false,
+        audioRecorderStatus,
+        audioMessage: null,
+        mediaUploadFiles: [],
+        isSuggestionBoxOpen: false,
+      },
+      aiTextImprovement: { isLoading: isAiLoading },
+      featureFlag: { featureFlags },
+      discussions: { activeDiscussion },
+    },
+  });
+  setActivePinia(pinia);
+
+  return mount(Actions, {
+    global: {
+      plugins: [pinia],
+      mocks: { $t: (key) => key },
+      stubs: {
+        UnnnicButton: {
+          name: 'UnnnicButton',
+          inheritAttrs: false,
+          template:
+            '<button :data-disabled="disabled" :data-text="text" @click="$emit(\'click\')"><slot /></button>',
+          props: [
+            'iconCenter',
+            'iconLeft',
+            'type',
+            'size',
+            'disabled',
+            'pressed',
+            'text',
+            'tooltip',
+          ],
+        },
+      },
+    },
+  });
+};
+
+describe('Actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('action buttons', () => {
+    it('should render all 5 action buttons in room mode', () => {
+      const wrapper = createWrapper();
+      const items = wrapper.findAll('.text-box__actions__item');
+      expect(items).toHaveLength(5);
+    });
+
+    it('should hide discussion-only buttons in discussion mode', () => {
+      const wrapper = createWrapper({
+        activeDiscussion: { uuid: 'disc-1' },
+      });
+      const items = wrapper.findAll('.text-box__actions__item');
+      expect(items).toHaveLength(3);
+    });
+
+    it('should emit send when send button is clicked', async () => {
+      const wrapper = createWrapper();
+      const sendButton = wrapper.find(
+        '.text-box__actions > button[data-text="send"]',
+      );
+      await sendButton.trigger('click');
+      expect(wrapper.emitted('send')).toBeTruthy();
+    });
+  });
+
+  describe('AI text improvement visibility', () => {
+    it('should show AiTextImprovement when feature flag is active', () => {
+      const wrapper = createWrapper();
+      expect(
+        wrapper.find('[data-testid="ai-text-improvement"]').exists(),
+      ).toBe(true);
+    });
+
+    it('should hide AiTextImprovement when feature flag is off', () => {
+      const wrapper = createWrapper({
+        featureFlags: { active_features: [] },
+      });
+      expect(
+        wrapper.find('[data-testid="ai-text-improvement"]').exists(),
+      ).toBe(false);
+    });
+
+    it('should hide AiTextImprovement in discussion mode', () => {
+      const wrapper = createWrapper({
+        activeDiscussion: { uuid: 'disc-1' },
+      });
+      expect(
+        wrapper.find('[data-testid="ai-text-improvement"]').exists(),
+      ).toBe(false);
+    });
+  });
+
+  describe('AI loading state', () => {
+    it('should disable send button when AI is loading', () => {
+      const wrapper = createWrapper({ isAiLoading: true });
+      const allButtons = wrapper.findAll('.text-box__actions > button');
+      const sendButton = allButtons[allButtons.length - 1];
+      expect(sendButton.attributes('data-disabled')).toBe('true');
+    });
+  });
+});

--- a/src/components/chats/MessageManagerV2/TextBox/__tests__/AiTextImprovement.spec.js
+++ b/src/components/chats/MessageManagerV2/TextBox/__tests__/AiTextImprovement.spec.js
@@ -1,0 +1,257 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  beforeAll,
+  afterAll,
+} from 'vitest';
+import { mount, config, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+
+import { useAiTextImprovement } from '@/store/modules/chats/aiTextImprovement';
+import { useMessageManager } from '@/store/modules/chats/messageManager';
+import i18n from '@/plugins/i18n';
+
+vi.mock('@/services/api/resources/chats/aiTextImprovement', () => ({
+  default: { improve: vi.fn() },
+}));
+
+vi.mock('@/utils/callUnnnicAlert', () => ({ default: vi.fn() }));
+
+const UnnnicSystemPlugin = config.global.plugins.find(
+  (p) => p !== i18n && typeof p !== 'function',
+);
+
+beforeAll(() => {
+  config.global.plugins = (config.global.plugins || []).filter(
+    (plugin) => plugin !== i18n && plugin !== UnnnicSystemPlugin,
+  );
+});
+
+afterAll(() => {
+  if (config.global.plugins && !config.global.plugins.includes(i18n)) {
+    config.global.plugins.push(i18n);
+  }
+  if (
+    UnnnicSystemPlugin &&
+    config.global.plugins &&
+    !config.global.plugins.includes(UnnnicSystemPlugin)
+  ) {
+    config.global.plugins.push(UnnnicSystemPlugin);
+  }
+});
+
+vi.spyOn(i18n.global, 't').mockImplementation((key) => key);
+
+const unnnicStubs = {
+  UnnnicButton: {
+    name: 'UnnnicButton',
+    inheritAttrs: false,
+    template:
+      '<button :data-icon="iconCenter || iconLeft" :data-disabled="String(disabled)" :data-type="type" :data-text="text" @click="$emit(\'click\')"><slot /></button>',
+    props: {
+      iconCenter: { default: '' },
+      iconLeft: { default: '' },
+      type: { default: '' },
+      size: { default: '' },
+      disabled: { default: false },
+      pressed: { default: false },
+      text: { default: '' },
+      tooltip: { default: '' },
+    },
+    emits: ['click'],
+  },
+  UnnnicToolTip: {
+    name: 'UnnnicToolTip',
+    template: '<div class="unnnic-tooltip-stub"><slot /></div>',
+    props: ['enabled', 'text', 'side'],
+  },
+  UnnnicPopover: {
+    name: 'UnnnicPopover',
+    template: '<div class="mock-popover"><slot /></div>',
+    props: ['open'],
+  },
+  UnnnicPopoverTrigger: {
+    name: 'UnnnicPopoverTrigger',
+    template: '<div class="mock-popover-trigger"><slot /></div>',
+  },
+  UnnnicPopoverContent: {
+    name: 'UnnnicPopoverContent',
+    template: '<div class="mock-popover-content"><slot /></div>',
+    props: ['size', 'side', 'align'],
+  },
+};
+
+let AiTextImprovement;
+
+beforeAll(async () => {
+  const mod = await import('../AiTextImprovement.vue');
+  AiTextImprovement = mod.default;
+});
+
+const createWrapper = (options = {}) => {
+  const { inputMessage = '', isLoading = false, showNewTag = true } = options;
+
+  const pinia = createPinia();
+  setActivePinia(pinia);
+
+  const aiStore = useAiTextImprovement();
+  aiStore.isLoading = isLoading;
+  aiStore.showNewTag = showNewTag;
+
+  const msgStore = useMessageManager();
+  msgStore.inputMessage = inputMessage;
+
+  return mount(AiTextImprovement, {
+    global: {
+      plugins: [pinia],
+      mocks: { $t: (key) => key },
+      stubs: unnnicStubs,
+    },
+  });
+};
+
+describe('AiTextImprovement', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  describe('default state (not loading)', () => {
+    it('should render wand_shine button', () => {
+      const wrapper = createWrapper({ inputMessage: 'hello' });
+      const button = wrapper.find(
+        '.ai-text-improvement__button-wrapper button',
+      );
+      expect(button.exists()).toBe(true);
+      expect(button.attributes('data-icon')).toBe('wand_shine');
+    });
+
+    it('should disable button when inputMessage is empty', () => {
+      const wrapper = createWrapper({ inputMessage: '' });
+      const button = wrapper.find(
+        '.ai-text-improvement__button-wrapper button',
+      );
+      expect(button.attributes('data-disabled')).toBe('true');
+    });
+
+    it('should enable button when inputMessage has text', () => {
+      const wrapper = createWrapper({ inputMessage: 'hello' });
+      const button = wrapper.find(
+        '.ai-text-improvement__button-wrapper button',
+      );
+      expect(button.attributes('data-disabled')).toBe('false');
+    });
+
+    it('should render 3 improvement options in the popover', () => {
+      const wrapper = createWrapper({ inputMessage: 'hello' });
+      const items = wrapper.findAll('.ai-text-improvement__popover-item');
+      expect(items).toHaveLength(3);
+    });
+
+    it('should show New tag when showNewTag is true', () => {
+      const wrapper = createWrapper({ showNewTag: true });
+      expect(wrapper.find('.ai-text-improvement__new-tag').exists()).toBe(true);
+    });
+
+    it('should not show New tag when showNewTag is false', () => {
+      const wrapper = createWrapper({ showNewTag: false });
+      expect(wrapper.find('.ai-text-improvement__new-tag').exists()).toBe(
+        false,
+      );
+    });
+
+    it('should hide New tag on mouseenter', async () => {
+      const wrapper = createWrapper({ showNewTag: true });
+      await wrapper.find('.ai-text-improvement').trigger('mouseenter');
+
+      const store = useAiTextImprovement();
+      expect(store.showNewTag).toBe(false);
+    });
+  });
+
+  describe('loading state', () => {
+    it('should show cancel button with close icon when loading', () => {
+      const wrapper = createWrapper({
+        isLoading: true,
+        inputMessage: 'hello',
+      });
+      const cancelButton = wrapper.find(
+        '.ai-text-improvement button[data-icon="close"]',
+      );
+      expect(cancelButton.exists()).toBe(true);
+    });
+
+    it('should not show popover/wand button when loading', () => {
+      const wrapper = createWrapper({
+        isLoading: true,
+        inputMessage: 'hello',
+      });
+      expect(
+        wrapper.find('.ai-text-improvement__button-wrapper').exists(),
+      ).toBe(false);
+    });
+
+    it('should emit improvementCancelled on cancel click', async () => {
+      const wrapper = createWrapper({
+        isLoading: true,
+        inputMessage: 'hello',
+      });
+
+      const cancelButton = wrapper.find(
+        '.ai-text-improvement button[data-icon="close"]',
+      );
+      await cancelButton.trigger('click');
+
+      expect(wrapper.emitted('improvementCancelled')).toBeTruthy();
+    });
+  });
+
+  describe('selecting an option', () => {
+    it('should call requestImprovement and emit improvementReceived on success', async () => {
+      const wrapper = createWrapper({ inputMessage: 'hello' });
+      const store = useAiTextImprovement();
+      store.requestImprovement = vi.fn().mockResolvedValue('improved hello');
+
+      const firstOption = wrapper.find('.ai-text-improvement__popover-item');
+      await firstOption.trigger('click');
+      await flushPromises();
+
+      expect(store.requestImprovement).toHaveBeenCalledWith(
+        'hello',
+        'GRAMMAR_AND_SPELLING',
+      );
+      expect(wrapper.emitted('improvementReceived')?.[0]).toEqual([
+        'improved hello',
+      ]);
+    });
+
+    it('should emit improvementCancelled when requestImprovement returns null', async () => {
+      const wrapper = createWrapper({ inputMessage: 'hello' });
+      const store = useAiTextImprovement();
+      store.requestImprovement = vi.fn().mockResolvedValue(null);
+
+      const firstOption = wrapper.find('.ai-text-improvement__popover-item');
+      await firstOption.trigger('click');
+      await flushPromises();
+
+      expect(wrapper.emitted('improvementCancelled')).toBeTruthy();
+    });
+
+    it('should not call requestImprovement when inputMessage is empty', async () => {
+      const wrapper = createWrapper({ inputMessage: '   ' });
+      const store = useAiTextImprovement();
+      store.requestImprovement = vi.fn();
+
+      const firstOption = wrapper.find('.ai-text-improvement__popover-item');
+      if (firstOption.exists()) {
+        await firstOption.trigger('click');
+        await flushPromises();
+      }
+
+      expect(store.requestImprovement).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/chats/MessageManagerV2/TextBox/__tests__/BackToOriginal.spec.js
+++ b/src/components/chats/MessageManagerV2/TextBox/__tests__/BackToOriginal.spec.js
@@ -1,0 +1,108 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  beforeAll,
+  afterAll,
+} from 'vitest';
+import { mount, config } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+
+import BackToOriginal from '../BackToOriginal.vue';
+import { useAiTextImprovement } from '@/store/modules/chats/aiTextImprovement';
+import { useMessageManager } from '@/store/modules/chats/messageManager';
+import i18n from '@/plugins/i18n';
+
+vi.mock('@/services/api/resources/chats/aiTextImprovement', () => ({
+  default: { improve: vi.fn() },
+}));
+
+vi.mock('@/utils/callUnnnicAlert', () => ({ default: vi.fn() }));
+
+beforeAll(() => {
+  config.global.plugins = (config.global.plugins || []).filter(
+    (plugin) => plugin !== i18n,
+  );
+});
+
+afterAll(() => {
+  if (config.global.plugins && !config.global.plugins.includes(i18n)) {
+    config.global.plugins.push(i18n);
+  }
+});
+
+const createWrapper = (options = {}) => {
+  const { originalText = 'original text', inputMessage = 'improved text' } =
+    options;
+
+  const pinia = createTestingPinia({
+    createSpy: vi.fn,
+    stubActions: false,
+    initialState: {
+      messageManager: { inputMessage },
+      aiTextImprovement: {
+        originalText,
+        improvedText: 'improved text',
+        feedbackStatus: 'USED',
+      },
+    },
+  });
+  setActivePinia(pinia);
+
+  return mount(BackToOriginal, {
+    global: {
+      plugins: [pinia],
+      mocks: { $t: (key) => key },
+      stubs: {
+        UnnnicButton: {
+          name: 'UnnnicButton',
+          template:
+            '<button v-bind="$attrs" @click="$emit(\'click\')"><slot /></button>',
+          props: ['iconLeft', 'type', 'size', 'text'],
+        },
+      },
+    },
+  });
+};
+
+describe('BackToOriginal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render the undo button', () => {
+    const wrapper = createWrapper();
+    const button = wrapper.find('.back-to-original button');
+    expect(button.exists()).toBe(true);
+  });
+
+  it('should render a button component', () => {
+    const wrapper = createWrapper();
+    const btn = wrapper.findComponent({ name: 'UnnnicButton' });
+    expect(btn.exists()).toBe(true);
+  });
+
+  it('should restore original text and set DISCARDED on click', async () => {
+    const wrapper = createWrapper();
+    const aiStore = useAiTextImprovement();
+    const messageStore = useMessageManager();
+
+    await wrapper.find('.back-to-original button').trigger('click');
+
+    expect(messageStore.inputMessage).toBe('original text');
+    expect(aiStore.feedbackStatus).toBe('DISCARDED');
+    expect(aiStore.improvedText).toBe('');
+  });
+
+  it('should emit reverted on click', async () => {
+    const wrapper = createWrapper();
+
+    await wrapper.find('.back-to-original button').trigger('click');
+
+    expect(wrapper.emitted('reverted')).toBeTruthy();
+    expect(wrapper.emitted('reverted').length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/components/chats/MessageManagerV2/TextBox/__tests__/TextArea.spec.js
+++ b/src/components/chats/MessageManagerV2/TextBox/__tests__/TextArea.spec.js
@@ -1,0 +1,144 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  beforeAll,
+  afterAll,
+} from 'vitest';
+import { mount, config } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+
+import TextArea from '../TextArea.vue';
+import { useMessageManager } from '@/store/modules/chats/messageManager';
+import i18n from '@/plugins/i18n';
+
+vi.mock('@/services/api/resources/chats/aiTextImprovement', () => ({
+  default: { improve: vi.fn() },
+}));
+
+vi.mock('@/utils/callUnnnicAlert', () => ({ default: vi.fn() }));
+
+beforeAll(() => {
+  config.global.plugins = (config.global.plugins || []).filter(
+    (plugin) => plugin !== i18n,
+  );
+});
+
+afterAll(() => {
+  if (config.global.plugins && !config.global.plugins.includes(i18n)) {
+    config.global.plugins.push(i18n);
+  }
+});
+
+const createWrapper = (options = {}) => {
+  const {
+    inputMessage = '',
+    isAiImproving = false,
+    isInternalNote = false,
+    mediaUploadFiles = [],
+  } = options;
+
+  const pinia = createTestingPinia({
+    createSpy: vi.fn,
+    stubActions: false,
+    initialState: {
+      messageManager: {
+        inputMessage,
+        isInternalNote,
+        mediaUploadFiles,
+        audioRecorderStatus: 'idle',
+        inputMessageFocused: false,
+      },
+      aiTextImprovement: { isLoading: isAiImproving },
+    },
+  });
+  setActivePinia(pinia);
+
+  return mount(TextArea, {
+    global: {
+      plugins: [pinia],
+      mocks: { $t: (key) => key },
+      stubs: {
+        UnnnicIcon: {
+          name: 'UnnnicIcon',
+          template: '<span class="unnnic-icon" v-bind="$attrs" />',
+          props: ['icon', 'size', 'scheme', 'clickable'],
+        },
+      },
+    },
+  });
+};
+
+describe('TextArea', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('default state', () => {
+    it('should show the textarea when not loading', () => {
+      const wrapper = createWrapper({ inputMessage: 'hello' });
+      expect(wrapper.find('[data-testid="text-area"]').exists()).toBe(true);
+    });
+
+    it('should not show loading animation when not loading', () => {
+      const wrapper = createWrapper();
+      expect(wrapper.find('.text-box__ai-loading-text').exists()).toBe(false);
+    });
+
+    it('should emit keydown on textarea keydown', async () => {
+      const wrapper = createWrapper();
+      const textarea = wrapper.find('[data-testid="text-area"]');
+      await textarea.trigger('keydown', { key: 'a' });
+      expect(wrapper.emitted('keydown')).toBeTruthy();
+    });
+
+    it('should update inputMessage on input', async () => {
+      const wrapper = createWrapper();
+      const store = useMessageManager();
+      const textarea = wrapper.find('[data-testid="text-area"]');
+
+      await textarea.setValue('new text');
+      expect(store.inputMessage).toBe('new text');
+    });
+  });
+
+  describe('AI loading state', () => {
+    it('should show loading animation when AI is improving', () => {
+      const wrapper = createWrapper({ isAiImproving: true });
+      expect(wrapper.find('.text-box__ai-loading-text').exists()).toBe(true);
+    });
+
+    it('should show improving_response text', () => {
+      const wrapper = createWrapper({ isAiImproving: true });
+      expect(wrapper.find('.text-box__ai-loading-text').text()).toBe(
+        'ai_text_improvement.improving_response',
+      );
+    });
+
+    it('should show 3 jumping dots', () => {
+      const wrapper = createWrapper({ isAiImproving: true });
+      const dots = wrapper.findAll('.text-box__ai-loading-dot');
+      expect(dots).toHaveLength(3);
+    });
+
+    it('should hide textarea when AI is improving', () => {
+      const wrapper = createWrapper({ isAiImproving: true });
+      expect(wrapper.find('[data-testid="text-area"]').exists()).toBe(false);
+    });
+  });
+
+  describe('internal note', () => {
+    it('should show internal note close button when isInternalNote', () => {
+      const wrapper = createWrapper({ isInternalNote: true });
+      expect(wrapper.find('.internal-note__close-button').exists()).toBe(true);
+    });
+
+    it('should show internal note prefix', () => {
+      const wrapper = createWrapper({ isInternalNote: true });
+      expect(wrapper.find('.internal-note__prefix').exists()).toBe(true);
+    });
+  });
+});

--- a/src/components/chats/MessageManagerV2/TextBox/__tests__/TextBox.spec.js
+++ b/src/components/chats/MessageManagerV2/TextBox/__tests__/TextBox.spec.js
@@ -1,0 +1,245 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  beforeAll,
+  afterAll,
+} from 'vitest';
+import { mount, config } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+
+import TextBox from '../index.vue';
+import { useMessageManager } from '@/store/modules/chats/messageManager';
+import { useAiTextImprovement } from '@/store/modules/chats/aiTextImprovement';
+import i18n from '@/plugins/i18n';
+
+vi.mock('@/services/api/resources/chats/aiTextImprovement', () => ({
+  default: { improve: vi.fn() },
+}));
+
+vi.mock('@/utils/callUnnnicAlert', () => ({ default: vi.fn() }));
+
+vi.mock('../Medias.vue', () => ({
+  default: {
+    name: 'MessageManagerTextBoxMedias',
+    template: '<div data-testid="medias" />',
+  },
+}));
+
+vi.mock('../AudioRecorder.vue', () => ({
+  default: {
+    name: 'MessageManagerTextBoxAudioRecorder',
+    template: '<div data-testid="audio-recorder" />',
+    methods: { record: vi.fn() },
+  },
+}));
+
+vi.mock('../Actions.vue', () => ({
+  default: {
+    name: 'MessageManagerTextBoxActions',
+    template: `<div data-testid="actions">
+      <button data-testid="send-btn" @click="$emit('send')" />
+      <button data-testid="improvement-received-btn" @click="$emit('improvementReceived', 'improved text')" />
+      <button data-testid="improvement-cancelled-btn" @click="$emit('improvementCancelled')" />
+    </div>`,
+    emits: [
+      'startAudioRecording',
+      'openUploadFiles',
+      'focusInput',
+      'send',
+      'improvementReceived',
+      'improvementCancelled',
+    ],
+  },
+}));
+
+vi.mock('../UploadField.vue', () => ({
+  default: {
+    name: 'MessageManagerTextBoxUploadField',
+    template: '<div data-testid="upload-field" />',
+    methods: { clickInput: vi.fn() },
+  },
+}));
+
+vi.mock('../TextArea.vue', () => ({
+  default: {
+    name: 'MessageManagerTextBoxTextArea',
+    template: '<div data-testid="text-area" />',
+    emits: ['keydown'],
+    methods: { focus: vi.fn() },
+  },
+}));
+
+vi.mock('../BackToOriginal.vue', () => ({
+  default: {
+    name: 'BackToOriginal',
+    template:
+      '<div data-testid="back-to-original" @click="$emit(\'reverted\')" />',
+    emits: ['reverted'],
+  },
+}));
+
+beforeAll(() => {
+  config.global.plugins = (config.global.plugins || []).filter(
+    (plugin) => plugin !== i18n,
+  );
+});
+
+afterAll(() => {
+  if (config.global.plugins && !config.global.plugins.includes(i18n)) {
+    config.global.plugins.push(i18n);
+  }
+});
+
+const createWrapper = (options = {}) => {
+  const {
+    inputMessage = '',
+    isAiLoading = false,
+    improvedText = '',
+    originalText = '',
+    isInternalNote = false,
+    mediaUploadFiles = [],
+  } = options;
+
+  const pinia = createTestingPinia({
+    createSpy: vi.fn,
+    stubActions: false,
+    initialState: {
+      messageManager: {
+        inputMessage,
+        isInternalNote,
+        mediaUploadFiles,
+        audioMessage: null,
+        audioRecorderStatus: 'idle',
+        isEmojiPickerOpen: false,
+        inputMessageFocused: false,
+        isSuggestionBoxOpen: false,
+        isCopilotOpen: false,
+        replyMessage: null,
+      },
+      aiTextImprovement: {
+        isLoading: isAiLoading,
+        improvedText,
+        originalText,
+        feedbackStatus: improvedText ? 'USED' : null,
+      },
+    },
+  });
+  setActivePinia(pinia);
+
+  return mount(TextBox, {
+    global: {
+      plugins: [pinia],
+      mocks: { $t: (key) => key },
+      stubs: {
+        UnnnicEmojiPicker: {
+          name: 'UnnnicEmojiPicker',
+          template: '<div data-testid="emoji-picker" />',
+        },
+      },
+    },
+  });
+};
+
+describe('TextBox (index.vue)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('BackToOriginal visibility', () => {
+    it('should show BackToOriginal when there is improved text and not loading', () => {
+      const wrapper = createWrapper({
+        improvedText: 'improved',
+        originalText: 'original',
+      });
+      expect(wrapper.find('[data-testid="back-to-original"]').exists()).toBe(
+        true,
+      );
+    });
+
+    it('should hide BackToOriginal when loading', () => {
+      const wrapper = createWrapper({
+        improvedText: 'improved',
+        isAiLoading: true,
+      });
+      expect(wrapper.find('[data-testid="back-to-original"]').exists()).toBe(
+        false,
+      );
+    });
+
+    it('should hide BackToOriginal when no improved text', () => {
+      const wrapper = createWrapper({ improvedText: '' });
+      expect(wrapper.find('[data-testid="back-to-original"]').exists()).toBe(
+        false,
+      );
+    });
+
+    it('should show textarea-row wrapper when BackToOriginal is visible', () => {
+      const wrapper = createWrapper({
+        improvedText: 'improved',
+        originalText: 'original',
+      });
+      expect(wrapper.find('.text-box__textarea-row').exists()).toBe(true);
+    });
+
+    it('should not show textarea-row wrapper when BackToOriginal is hidden', () => {
+      const wrapper = createWrapper({ improvedText: '' });
+      expect(wrapper.find('.text-box__textarea-row').exists()).toBe(false);
+    });
+  });
+
+  describe('AI improvement events', () => {
+    it('should set inputMessage when improvementReceived is emitted', async () => {
+      const wrapper = createWrapper({ inputMessage: 'original' });
+      const store = useMessageManager();
+
+      await wrapper
+        .find('[data-testid="improvement-received-btn"]')
+        .trigger('click');
+
+      expect(store.inputMessage).toBe('improved text');
+    });
+
+    it('should restore original text when improvementCancelled is emitted', async () => {
+      const wrapper = createWrapper({
+        inputMessage: 'current',
+        originalText: 'the original',
+        improvedText: 'the improved',
+      });
+      const store = useMessageManager();
+
+      await wrapper
+        .find('[data-testid="improvement-cancelled-btn"]')
+        .trigger('click');
+
+      expect(store.inputMessage).toBe('the original');
+    });
+  });
+
+  describe('CSS classes', () => {
+    it('should add ai-improving class when loading', () => {
+      const wrapper = createWrapper({ isAiLoading: true });
+      expect(wrapper.find('.text-box--ai-improving').exists()).toBe(true);
+    });
+
+    it('should not add ai-improving class when not loading', () => {
+      const wrapper = createWrapper({ isAiLoading: false });
+      expect(wrapper.find('.text-box--ai-improving').exists()).toBe(false);
+    });
+
+    it('should add internal-note class when in internal note mode', () => {
+      const wrapper = createWrapper({ isInternalNote: true });
+      expect(wrapper.find('.internal-note').exists()).toBe(true);
+    });
+  });
+
+  describe('TextArea rendering', () => {
+    it('should always render TextArea component', () => {
+      const wrapper = createWrapper();
+      expect(wrapper.find('[data-testid="text-area"]').exists()).toBe(true);
+    });
+  });
+});

--- a/src/components/chats/MessageManagerV2/TextBox/index.vue
+++ b/src/components/chats/MessageManagerV2/TextBox/index.vue
@@ -4,6 +4,7 @@
       'text-box',
       {
         'text-box--focused': inputMessageFocused,
+        'text-box--ai-improving': isAiImproving,
         'internal-note': isInternalNote,
       },
     ]"
@@ -22,6 +23,8 @@
       @open-upload-files="uploadFieldRef.clickInput()"
       @focus-input="focus"
       @send="handleSend"
+      @improvement-received="handleImprovementReceived"
+      @improvement-cancelled="handleImprovementCancelled"
     />
     <UnnnicEmojiPicker
       v-show="isEmojiPickerOpen"
@@ -44,6 +47,7 @@ import MessageManagerTextBoxUploadField from './UploadField.vue';
 import MessageManagerTextBoxTextArea from './TextArea.vue';
 
 import { useMessageManager } from '@/store/modules/chats/messageManager';
+import { useAiTextImprovement } from '@/store/modules/chats/aiTextImprovement';
 
 defineOptions({
   name: 'MessageManagerTextBox',
@@ -65,6 +69,9 @@ const {
   isEmojiPickerOpen,
   inputMessageFocused,
 } = storeToRefs(messageManager);
+
+const aiTextImprovementStore = useAiTextImprovement();
+const { isLoading: isAiImproving } = storeToRefs(aiTextImprovementStore);
 
 const textareaRef = useTemplateRef('textArea');
 const audioRecorderRef = useTemplateRef('audioRecorder');
@@ -102,6 +109,19 @@ const handleSend = async () => {
   }
 };
 
+const handleImprovementReceived = (improvedText: string) => {
+  inputMessage.value = improvedText;
+  focus();
+};
+
+const handleImprovementCancelled = () => {
+  const original = aiTextImprovementStore.originalText;
+  if (original) {
+    inputMessage.value = original;
+  }
+  focus();
+};
+
 const clearTextarea = () => {
   inputMessage.value = '';
   audioMessage.value = null;
@@ -130,6 +150,9 @@ defineExpose({
 
   &--focused {
     border-color: $unnnic-color-border-active;
+  }
+  &--ai-improving {
+    border-color: $unnnic-color-border-accent-strong;
   }
   &.internal-note {
     background-color: $unnnic-color-bg-warning;

--- a/src/components/chats/MessageManagerV2/TextBox/index.vue
+++ b/src/components/chats/MessageManagerV2/TextBox/index.vue
@@ -12,7 +12,18 @@
     <MessageManagerTextBoxUploadField ref="uploadField" />
     <MessageManagerTextBoxMedias v-if="mediaUploadFiles.length > 0" />
     <MessageManagerTextBoxAudioRecorder ref="audioRecorder" />
+    <section
+      v-if="showBackToOriginal"
+      class="text-box__textarea-row"
+    >
+      <MessageManagerTextBoxTextArea
+        ref="textArea"
+        @keydown="handleKeyDown"
+      />
+      <BackToOriginal @reverted="focus" />
+    </section>
     <MessageManagerTextBoxTextArea
+      v-else
       ref="textArea"
       @keydown="handleKeyDown"
     />
@@ -36,7 +47,7 @@
 </template>
 
 <script setup lang="ts">
-import { useTemplateRef, watch } from 'vue';
+import { computed, useTemplateRef, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 import { vOnClickOutside } from '@vueuse/components';
 
@@ -45,6 +56,7 @@ import MessageManagerTextBoxAudioRecorder from './AudioRecorder.vue';
 import MessageManagerTextBoxActions from './Actions.vue';
 import MessageManagerTextBoxUploadField from './UploadField.vue';
 import MessageManagerTextBoxTextArea from './TextArea.vue';
+import BackToOriginal from './BackToOriginal.vue';
 
 import { useMessageManager } from '@/store/modules/chats/messageManager';
 import { useAiTextImprovement } from '@/store/modules/chats/aiTextImprovement';
@@ -71,7 +83,13 @@ const {
 } = storeToRefs(messageManager);
 
 const aiTextImprovementStore = useAiTextImprovement();
-const { isLoading: isAiImproving } = storeToRefs(aiTextImprovementStore);
+const { isLoading: isAiImproving, hasImprovedText } = storeToRefs(
+  aiTextImprovementStore,
+);
+
+const showBackToOriginal = computed(
+  () => hasImprovedText.value && !isAiImproving.value,
+);
 
 const textareaRef = useTemplateRef('textArea');
 const audioRecorderRef = useTemplateRef('audioRecorder');
@@ -158,6 +176,13 @@ defineExpose({
     background-color: $unnnic-color-bg-warning;
     border-color: $unnnic-color-border-warning;
   }
+  &__textarea-row {
+    display: flex;
+    align-items: stretch;
+    gap: $unnnic-space-2;
+    width: 100%;
+  }
+
   &__divider {
     border: 1px solid $unnnic-color-border-soft;
     width: 100%;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -519,6 +519,18 @@
   "no_tags_assigned": "No tags assigned",
   "contact_await_for_you": "A contact is waiting for you!",
   "agent": "Agent",
+  "ai_text_improvement": {
+    "tooltip_disabled": "Write a response in the text field to enable improved responses with AI",
+    "tooltip_enabled": "Improve response with AI",
+    "tooltip_cancel": "Cancel AI response improvement",
+    "fix_grammar_and_spelling": "Fix grammar & spelling",
+    "make_more_empathetic": "Make more empathetic",
+    "rewrite_for_clarity": "Rewrite for clarity",
+    "improving_response": "Improving your response",
+    "improvement": "Improvement",
+    "error": "Error improving response with AI. Try again.",
+    "new": "New"
+  },
   "manager": "Manager",
   "you": "You",
   "queue": "Queue",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -529,7 +529,9 @@
     "improving_response": "Improving your response",
     "improvement": "Improvement",
     "error": "Error improving response with AI. Try again.",
-    "new": "New"
+    "new": "New",
+    "back_to_original": "Original",
+    "back_to_original_tooltip": "Return to original version (Ctrl+Z)"
   },
   "manager": "Manager",
   "you": "You",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -525,7 +525,9 @@
     "improving_response": "Mejorando tu respuesta",
     "improvement": "Mejora",
     "error": "Error al mejorar respuesta con IA. Inténtalo de nuevo.",
-    "new": "Nuevo"
+    "new": "Nuevo",
+    "back_to_original": "Original",
+    "back_to_original_tooltip": "Volver a la versión original (Ctrl+Z)"
   },
   "manager": "Gerente",
   "you": "Tú",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -515,6 +515,18 @@
   "no_tags_assigned": "No se han asignado etiquetas",
   "contact_await_for_you": "¡Un contacto está esperando por ti!",
   "agent": "Agente",
+  "ai_text_improvement": {
+    "tooltip_disabled": "Escribe una respuesta en el campo de texto para habilitar mejoras de respuestas con IA",
+    "tooltip_enabled": "Mejorar respuesta con IA",
+    "tooltip_cancel": "Cancelar mejora de respuesta con IA",
+    "fix_grammar_and_spelling": "Corregir gramática y ortografía",
+    "make_more_empathetic": "Hacer más empática",
+    "rewrite_for_clarity": "Reescribir con claridad",
+    "improving_response": "Mejorando tu respuesta",
+    "improvement": "Mejora",
+    "error": "Error al mejorar respuesta con IA. Inténtalo de nuevo.",
+    "new": "Nuevo"
+  },
   "manager": "Gerente",
   "you": "Tú",
   "queue": "Cola",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -515,6 +515,18 @@
   "no_tags_assigned": "Nenhuma tag atribuída",
   "contact_await_for_you": "Um contato está esperando por você!",
   "agent": "Atendente",
+  "ai_text_improvement": {
+    "tooltip_disabled": "Escreva uma resposta no campo de texto para habilitar melhorias de respostas com IA",
+    "tooltip_enabled": "Melhorar resposta com IA",
+    "tooltip_cancel": "Cancelar melhoria de resposta com IA",
+    "fix_grammar_and_spelling": "Corrigir gramática e ortografia",
+    "make_more_empathetic": "Tornar mais empática",
+    "rewrite_for_clarity": "Reescrever com clareza",
+    "improving_response": "Melhorando sua resposta",
+    "improvement": "Melhoria",
+    "error": "Erro ao melhorar resposta com IA. Tente novamente.",
+    "new": "Novo"
+  },
   "manager": "Gerente",
   "you": "Você",
   "queue": "Fila",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -525,7 +525,9 @@
     "improving_response": "Melhorando sua resposta",
     "improvement": "Melhoria",
     "error": "Erro ao melhorar resposta com IA. Tente novamente.",
-    "new": "Novo"
+    "new": "Novo",
+    "back_to_original": "Original",
+    "back_to_original_tooltip": "Voltar para a versão original (Ctrl+Z)"
   },
   "manager": "Gerente",
   "you": "Você",

--- a/src/services/api/resources/chats/aiTextImprovement.ts
+++ b/src/services/api/resources/chats/aiTextImprovement.ts
@@ -1,0 +1,29 @@
+import http from '@/services/api/http';
+
+export type AiTextImprovementType =
+  | 'GRAMMAR_AND_SPELLING'
+  | 'MORE_EMPATHY'
+  | 'CLARITY';
+
+interface ImproveRequest {
+  text: string;
+  type: AiTextImprovementType;
+}
+
+interface ImproveResponse {
+  text: string;
+}
+
+export default {
+  async improve(
+    { text, type }: ImproveRequest,
+    { signal }: { signal?: AbortSignal } = {},
+  ): Promise<ImproveResponse> {
+    const response = await http.post(
+      '/ai_features/ai_text_improvement/',
+      { text, type },
+      { signal },
+    );
+    return response.data;
+  },
+};

--- a/src/services/api/resources/chats/aiTextImprovement.ts
+++ b/src/services/api/resources/chats/aiTextImprovement.ts
@@ -16,7 +16,7 @@ interface ImproveResponse {
 }
 
 // TODO: Remove mock and uncomment real implementation when backend is ready
-const USE_MOCK = true;
+const USE_MOCK = false;
 
 const MOCK_RESPONSES: Record<AiTextImprovementType, (text: string) => string> =
   {

--- a/src/services/api/resources/chats/aiTextImprovement.ts
+++ b/src/services/api/resources/chats/aiTextImprovement.ts
@@ -15,48 +15,12 @@ interface ImproveResponse {
   text: string;
 }
 
-// TODO: Remove mock and uncomment real implementation when backend is ready
-const USE_MOCK = false;
-
-const MOCK_RESPONSES: Record<AiTextImprovementType, (text: string) => string> =
-  {
-    GRAMMAR_AND_SPELLING: (text) =>
-      `[Grammar fixed] ${text.charAt(0).toUpperCase()}${text.slice(1)}.`,
-    MORE_EMPATHY: (text) =>
-      `[More empathetic] I completely understand your concern. ${text}`,
-    CLARITY: (text) => `[Clearer] To summarize: ${text}`,
-  };
-
-function mockImprove(
-  {
-    text,
-    type,
-  }: { text: string; type: AiTextImprovementType; projectUuid: string },
-  { signal }: { signal?: AbortSignal } = {},
-): Promise<ImproveResponse> {
-  return new Promise((resolve, reject) => {
-    const timeout = setTimeout(
-      () => resolve({ text: MOCK_RESPONSES[type](text) }),
-      5000,
-    );
-
-    signal?.addEventListener('abort', () => {
-      clearTimeout(timeout);
-      reject(new DOMException('The operation was aborted.', 'AbortError'));
-    });
-  });
-}
-
 export default {
   async improve(
     { text, type }: ImproveRequest,
     { signal }: { signal?: AbortSignal } = {},
   ): Promise<ImproveResponse> {
     const projectUuid = getProject();
-
-    if (USE_MOCK) {
-      return mockImprove({ text, type, projectUuid }, { signal });
-    }
 
     const response = await http.post(
       '/ai_features/ai_text_improvement/',

--- a/src/services/api/resources/chats/aiTextImprovement.ts
+++ b/src/services/api/resources/chats/aiTextImprovement.ts
@@ -14,11 +14,44 @@ interface ImproveResponse {
   text: string;
 }
 
+// TODO: Remove mock and uncomment real implementation when backend is ready
+const USE_MOCK = true;
+
+const MOCK_RESPONSES: Record<AiTextImprovementType, (text: string) => string> =
+  {
+    GRAMMAR_AND_SPELLING: (text) =>
+      `[Grammar fixed] ${text.charAt(0).toUpperCase()}${text.slice(1)}.`,
+    MORE_EMPATHY: (text) =>
+      `[More empathetic] I completely understand your concern. ${text}`,
+    CLARITY: (text) => `[Clearer] To summarize: ${text}`,
+  };
+
+function mockImprove(
+  { text, type }: ImproveRequest,
+  { signal }: { signal?: AbortSignal } = {},
+): Promise<ImproveResponse> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(
+      () => resolve({ text: MOCK_RESPONSES[type](text) }),
+      5000,
+    );
+
+    signal?.addEventListener('abort', () => {
+      clearTimeout(timeout);
+      reject(new DOMException('The operation was aborted.', 'AbortError'));
+    });
+  });
+}
+
 export default {
   async improve(
     { text, type }: ImproveRequest,
     { signal }: { signal?: AbortSignal } = {},
   ): Promise<ImproveResponse> {
+    if (USE_MOCK) {
+      return mockImprove({ text, type }, { signal });
+    }
+
     const response = await http.post(
       '/ai_features/ai_text_improvement/',
       { text, type },

--- a/src/services/api/resources/chats/aiTextImprovement.ts
+++ b/src/services/api/resources/chats/aiTextImprovement.ts
@@ -1,4 +1,5 @@
 import http from '@/services/api/http';
+import { getProject } from '@/utils/config';
 
 export type AiTextImprovementType =
   | 'GRAMMAR_AND_SPELLING'
@@ -27,7 +28,10 @@ const MOCK_RESPONSES: Record<AiTextImprovementType, (text: string) => string> =
   };
 
 function mockImprove(
-  { text, type }: ImproveRequest,
+  {
+    text,
+    type,
+  }: { text: string; type: AiTextImprovementType; projectUuid: string },
   { signal }: { signal?: AbortSignal } = {},
 ): Promise<ImproveResponse> {
   return new Promise((resolve, reject) => {
@@ -48,13 +52,15 @@ export default {
     { text, type }: ImproveRequest,
     { signal }: { signal?: AbortSignal } = {},
   ): Promise<ImproveResponse> {
+    const projectUuid = getProject();
+
     if (USE_MOCK) {
-      return mockImprove({ text, type }, { signal });
+      return mockImprove({ text, type, projectUuid }, { signal });
     }
 
     const response = await http.post(
       '/ai_features/ai_text_improvement/',
-      { text, type },
+      { text, type, project_uuid: projectUuid },
       { signal },
     );
     return response.data;

--- a/src/services/api/resources/chats/message.js
+++ b/src/services/api/resources/chats/message.js
@@ -78,14 +78,23 @@ export default {
     return response.data;
   },
 
-  async sendRoomMessage(roomId, { text, user_email, seen, repliedMessageId }) {
-    const response = await http.post('/msg/', {
+  async sendRoomMessage(
+    roomId,
+    { text, user_email, seen, repliedMessageId, aiTextImprovement },
+  ) {
+    const payload = {
       room: roomId,
       text,
       user_email,
       seen,
       replied_message_id: repliedMessageId,
-    });
+    };
+
+    if (aiTextImprovement) {
+      payload.ai_text_improvement = aiTextImprovement;
+    }
+
+    const response = await http.post('/msg/', payload);
     return response.data;
   },
 

--- a/src/store/modules/chats/__tests__/aiTextImprovement.spec.js
+++ b/src/store/modules/chats/__tests__/aiTextImprovement.spec.js
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { useAiTextImprovement } from '../aiTextImprovement';
+
+vi.mock('@/services/api/resources/chats/aiTextImprovement', () => ({
+  default: { improve: vi.fn() },
+}));
+
+vi.mock('@/utils/callUnnnicAlert', () => ({ default: vi.fn() }));
+
+vi.mock('@/plugins/i18n', () => ({
+  default: { global: { t: (key) => key } },
+}));
+
+let mockImprove;
+let mockCallAlert;
+
+describe('aiTextImprovement store', () => {
+  let store;
+
+  beforeEach(async () => {
+    setActivePinia(createPinia());
+
+    const apiModule = await import(
+      '@/services/api/resources/chats/aiTextImprovement'
+    );
+    mockImprove = apiModule.default.improve;
+
+    const alertModule = await import('@/utils/callUnnnicAlert');
+    mockCallAlert = alertModule.default;
+
+    store = useAiTextImprovement();
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('initial state', () => {
+    it('should have correct default values', () => {
+      expect(store.isLoading).toBe(false);
+      expect(store.isPopoverOpen).toBe(false);
+      expect(store.selectedType).toBeNull();
+      expect(store.improvedText).toBe('');
+      expect(store.originalText).toBe('');
+      expect(store.feedbackStatus).toBeNull();
+      expect(store.hasImprovedText).toBe(false);
+    });
+
+    it('should set showNewTag to true when localStorage has no value', () => {
+      expect(store.showNewTag).toBe(true);
+    });
+
+    it('should set showNewTag to false when localStorage has the flag', () => {
+      localStorage.setItem('ai_text_improvement_new_tag_seen', 'true');
+      setActivePinia(createPinia());
+      const freshStore = useAiTextImprovement();
+      expect(freshStore.showNewTag).toBe(false);
+    });
+  });
+
+  describe('hideNewTag', () => {
+    it('should set showNewTag to false and persist to localStorage', () => {
+      store.hideNewTag();
+      expect(store.showNewTag).toBe(false);
+      expect(localStorage.getItem('ai_text_improvement_new_tag_seen')).toBe(
+        'true',
+      );
+    });
+  });
+
+  describe('getAiTextImprovementPayload', () => {
+    it('should return null when selectedType is not set', () => {
+      store.feedbackStatus = 'USED';
+      expect(store.getAiTextImprovementPayload('text')).toBeNull();
+    });
+
+    it('should return null when feedbackStatus is not set', () => {
+      store.selectedType = 'CLARITY';
+      expect(store.getAiTextImprovementPayload('text')).toBeNull();
+    });
+
+    it('should return USED when text matches improvedText', () => {
+      store.selectedType = 'CLARITY';
+      store.feedbackStatus = 'USED';
+      store.improvedText = 'improved';
+
+      const payload = store.getAiTextImprovementPayload('improved');
+      expect(payload).toEqual({ status: 'USED', type: 'CLARITY' });
+    });
+
+    it('should return EDITED when text differs from improvedText', () => {
+      store.selectedType = 'GRAMMAR_AND_SPELLING';
+      store.feedbackStatus = 'USED';
+      store.improvedText = 'improved';
+
+      const payload = store.getAiTextImprovementPayload('edited text');
+      expect(payload).toEqual({
+        status: 'EDITED',
+        type: 'GRAMMAR_AND_SPELLING',
+      });
+    });
+
+    it('should return feedbackStatus directly for non-USED statuses', () => {
+      store.selectedType = 'MORE_EMPATHY';
+      store.feedbackStatus = 'DISCARDED';
+      store.improvedText = 'improved';
+
+      const payload = store.getAiTextImprovementPayload('original');
+      expect(payload).toEqual({ status: 'DISCARDED', type: 'MORE_EMPATHY' });
+    });
+  });
+
+  describe('requestImprovement', () => {
+    it('should call API and return improved text on success', async () => {
+      mockImprove.mockResolvedValue({ text: 'better text' });
+
+      const result = await store.requestImprovement('hello', 'CLARITY');
+
+      expect(mockImprove).toHaveBeenCalledWith(
+        { text: 'hello', type: 'CLARITY' },
+        { signal: expect.any(AbortSignal) },
+      );
+      expect(result).toBe('better text');
+      expect(store.improvedText).toBe('better text');
+      expect(store.originalText).toBe('hello');
+      expect(store.selectedType).toBe('CLARITY');
+      expect(store.feedbackStatus).toBe('USED');
+      expect(store.isLoading).toBe(false);
+    });
+
+    it('should close popover and set loading during request', async () => {
+      let resolvePromise;
+      mockImprove.mockImplementation(
+        () => new Promise((resolve) => (resolvePromise = resolve)),
+      );
+
+      const promise = store.requestImprovement('hello', 'CLARITY');
+      expect(store.isPopoverOpen).toBe(false);
+      expect(store.isLoading).toBe(true);
+
+      resolvePromise({ text: 'done' });
+      await promise;
+      expect(store.isLoading).toBe(false);
+    });
+
+    it('should show alert on API error and return null', async () => {
+      mockImprove.mockRejectedValue(new Error('Network error'));
+
+      const result = await store.requestImprovement('hello', 'CLARITY');
+
+      expect(result).toBeNull();
+      expect(mockCallAlert).toHaveBeenCalledWith({
+        props: {
+          text: 'ai_text_improvement.error',
+          type: 'error',
+        },
+      });
+      expect(store.isLoading).toBe(false);
+    });
+
+    it('should return null without alert on abort', async () => {
+      mockImprove.mockRejectedValue(
+        new DOMException('Aborted', 'AbortError'),
+      );
+
+      const result = await store.requestImprovement('hello', 'CLARITY');
+
+      expect(result).toBeNull();
+      expect(mockCallAlert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cancelImprovement', () => {
+    it('should abort the controller and reset loading state', async () => {
+      let resolvePromise;
+      mockImprove.mockImplementation(
+        () => new Promise((resolve) => (resolvePromise = resolve)),
+      );
+
+      const promise = store.requestImprovement('hello', 'CLARITY');
+      expect(store.isLoading).toBe(true);
+
+      store.cancelImprovement();
+      expect(store.isLoading).toBe(false);
+      expect(store.feedbackStatus).toBeNull();
+
+      resolvePromise({ text: 'done' });
+      await promise.catch(() => {});
+    });
+  });
+
+  describe('reset', () => {
+    it('should clear all state', () => {
+      store.isLoading = true;
+      store.isPopoverOpen = true;
+      store.selectedType = 'CLARITY';
+      store.improvedText = 'improved';
+      store.originalText = 'original';
+      store.feedbackStatus = 'USED';
+
+      store.reset();
+
+      expect(store.isLoading).toBe(false);
+      expect(store.isPopoverOpen).toBe(false);
+      expect(store.selectedType).toBeNull();
+      expect(store.improvedText).toBe('');
+      expect(store.originalText).toBe('');
+      expect(store.feedbackStatus).toBeNull();
+    });
+  });
+
+  describe('hasImprovedText', () => {
+    it('should return true when improvedText has a value', () => {
+      store.improvedText = 'some text';
+      expect(store.hasImprovedText).toBe(true);
+    });
+
+    it('should return false when improvedText is empty', () => {
+      store.improvedText = '';
+      expect(store.hasImprovedText).toBe(false);
+    });
+  });
+});

--- a/src/store/modules/chats/__tests__/roomMessages.spec.js
+++ b/src/store/modules/chats/__tests__/roomMessages.spec.js
@@ -86,6 +86,8 @@ describe('useRoomMessages Store', () => {
         seen: true,
         text: 'Hello',
         user_email: roomStore.activeRoom.user.email,
+        aiTextImprovement: null,
+        repliedMessageId: undefined,
       },
     );
   });

--- a/src/store/modules/chats/aiTextImprovement.ts
+++ b/src/store/modules/chats/aiTextImprovement.ts
@@ -1,0 +1,131 @@
+import { ref, computed } from 'vue';
+import { defineStore } from 'pinia';
+
+import AiTextImprovement from '@/services/api/resources/chats/aiTextImprovement';
+import type { AiTextImprovementType } from '@/services/api/resources/chats/aiTextImprovement';
+
+import callUnnnicAlert from '@/utils/callUnnnicAlert';
+import i18n from '@/plugins/i18n';
+
+export type AiTextImprovementFeedback = 'USED' | 'DISCARDED' | 'EDITED';
+
+const LOCAL_STORAGE_KEY = 'ai_text_improvement_new_tag_seen';
+
+export const useAiTextImprovement = defineStore('aiTextImprovement', () => {
+  const { t } = i18n.global;
+
+  const isLoading = ref(false);
+  const isPopoverOpen = ref(false);
+  const selectedType = ref<AiTextImprovementType | null>(null);
+  const improvedText = ref('');
+  const originalText = ref('');
+  const abortController = ref<AbortController | null>(null);
+
+  const showNewTag = ref(localStorage.getItem(LOCAL_STORAGE_KEY) !== 'true');
+
+  const feedbackStatus = ref<AiTextImprovementFeedback | null>(null);
+
+  const hasImprovedText = computed(() => !!improvedText.value);
+
+  function hideNewTag() {
+    showNewTag.value = false;
+    localStorage.setItem(LOCAL_STORAGE_KEY, 'true');
+  }
+
+  function getAiTextImprovementPayload(currentText: string) {
+    if (!selectedType.value || !feedbackStatus.value) return null;
+
+    if (feedbackStatus.value === 'USED') {
+      const wasEdited = currentText !== improvedText.value;
+      return {
+        status: wasEdited ? 'EDITED' : 'USED',
+        type: selectedType.value,
+      };
+    }
+
+    return {
+      status: feedbackStatus.value,
+      type: selectedType.value,
+    };
+  }
+
+  async function requestImprovement(text: string, type: AiTextImprovementType) {
+    isPopoverOpen.value = false;
+    isLoading.value = true;
+    selectedType.value = type;
+    originalText.value = text;
+    feedbackStatus.value = null;
+
+    abortController.value = new AbortController();
+
+    try {
+      const response = await AiTextImprovement.improve(
+        { text, type },
+        { signal: abortController.value.signal },
+      );
+
+      improvedText.value = response.text;
+      feedbackStatus.value = 'USED';
+
+      return response.text;
+    } catch (error: unknown) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        return null;
+      }
+
+      callUnnnicAlert({
+        props: {
+          text: t('ai_text_improvement.error'),
+          type: 'error',
+        },
+      });
+
+      return null;
+    } finally {
+      isLoading.value = false;
+      abortController.value = null;
+    }
+  }
+
+  function cancelImprovement() {
+    if (abortController.value) {
+      abortController.value.abort();
+      abortController.value = null;
+    }
+
+    isLoading.value = false;
+    feedbackStatus.value = null;
+  }
+
+  function reset() {
+    isLoading.value = false;
+    isPopoverOpen.value = false;
+    selectedType.value = null;
+    improvedText.value = '';
+    originalText.value = '';
+    feedbackStatus.value = null;
+
+    if (abortController.value) {
+      abortController.value.abort();
+      abortController.value = null;
+    }
+  }
+
+  return {
+    isLoading,
+    isPopoverOpen,
+    selectedType,
+    improvedText,
+    originalText,
+    showNewTag,
+    feedbackStatus,
+
+    hasImprovedText,
+
+    hideNewTag,
+    getAiTextImprovementPayload,
+    requestImprovement,
+    cancelImprovement,
+    reset,
+  };
+});

--- a/src/store/modules/chats/messageManager.ts
+++ b/src/store/modules/chats/messageManager.ts
@@ -5,6 +5,7 @@ import { useRooms } from './rooms';
 import { useDiscussions } from './discussions';
 import { useRoomMessages } from './roomMessages';
 import { useDiscussionMessages } from './discussionMessages';
+import { useAiTextImprovement } from './aiTextImprovement';
 
 import i18n from '@/plugins/i18n';
 
@@ -50,6 +51,9 @@ export const useMessageManager = defineStore('messageManager', () => {
     isCopilotOpen.value = false;
     isEmojiPickerOpen.value = false;
     replyMessage.value = null;
+
+    const aiTextImprovementStore = useAiTextImprovement();
+    aiTextImprovementStore.reset();
   }
 
   const isLoadingSend = ref(false);
@@ -80,11 +84,21 @@ export const useMessageManager = defineStore('messageManager', () => {
   async function sendTextMessage(repliedMessage) {
     const message = inputMessage.value.trim();
     if (message) {
+      const aiTextImprovementStore = useAiTextImprovement();
+      const aiTextImprovementPayload =
+        aiTextImprovementStore.getAiTextImprovementPayload(message);
+
       clearInputs();
+      aiTextImprovementStore.reset();
+
       if (discussionsStore.activeDiscussion?.uuid) {
         await discussionMessagesStore.sendDiscussionMessage(message);
       } else {
-        await roomMessagesStore.sendRoomMessage(message, repliedMessage);
+        await roomMessagesStore.sendRoomMessage(
+          message,
+          repliedMessage,
+          aiTextImprovementPayload,
+        );
       }
     }
   }

--- a/src/store/modules/chats/roomMessages.js
+++ b/src/store/modules/chats/roomMessages.js
@@ -222,7 +222,7 @@ export const useRoomMessages = defineStore('roomMessages', {
       }
     },
 
-    async sendRoomMessage(text, repliedMessage) {
+    async sendRoomMessage(text, repliedMessage, aiTextImprovement = null) {
       const roomsStore = useRooms();
       const { activeRoom } = roomsStore;
 
@@ -240,6 +240,7 @@ export const useRoomMessages = defineStore('roomMessages', {
             user_email: activeRoom.user.email,
             seen: true,
             repliedMessageId: repliedMessage?.uuid,
+            aiTextImprovement,
           }),
         addMessage: (message) => this.handlingAddMessage({ message }),
         addSortedMessage: (message) => this.addRoomMessageSorted({ message }),

--- a/src/store/modules/featureFlag.js
+++ b/src/store/modules/featureFlag.js
@@ -3,7 +3,7 @@ import FeatureFlag from '@/services/api/resources/featureFlag/featureFlag';
 
 export const useFeatureFlag = defineStore('featureFlag', {
   state: () => ({
-    featureFlags: {},
+    featureFlags: /** @type {{ active_features?: string[] }} */ ({}),
     isLoadingFeatureFlags: false,
   }),
 


### PR DESCRIPTION
## Description
### Type of Change
* [x] Feature
* [x] Tests

### Motivation and Context
Agents need the ability to improve their responses using AI before sending them to contacts. This feature enables grammar/spelling correction, empathy enhancement, and clarity rewriting directly from the message input, improving the overall quality of agent communications.

### Summary of Changes

**New AI Text Improvement feature** gated behind `weniChatsAiTextImprovement` feature flag:

- Added a new `wand_shine` button in the message input action bar (between quick messages and emoji) that opens a popover with 3 improvement options: Fix grammar & spelling, Make more empathetic, Rewrite for clarity
- Button is only enabled when there is text in the input field; shows contextual tooltips for both disabled and enabled states
- "New" tag badge appears on the button until the user hovers over it (persisted via localStorage)
- While AI generates the improvement, the textarea shows an animated "Improving your response..." loading state with jumping dots, the input border changes to accent color, and the button transforms into a cancel button
- On success, the improved text replaces the input content; on error, an error toast is shown and original text is restored
- "Back to original" undo button appears next to the textarea after improvement, allowing the user to revert to the original text
- Cancel button allows aborting the AI request mid-flight via AbortController

**API integration:**
- `POST /v1/ai_features/ai_text_improvement/` for generating improvements (with temporary mock for testing)
- `POST /v1/msg/` now accepts optional `ai_text_improvement` payload with `status` (USED/EDITED/DISCARDED) and `type` (GRAMMAR_AND_SPELLING/MORE_EMPATHY/CLARITY)

**Files created:**
- `src/services/api/resources/chats/aiTextImprovement.ts` — API service
- `src/store/modules/chats/aiTextImprovement.ts` — Pinia store managing the full lifecycle
- `src/components/chats/MessageManagerV2/TextBox/AiTextImprovement.vue` — Button + popover + cancel component
- `src/components/chats/MessageManagerV2/TextBox/BackToOriginal.vue` — Undo/revert component

**Files modified:**
- `src/components/chats/MessageManagerV2/TextBox/Actions.vue` — Integrated AI button via `insertAiAfter` flag, updated gap to 8px
- `src/components/chats/MessageManagerV2/TextBox/index.vue` — Added BackToOriginal, AI loading border, improvement event handlers
- `src/components/chats/MessageManagerV2/TextBox/TextArea.vue` — Added AI loading animation state
- `src/store/modules/chats/messageManager.ts` — Passes `ai_text_improvement` payload on send, resets AI store on clearInputs
- `src/store/modules/chats/roomMessages.js` — Forwards `aiTextImprovement` parameter
- `src/services/api/resources/chats/message.js` — Includes `ai_text_improvement` in POST body
- `src/store/modules/featureFlag.js` — Added JSDoc type for `featureFlags` state
- `src/locales/en.json`, `pt_br.json`, `es.json` — Added all translations for the feature

**Tests (62 new tests across 6 files):**
- `src/store/modules/chats/__tests__/aiTextImprovement.spec.js` (17 tests)
- `src/components/chats/MessageManagerV2/TextBox/__tests__/AiTextImprovement.spec.js` (13 tests)
- `src/components/chats/MessageManagerV2/TextBox/__tests__/BackToOriginal.spec.js` (4 tests)
- `src/components/chats/MessageManagerV2/TextBox/__tests__/Actions.spec.js` (7 tests)
- `src/components/chats/MessageManagerV2/TextBox/__tests__/TextArea.spec.js` (10 tests)
- `src/components/chats/MessageManagerV2/TextBox/__tests__/TextBox.spec.js` (11 tests)
- Updated `src/store/modules/chats/__tests__/roomMessages.spec.js` to match new parameter signature


### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File](https://www.figma.com/design/IAXGYmgDyjLzHavOtX0ram/Live-Desk----General-improvements--2026-?node-id=290-2&m=dev)

### Demonstration <!--- (If not appropriate, remove this topic) -->
<!--- Include a screenshot or video showcasing a feature or fix implemented in this pull request. -->

<img width="1070" height="158" alt="image" src="https://github.com/user-attachments/assets/5df348de-f8b0-4993-aac2-9501e3732368" />
<img width="1012" height="167" alt="image" src="https://github.com/user-attachments/assets/93991621-663f-47fb-b30b-a3ca74d9a606" />


