### PR TITLE
[ENGAGE-7606] Feat: confirm disable prompt ai settings

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -889,7 +889,11 @@
         "switch_inactive": "Allow AI agents to transfer conversations to human support",
         "modal_title": "Scenarios or criteria that require transfer to human support",
         "textarea_label": "Define the scenarios or criteria that require transfer to human support",
-        "textarea_placeholder": "Describe the scenarios or criteria..."
+        "textarea_placeholder": "Describe the scenarios or criteria...",
+        "disable_modal": {
+          "description": "Turning off this option will permanently delete the scenarios and criteria prompt. You'll need to set it up again if you turn it back on.",
+          "confirmation": "Do you want to continue anyway?"
+        }
       },
       "bulk_transfer": {
         "tooltip": "This function allows agents to transfer various contacts at once to a row or agent",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -885,7 +885,11 @@
         "switch_inactive": "Permitir que los agentes de IA transfieran conversaciones al soporte humano",
         "modal_title": "Escenarios o criterios que requieren transferencia al soporte humano",
         "textarea_label": "Defina los escenarios o criterios que requieren transferencia al soporte humano",
-        "textarea_placeholder": "Describa los escenarios o criterios..."
+        "textarea_placeholder": "Describa los escenarios o criterios...",
+        "disable_modal": {
+          "description": "Desactivar esta opción eliminará permanentemente el prompt de escenarios y criterios. Será necesario configurarlo nuevamente al reactivarla.",
+          "confirmation": "¿Deseas continuar de todos modos?"
+        }
       },
       "bulk_transfer": {
         "tooltip": "Esta función permite a los agentes transferir varios contactos a la vez a una fila o agente",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -887,7 +887,11 @@
         "switch_inactive": "Permitir que agentes de IA transfiram conversas para atendimento humano",
         "modal_title": "Cenários ou critérios que requerem transferência para atendimento humano",
         "textarea_label": "Defina os cenários ou critérios que requerem transferência para atendimento humano",
-        "textarea_placeholder": "Descreva os cenários ou critérios..."
+        "textarea_placeholder": "Descreva os cenários ou critérios...",
+        "disable_modal": {
+          "description": "Desativar essa opção excluirá permanentemente o prompt de cenários e critérios. Será necessário configurá-lo novamente ao reativar.",
+          "confirmation": "Deseja continuar mesmo assim?"
+        }
       },
       "bulk_transfer": {
         "tooltip": "Essa função permite que agentes transfiram diversos contatos de uma vez para uma fila ou agente",

--- a/src/views/Settings/SettingsProjectOptions/AiTransferDisableModal.vue
+++ b/src/views/Settings/SettingsProjectOptions/AiTransferDisableModal.vue
@@ -1,0 +1,103 @@
+<template>
+  <UnnnicDialog
+    v-model:open="isOpen"
+    data-testid="ai-transfer-disable-modal"
+  >
+    <UnnnicDialogContent size="medium">
+      <UnnnicDialogHeader type="attention">
+        <UnnnicDialogTitle>
+          {{ $t('attention') }}
+        </UnnnicDialogTitle>
+        <UnnnicDialogClose @click="close" />
+      </UnnnicDialogHeader>
+
+      <section class="ai-transfer-disable-modal__body">
+        <p
+          class="ai-transfer-disable-modal__text"
+          data-testid="ai-transfer-disable-description"
+        >
+          {{
+            $t(
+              'config_chats.project_configs.ai_transfer.disable_modal.description',
+            )
+          }}
+        </p>
+        <p
+          class="ai-transfer-disable-modal__text"
+          data-testid="ai-transfer-disable-confirmation"
+        >
+          {{
+            $t(
+              'config_chats.project_configs.ai_transfer.disable_modal.confirmation',
+            )
+          }}
+        </p>
+      </section>
+
+      <UnnnicDialogFooter>
+        <UnnnicButton
+          type="tertiary"
+          :text="$t('cancel')"
+          data-testid="ai-transfer-disable-cancel-btn"
+          @click="close"
+        />
+        <UnnnicButton
+          type="attention"
+          :text="$t('continue')"
+          data-testid="ai-transfer-disable-confirm-btn"
+          @click="confirm"
+        />
+      </UnnnicDialogFooter>
+    </UnnnicDialogContent>
+  </UnnnicDialog>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+const props = withDefaults(
+  defineProps<{
+    modelValue?: boolean;
+  }>(),
+  {
+    modelValue: false,
+  },
+);
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean];
+  confirm: [];
+}>();
+
+const isOpen = computed<boolean>({
+  get: () => props.modelValue,
+  set: (value: boolean) => emit('update:modelValue', value),
+});
+
+const close = (): void => {
+  isOpen.value = false;
+};
+
+const confirm = (): void => {
+  emit('confirm');
+  close();
+};
+
+defineExpose({ isOpen, close, confirm });
+</script>
+
+<style lang="scss" scoped>
+.ai-transfer-disable-modal {
+  &__body {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-2;
+    padding: $unnnic-space-6;
+  }
+
+  &__text {
+    color: $unnnic-color-fg-base;
+    font: $unnnic-text-body;
+  }
+}
+</style>

