### PR TITLE
[ENGAGE-7798] Feat: history search improvement

### DIFF
--- a/src/utils/__tests__/room.spec.js
+++ b/src/utils/__tests__/room.spec.js
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getRoomType,
+  parseUrn,
+  sanitizeDocument,
+  buildHistorySearchTerm,
+} from '@/utils/room';
+
+describe('room utils', () => {
+  describe('getRoomType', () => {
+    it('returns "waiting" when not waiting and no user', () => {
+      expect(getRoomType({ is_waiting: false, user: null })).toBe('waiting');
+    });
+
+    it('returns "ongoing" when user exists and not waiting', () => {
+      expect(getRoomType({ is_waiting: false, user: { id: 1 } })).toBe(
+        'ongoing',
+      );
+    });
+
+    it('returns "flow_start" when is_waiting', () => {
+      expect(getRoomType({ is_waiting: true, user: null })).toBe('flow_start');
+    });
+  });
+
+  describe('parseUrn', () => {
+    it('returns empty object when room has no urn', () => {
+      expect(parseUrn({})).toEqual({});
+      expect(parseUrn(null)).toEqual({});
+      expect(parseUrn({ urn: '' })).toEqual({});
+    });
+
+    it('parses whatsapp urn correctly', () => {
+      const result = parseUrn({ urn: 'whatsapp:5511999998888' });
+      expect(result.plataform).toBe('whatsapp');
+      expect(result.contactNum).toBe('+5511999998888');
+    });
+
+    it('parses telegram urn correctly', () => {
+      const result = parseUrn({ urn: 'telegram:123456' });
+      expect(result.plataform).toBe('telegram');
+      expect(result.contactNum).toBe('123456');
+    });
+  });
+
+  describe('sanitizeDocument', () => {
+    it('returns empty string for null/undefined/empty', () => {
+      expect(sanitizeDocument(null)).toBe('');
+      expect(sanitizeDocument(undefined)).toBe('');
+      expect(sanitizeDocument('')).toBe('');
+    });
+
+    it('strips dots and hyphens from CPF format', () => {
+      expect(sanitizeDocument('234.234.243-20')).toBe('23423424320');
+    });
+
+    it('strips hyphens from RG format', () => {
+      expect(sanitizeDocument('30404-8')).toBe('304048');
+    });
+
+    it('strips spaces, dots, hyphens from mixed formats', () => {
+      expect(sanitizeDocument('12.345.678/0001-90')).toBe('12345678000190');
+    });
+
+    it('returns already clean string unchanged', () => {
+      expect(sanitizeDocument('12345678900')).toBe('12345678900');
+    });
+
+    it('strips spaces', () => {
+      expect(sanitizeDocument('123 456 789')).toBe('123456789');
+    });
+  });
+
+  describe('buildHistorySearchTerm', () => {
+    it('returns empty string when room has no identifiers', () => {
+      expect(buildHistorySearchTerm({ contact: {} })).toBe('');
+      expect(buildHistorySearchTerm({})).toBe('');
+    });
+
+    it('returns only contactUrn when only urn is present', () => {
+      const room = {
+        urn: 'whatsapp:5511999998888',
+        contact: {},
+      };
+      expect(buildHistorySearchTerm(room)).toBe('5511999998888');
+    });
+
+    it('returns only email when only email is present', () => {
+      const room = {
+        contact: { email: 'test@example.com' },
+      };
+      expect(buildHistorySearchTerm(room)).toBe('test@example.com');
+    });
+
+    it('returns only sanitized document when only document is present', () => {
+      const room = {
+        contact: { document: '234.234.243-20' },
+      };
+      expect(buildHistorySearchTerm(room)).toBe('23423424320');
+    });
+
+    it('returns comma-separated values when multiple identifiers exist', () => {
+      const room = {
+        urn: 'whatsapp:5511999998888',
+        contact: {
+          email: 'test@example.com',
+          document: '123.456.789-00',
+        },
+      };
+      expect(buildHistorySearchTerm(room)).toBe(
+        '5511999998888,test@example.com,12345678900',
+      );
+    });
+
+    it('returns urn and email without document when document is empty', () => {
+      const room = {
+        urn: 'telegram:123456',
+        contact: {
+          email: 'user@mail.com',
+          document: '',
+        },
+      };
+      expect(buildHistorySearchTerm(room)).toBe('123456,user@mail.com');
+    });
+
+    it('handles non-whatsapp platforms without removing +', () => {
+      const room = {
+        urn: 'telegram:+999888',
+        contact: {},
+      };
+      expect(buildHistorySearchTerm(room)).toBe('+999888');
+    });
+  });
+});