--- a/src/views/Settings/SettingsProjectOptions/__tests__/AiTransferDisableModal.spec.js
+++ b/src/views/Settings/SettingsProjectOptions/__tests__/AiTransferDisableModal.spec.js
@@ -1,0 +1,152 @@
+import { beforeAll, afterAll, describe, it, expect, beforeEach } from 'vitest';
+import { mount, config } from '@vue/test-utils';
+
+import AiTransferDisableModal from '@/views/Settings/SettingsProjectOptions/AiTransferDisableModal.vue';
+import i18n from '@/plugins/i18n';
+
+beforeAll(() => {
+  config.global.plugins = config.global.plugins.filter(
+    (plugin) => plugin !== i18n,
+  );
+});
+
+afterAll(() => {
+  if (!config.global.plugins.includes(i18n)) {
+    config.global.plugins.push(i18n);
+  }
+});
+
+const createWrapper = (props = {}) => {
+  return mount(AiTransferDisableModal, {
+    props: {
+      modelValue: true,
+      ...props,
+    },
+    global: {
+      mocks: {
+        $t: (key) => key,
+      },
+      stubs: {
+        UnnnicDialog: {
+          template: '<div><slot /></div>',
+          props: ['open'],
+        },
+        UnnnicDialogContent: {
+          template: '<div><slot /></div>',
+        },
+        UnnnicDialogHeader: {
+          template: '<div><slot /></div>',
+        },
+        UnnnicDialogTitle: {
+          template: '<div><slot /></div>',
+        },
+        UnnnicDialogClose: {
+          template:
+            '<button data-testid="dialog-close" @click="$emit(\'click\')"></button>',
+        },
+        UnnnicDialogFooter: {
+          template: '<div><slot /></div>',
+        },
+      },
+    },
+  });
+};
+
+describe('AiTransferDisableModal.vue', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = createWrapper();
+  });
+
+  describe('Rendering', () => {
+    it('should render the modal as open when modelValue is true', () => {
+      expect(wrapper.vm.isOpen).toBe(true);
+    });
+
+    it('should render the description paragraph', () => {
+      const description = wrapper.find(
+        '[data-testid="ai-transfer-disable-description"]',
+      );
+      expect(description.exists()).toBe(true);
+      expect(description.text()).toBe(
+        'config_chats.project_configs.ai_transfer.disable_modal.description',
+      );
+    });
+
+    it('should render the confirmation question paragraph', () => {
+      const confirmation = wrapper.find(
+        '[data-testid="ai-transfer-disable-confirmation"]',
+      );
+      expect(confirmation.exists()).toBe(true);
+      expect(confirmation.text()).toBe(
+        'config_chats.project_configs.ai_transfer.disable_modal.confirmation',
+      );
+    });
+
+    it('should render cancel and confirm buttons', () => {
+      expect(
+        wrapper.find('[data-testid="ai-transfer-disable-cancel-btn"]').exists(),
+      ).toBe(true);
+      expect(
+        wrapper
+          .find('[data-testid="ai-transfer-disable-confirm-btn"]')
+          .exists(),
+      ).toBe(true);
+    });
+  });
+
+  describe('Cancel button', () => {
+    it('should close the modal without emitting confirm when cancel is clicked', async () => {
+      const cancelBtn = wrapper.find(
+        '[data-testid="ai-transfer-disable-cancel-btn"]',
+      );
+      await cancelBtn.trigger('click');
+
+      expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+      expect(wrapper.emitted('update:modelValue')[0]).toEqual([false]);
+      expect(wrapper.emitted('confirm')).toBeFalsy();
+    });
+  });
+
+  describe('Dialog close button', () => {
+    it('should close the modal without emitting confirm when the close icon is clicked', async () => {
+      const closeBtn = wrapper.find('[data-testid="dialog-close"]');
+      await closeBtn.trigger('click');
+
+      expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+      expect(wrapper.emitted('update:modelValue')[0]).toEqual([false]);
+      expect(wrapper.emitted('confirm')).toBeFalsy();
+    });
+  });
+
+  describe('Confirm button', () => {
+    it('should emit confirm and update:modelValue=false when continue is clicked', async () => {
+      const confirmBtn = wrapper.find(
+        '[data-testid="ai-transfer-disable-confirm-btn"]',
+      );
+      await confirmBtn.trigger('click');
+
+      expect(wrapper.emitted('confirm')).toBeTruthy();
+      expect(wrapper.emitted('confirm').length).toBe(1);
+      expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+      expect(wrapper.emitted('update:modelValue')[0]).toEqual([false]);
+    });
+  });
+
+  describe('isOpen computed', () => {
+    it('should reflect the modelValue prop', async () => {
+      wrapper = createWrapper({ modelValue: false });
+      expect(wrapper.vm.isOpen).toBe(false);
+
+      await wrapper.setProps({ modelValue: true });
+      expect(wrapper.vm.isOpen).toBe(true);
+    });
+
+    it('should emit update:modelValue when isOpen is set', () => {
+      wrapper.vm.isOpen = false;
+      expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+      expect(wrapper.emitted('update:modelValue')[0]).toEqual([false]);
+    });
+  });
+});

--- a/src/views/Settings/SettingsProjectOptions/__tests__/SettingsProjectOptions.spec.js
+++ b/src/views/Settings/SettingsProjectOptions/__tests__/SettingsProjectOptions.spec.js
@@ -71,6 +71,7 @@ const createWrapper = ({
       stubs: {
         CustomBreakOption: true,
         AiTransferModal: true,
+        AiTransferDisableModal: true,
       },
     },
   });
@@ -351,6 +352,105 @@ describe('SettingsProjectOptions.vue', () => {
       await wrapper.vm.$nextTick();
 
       expect(wrapper.vm.switchResetKey).toBe(0);
+    });
+  });
+
+  describe('AI Transfer disable confirmation', () => {
+    it('should open the disable modal when toggling OFF with a saved criteria', async () => {
+      agentBuilder.getAiTransferConfig.mockResolvedValueOnce({
+        enabled: true,
+        criteria: 'Saved criteria',
+      });
+
+      wrapper = createWrapper();
+      await flushPromises();
+
+      wrapper.vm.handleAiTransferToggle(false);
+
+      expect(wrapper.vm.showAiTransferDisableModal).toBe(true);
+      expect(wrapper.vm.aiTransferConfig.enabled).toBe(true);
+      expect(wrapper.vm.aiTransferConfig.criteria).toBe('Saved criteria');
+      expect(agentBuilder.updateAiTransferConfig).not.toHaveBeenCalled();
+    });
+
+    it('should not open the disable modal when toggling OFF without criteria', async () => {
+      await flushPromises();
+
+      wrapper.vm.aiTransferConfig.enabled = true;
+      wrapper.vm.aiTransferConfig.criteria = '';
+
+      wrapper.vm.handleAiTransferToggle(false);
+
+      expect(wrapper.vm.showAiTransferDisableModal).toBe(false);
+      expect(wrapper.vm.aiTransferConfig.enabled).toBe(false);
+      expect(agentBuilder.updateAiTransferConfig).toHaveBeenCalledWith({
+        enabled: false,
+        criteria: '',
+      });
+    });
+
+    it('should disable AI transfer and close modal on confirm', async () => {
+      agentBuilder.getAiTransferConfig.mockResolvedValueOnce({
+        enabled: true,
+        criteria: 'Saved criteria',
+      });
+
+      wrapper = createWrapper();
+      await flushPromises();
+
+      wrapper.vm.showAiTransferDisableModal = true;
+      wrapper.vm.handleAiTransferDisableConfirm();
+
+      expect(wrapper.vm.aiTransferConfig.enabled).toBe(false);
+      expect(wrapper.vm.aiTransferConfig.criteria).toBe('');
+      expect(wrapper.vm.showAiTransferDisableModal).toBe(false);
+      expect(agentBuilder.updateAiTransferConfig).toHaveBeenCalledWith({
+        enabled: false,
+        criteria: '',
+      });
+    });
+
+    it('should keep config and reset the switch when disable modal is dismissed', async () => {
+      agentBuilder.getAiTransferConfig.mockResolvedValueOnce({
+        enabled: true,
+        criteria: 'Saved criteria',
+      });
+
+      wrapper = createWrapper();
+      await flushPromises();
+
+      const initialResetKey = wrapper.vm.switchResetKey;
+
+      wrapper.vm.showAiTransferDisableModal = true;
+      await wrapper.vm.$nextTick();
+
+      wrapper.vm.showAiTransferDisableModal = false;
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.switchResetKey).toBe(initialResetKey + 1);
+      expect(wrapper.vm.aiTransferConfig.enabled).toBe(true);
+      expect(wrapper.vm.aiTransferConfig.criteria).toBe('Saved criteria');
+      expect(agentBuilder.updateAiTransferConfig).not.toHaveBeenCalled();
+    });
+
+    it('should not increment switchResetKey when disable modal closes after confirm', async () => {
+      agentBuilder.getAiTransferConfig.mockResolvedValueOnce({
+        enabled: true,
+        criteria: 'Saved criteria',
+      });
+
+      wrapper = createWrapper();
+      await flushPromises();
+
+      const initialResetKey = wrapper.vm.switchResetKey;
+      wrapper.vm.showAiTransferDisableModal = true;
+      await wrapper.vm.$nextTick();
+
+      wrapper.vm.handleAiTransferDisableConfirm();
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.switchResetKey).toBe(initialResetKey);
+      expect(wrapper.vm.aiTransferConfig.enabled).toBe(false);
     });
   });
 