--- a/src/utils/room.js
+++ b/src/utils/room.js
@@ -16,3 +16,22 @@ export const parseUrn = (room) => {
   };
   return infoNumber;
 };
+
+export const sanitizeDocument = (doc) => {
+  if (!doc) return '';
+  return doc.replaceAll(/[^a-zA-Z0-9]/g, '');
+};
+
+export const buildHistorySearchTerm = (room) => {
+  const { plataform, contactNum } = parseUrn(room);
+  const contactUrn =
+    plataform === 'whatsapp' ? contactNum.replace('+', '') : contactNum;
+
+  const parts = [];
+  if (contactUrn) parts.push(contactUrn);
+  if (room?.contact?.email) parts.push(room.contact.email);
+  if (room?.contact?.document)
+    parts.push(sanitizeDocument(room.contact.document));
+
+  return parts.join(',');
+};

--- a/src/views/Dashboard/ViewMode/__tests__/ViewMode.spec.js
+++ b/src/views/Dashboard/ViewMode/__tests__/ViewMode.spec.js
@@ -13,20 +13,20 @@ beforeAll(() => {
   );
 });
 
-vi.mock('@/utils/room', () => ({
-  parseUrn: vi.fn(),
-}));
+vi.mock('@/utils/room', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    buildHistorySearchTerm: vi.fn(() => ''),
+  };
+});
 
 describe('ViewMode', () => {
   const mockRouter = { push: vi.fn(), replace: vi.fn() };
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // Reset parseUrn mock to default behavior
-    vi.mocked(roomUtils.parseUrn).mockReturnValue({
-      plataform: '',
-      contactNum: '',
-    });
+    vi.mocked(roomUtils.buildHistorySearchTerm).mockReturnValue('');
   });
 
   const createWrapper = (storeState = {}) => {
@@ -209,11 +209,10 @@ describe('ViewMode', () => {
       expect(wrapper.vm.isModalTransferRoomsOpened).toBe(false);
     });
 
-    it('should handle openHistory correctly', () => {
-      vi.mocked(roomUtils.parseUrn).mockReturnValue({
-        plataform: 'whatsapp',
-        contactNum: '+1234567890',
-      });
+    it('should handle openHistory correctly with URN only', () => {
+      vi.mocked(roomUtils.buildHistorySearchTerm).mockReturnValue(
+        '1234567890',
+      );
 
       const wrapper = createWrapper({
         dashboard: { viewedAgent: mockAgent },
@@ -232,6 +231,54 @@ describe('ViewMode', () => {
           }),
         }),
       );
+    });
+
+    it('should handle openHistory with URN, email, and document', () => {
+      vi.mocked(roomUtils.buildHistorySearchTerm).mockReturnValue(
+        '1234567890,test@example.com,12345678900',
+      );
+
+      const roomWithContactInfo = {
+        ...mockRoom,
+        contact: {
+          name: 'John Doe',
+          email: 'test@example.com',
+          document: '123.456.789-00',
+        },
+      };
+
+      const wrapper = createWrapper({
+        dashboard: { viewedAgent: mockAgent },
+        rooms: { activeRoom: roomWithContactInfo },
+      });
+
+      wrapper.vm.openHistory();
+
+      expect(mockRouter.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'closed-rooms',
+          query: expect.objectContaining({
+            contactUrn: '1234567890,test@example.com,12345678900',
+            from: roomWithContactInfo.uuid,
+          }),
+        }),
+      );
+    });
+
+    it('should not navigate when has_history is false', () => {
+      const roomWithoutHistory = {
+        ...mockRoom,
+        has_history: false,
+      };
+
+      const wrapper = createWrapper({
+        dashboard: { viewedAgent: mockAgent },
+        rooms: { activeRoom: roomWithoutHistory },
+      });
+
+      wrapper.vm.openHistory();
+
+      expect(mockRouter.push).not.toHaveBeenCalled();
     });
 
     it('should handle navigation methods correctly', () => {
@@ -668,15 +715,15 @@ describe('ViewMode', () => {
       expect(wrapper.vm.room.contact.name).toBe('');
     });
 
-    it('should handle openHistory with contact name fallback', () => {
-      vi.mocked(roomUtils.parseUrn).mockReturnValue({
-        plataform: 'telegram',
-        contactNum: '',
-      });
+    it('should handle openHistory with only email when URN is empty', () => {
+      vi.mocked(roomUtils.buildHistorySearchTerm).mockReturnValue(
+        'contact@mail.com',
+      );
 
       const roomWithoutUrn = {
         ...mockRoom,
-        contact: { name: 'John Doe', urn: '' },
+        urn: '',
+        contact: { name: 'John Doe', email: 'contact@mail.com' },
       };
 
       const wrapper = createWrapper({
@@ -690,8 +737,7 @@ describe('ViewMode', () => {
         expect.objectContaining({
           name: 'closed-rooms',
           query: expect.objectContaining({
-            contactUrn: 'John Doe',
-            protocol: 'whatsapp',
+            contactUrn: 'contact@mail.com',
             from: roomWithoutUrn.uuid,
           }),
         }),

--- a/src/views/Dashboard/ViewMode/index.vue
+++ b/src/views/Dashboard/ViewMode/index.vue
@@ -194,7 +194,7 @@ import ModalTransferRooms from '@/components/chats/chat/ModalTransferRooms.vue';
 import ViewModeHeader from './components/ViewModeHeader.vue';
 import ContactHeader from '@/components/chats/ContactHeader.vue';
 
-import { parseUrn } from '@/utils/room';
+import { buildHistorySearchTerm } from '@/utils/room';
 
 export default {
   name: 'ViewMode',
@@ -331,10 +331,10 @@ export default {
       this.isModalTransferRoomsOpened = false;
     },
     openHistory() {
-      const { plataform, contactNum } = parseUrn(this.room);
+      if (!this.room?.has_history) return;
+
+      const contactUrn = buildHistorySearchTerm(this.room);
       const protocol = this.room.protocol;
-      const contactUrn =
-        plataform === 'whatsapp' ? contactNum.replace('+', '') : contactNum;
 
       const A_YEAR_AGO = dateFnsFormat(
         dateFnsSubYears(new Date(), 1),
@@ -344,7 +344,7 @@ export default {
       this.$router.push({
         name: 'closed-rooms',
         query: {
-          contactUrn: contactUrn || this.room?.contact?.name,
+          contactUrn,
           protocol,
           startDate: A_YEAR_AGO,
           from: this.room.uuid,

--- a/src/views/chats/Home/HomeChatHeaders.vue
+++ b/src/views/chats/Home/HomeChatHeaders.vue
@@ -170,7 +170,7 @@ import DiscussionHeader from '@/components/chats/DiscussionHeader.vue';
 import ModalCloseDiscussion from '@/views/chats/Home/ModalCloseDiscussion.vue';
 
 import { formatContactName } from '@/utils/chats';
-import { parseUrn } from '@/utils/room';
+import { buildHistorySearchTerm } from '@/utils/room';
 import { isUserAdmin } from '@/utils/permissions';
 
 export default {
@@ -308,10 +308,10 @@ export default {
       return this.$emit('back');
     },
     openHistory() {
-      const { plataform, contactNum } = parseUrn(this.room);
+      if (!this.room?.has_history) return;
+
+      const contactUrn = buildHistorySearchTerm(this.room);
       const protocol = this.room.protocol;
-      const contactUrn =
-        plataform === 'whatsapp' ? contactNum.replace('+', '') : contactNum;
 
       const A_YEAR_AGO = dateFnsFormat(
         dateFnsSubYears(new Date(), 1),

--- a/src/views/chats/Home/__tests__/HomeChatHeaders.spec.js
+++ b/src/views/chats/Home/__tests__/HomeChatHeaders.spec.js
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils';
-import { beforeEach, describe } from 'vitest';
+import { beforeEach, describe, vi } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 
 import { useRooms } from '@/store/modules/chats/rooms';
@@ -7,11 +7,15 @@ import { useDiscussions } from '@/store/modules/chats/discussions';
 
 import HomeChatHeaders from '../HomeChatHeaders.vue';
 
+const mockRouter = { push: vi.fn() };
+
 const createWrapper = ({ store }) => {
   return mount(HomeChatHeaders, {
     global: {
       mocks: {
         $t: (key) => key,
+        $tc: (key) => key,
+        $router: mockRouter,
       },
       plugins: [store],
       stubs: {
@@ -139,5 +143,128 @@ describe('HomeChatHeaders.vue', () => {
   it('emits back event when back method is called', async () => {
     await wrapper.vm.emitBack();
     expect(wrapper.emitted('back')).toBeTruthy();
+  });
+
+  describe('openHistory', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('does not navigate when has_history is false', async () => {
+      roomStore.activeRoom = {
+        uuid: 'room-1',
+        urn: 'whatsapp:5511999998888',
+        contact: { name: 'John Doe' },
+        protocol: 'whatsapp',
+        has_history: false,
+      };
+      await wrapper.vm.$nextTick();
+
+      wrapper.vm.openHistory();
+
+      expect(mockRouter.push).not.toHaveBeenCalled();
+    });
+
+    it('navigates with only URN when email and document are absent', async () => {
+      roomStore.activeRoom = {
+        uuid: 'room-1',
+        urn: 'whatsapp:5511999998888',
+        contact: { name: 'John Doe' },
+        protocol: 'whatsapp',
+        has_history: true,
+      };
+      await wrapper.vm.$nextTick();
+
+      wrapper.vm.openHistory();
+
+      expect(mockRouter.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'closed-rooms',
+          query: expect.objectContaining({
+            contactUrn: '5511999998888',
+            from: 'room-1',
+          }),
+        }),
+      );
+    });
+
+    it('navigates with URN, email, and sanitized document comma-separated', async () => {
+      roomStore.activeRoom = {
+        uuid: 'room-2',
+        urn: 'whatsapp:5511999998888',
+        contact: {
+          name: 'Jane Doe',
+          email: 'jane@example.com',
+          document: '234.234.243-20',
+        },
+        protocol: 'whatsapp',
+        has_history: true,
+      };
+      await wrapper.vm.$nextTick();
+
+      wrapper.vm.openHistory();
+
+      expect(mockRouter.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'closed-rooms',
+          query: expect.objectContaining({
+            contactUrn: '5511999998888,jane@example.com,23423424320',
+            from: 'room-2',
+          }),
+        }),
+      );
+    });
+
+    it('navigates with only email when URN is absent', async () => {
+      roomStore.activeRoom = {
+        uuid: 'room-3',
+        urn: '',
+        contact: {
+          name: 'Contact',
+          email: 'only@email.com',
+        },
+        protocol: '',
+        has_history: true,
+      };
+      await wrapper.vm.$nextTick();
+
+      wrapper.vm.openHistory();
+
+      expect(mockRouter.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'closed-rooms',
+          query: expect.objectContaining({
+            contactUrn: 'only@email.com',
+            from: 'room-3',
+          }),
+        }),
+      );
+    });
+
+    it('sanitizes document with various special characters', async () => {
+      roomStore.activeRoom = {
+        uuid: 'room-4',
+        urn: '',
+        contact: {
+          name: 'Contact',
+          document: '12.345.678/0001-90',
+        },
+        protocol: '',
+        has_history: true,
+      };
+      await wrapper.vm.$nextTick();
+
+      wrapper.vm.openHistory();
+
+      expect(mockRouter.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'closed-rooms',
+          query: expect.objectContaining({
+            contactUrn: '12345678000190',
+            from: 'room-4',
+          }),
+        }),
+      );
+    });
   });
 });


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [X] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
When a room has `has_history: true`, clicking the history button redirects to the closed-chats page with only the URN as a search term. However, the backend now considers additional contact fields (`email` and `document`) to determine history availability. The frontend needed to pass all available identifiers so the history search returns comprehensive results.

### Summary of Changes
- Added `sanitizeDocument` utility to strip non-alphanumeric characters from document strings (e.g., CPF "234.234.243-20" becomes "23423424320")
- Added `buildHistorySearchTerm` utility that collects all available contact identifiers (URN, email, document) and joins them comma-separated for the search endpoint
- Updated `openHistory` in `HomeChatHeaders.vue` and `ViewMode/index.vue` to use the new shared utility and added an early return guard when `has_history` is false
- Added unit tests for `sanitizeDocument` and `buildHistorySearchTerm`
- Added `openHistory` tests to `HomeChatHeaders.spec.js` covering all identifier combinations
- Updated `ViewMode.spec.js` tests to validate the new comma-separated logic and the `has_history` guard