--- a/src/views/Settings/SettingsProjectOptions/index.vue
+++ b/src/views/Settings/SettingsProjectOptions/index.vue
@@ -61,6 +61,11 @@
       :initialCriteria="aiTransferConfig.criteria"
       @saved="handleAiTransferSaved"
     />
+
+    <AiTransferDisableModal
+      v-model="showAiTransferDisableModal"
+      @confirm="handleAiTransferDisableConfirm"
+    />
   </section>
 </template>
 
@@ -78,6 +83,7 @@ import SettingsProjectOptionsItem from './SettingsProjectOptionsItem.vue';
 import SettingsSectionHeader from '../SettingsSectionHeader.vue';
 import CustomBreakOption from './CustomBreakOption.vue';
 import AiTransferModal from './AiTransferModal.vue';
+import AiTransferDisableModal from './AiTransferDisableModal.vue';
 
 export default {
   name: 'SettingsProjectOptions',
@@ -87,6 +93,7 @@ export default {
     SettingsProjectOptionsItem,
     CustomBreakOption,
     AiTransferModal,
+    AiTransferDisableModal,
   },
 
   data() {
@@ -108,6 +115,7 @@ export default {
         criteria: '',
       },
       showAiTransferModal: false,
+      showAiTransferDisableModal: false,
       switchResetKey: 0,
     };
   },
@@ -314,6 +322,11 @@ export default {
         this.switchResetKey += 1;
       }
     },
+    showAiTransferDisableModal(newVal) {
+      if (!newVal && this.aiTransferConfig.enabled) {
+        this.switchResetKey += 1;
+      }
+    },
   },
 
   async mounted() {
@@ -335,13 +348,26 @@ export default {
       if (value && !this.aiTransferConfig.enabled) {
         this.showAiTransferModal = true;
       } else if (!value) {
-        this.aiTransferConfig.enabled = false;
-        this.aiTransferConfig.criteria = '';
-        agentBuilder.updateAiTransferConfig({
-          enabled: false,
-          criteria: '',
-        });
+        if (this.aiTransferConfig.criteria) {
+          this.showAiTransferDisableModal = true;
+        } else {
+          this.disableAiTransfer();
+        }
       }
+    },
+
+    disableAiTransfer() {
+      this.aiTransferConfig.enabled = false;
+      this.aiTransferConfig.criteria = '';
+      agentBuilder.updateAiTransferConfig({
+        enabled: false,
+        criteria: '',
+      });
+    },
+
+    handleAiTransferDisableConfirm() {
+      this.disableAiTransfer();
+      this.showAiTransferDisableModal = false;
     },
 
     openAiTransferModal() {


### PR DESCRIPTION
## Description

### Type of Change
* * [ ] Bugfix
* * [X] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
When the "Allow AI agents to transfer conversations to human support" toggle is enabled, a saved scenarios/criteria prompt is associated with it. Previously, disabling the toggle would silently and permanently delete that prompt with no way to recover it. Users had no warning that their configuration was about to be lost, leading to accidental data loss.

This change introduces a confirmation modal so the user is aware of the consequence and can choose to proceed or cancel before losing the prompt.

### Summary of Changes
- **New `AiTransferDisableModal.vue` component** (`<script setup lang="ts">`) using `UnnnicDialog` (the deprecated `UnnnicModalDialog` is intentionally not used). Built per the Figma design with `UnnnicDialogHeader type="attention"`, two-paragraph body, a tertiary "Cancel" button, and an attention-styled "Continue" button.
- **Wired the new modal into `SettingsProjectOptions/index.vue`**:
  - When toggling the switch OFF, if there is a saved `criteria` prompt, the disable modal is shown instead of immediately clearing the configuration.
  - If no prompt exists, the previous behavior is preserved (immediate disable).
  - Extracted the disable logic into a reusable `disableAiTransfer()` method.
  - Added a watcher on `showAiTransferDisableModal` (mirroring the existing `showAiTransferModal` pattern) that increments `switchResetKey` whenever the modal closes without confirmation, ensuring the toggle visually reverts to ON regardless of how the modal is dismissed (Cancel button, X icon, or click outside).
- **Translations** added under `config_chats.project_configs.ai_transfer.disable_modal` in `en.json`, `pt_br.json`, and `es.json`, following the VTEX Content Guide (sentence case, no exclamation marks, question mark allowed for confirmation modals). Reused the existing shared keys `attention`, `cancel`, and `continue`.
- **Unit tests**:
  - New `AiTransferDisableModal.spec.js` covering rendering of title and both paragraphs, Cancel/X dismiss behavior, and the Continue (`confirm`) flow.
  - Extended `SettingsProjectOptions.spec.js` with cases covering: gating the modal on the presence of a prompt, the immediate-disable path when no prompt exists, the confirm path (API called, state cleared, modal closed, `switchResetKey` unchanged), and the dismiss path (state preserved, `switchResetKey` incremented to revert the switch animation).


### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File 1](https://www.figma.com/design/VBQTzeuz50s7XyaHuHlI3z/Live-Desk---Settings?node-id=4729-858&m=dev)

### Demonstration <!--- (If not appropriate, remove this topic) -->
<!--- Include a screenshot or video showcasing a feature or fix implemented in this pull request. -->
<img width="1698" height="754" alt="image" src="https://github.com/user-attachments/assets/22c86029-8ab0-4118-9a6f-b16002ff7075" />
