### PR TITLE
feat: correct logic for verify_chats_tag parameter in SelectFlow component

### DIFF
--- a/src/components/chats/FlowsTrigger/SelectFlow.vue
+++ b/src/components/chats/FlowsTrigger/SelectFlow.vue
@@ -116,7 +116,7 @@ export default {
 
       try {
         const response = await FlowsTrigger.getFlows(projectUuidFlow, {
-          verify_chats_tag: this.disableGetChatsTag,
+          verify_chats_tag: !this.disableGetChatsTag,
         });
 
         this.templates = response.map(({ name, uuid }) => ({

--- a/src/components/chats/FlowsTrigger/__tests__/SelectFlow.spec.js
+++ b/src/components/chats/FlowsTrigger/__tests__/SelectFlow.spec.js
@@ -17,6 +17,7 @@ describe('SelectFlow', () => {
   let wrapper;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     wrapper = mount(SelectFlow, { props: { modelValue: '' } });
   });
 
@@ -32,33 +33,45 @@ describe('SelectFlow', () => {
   it('fetches flows on mount and populates options', async () => {
     await flushPromises();
 
-    expect(FlowsTrigger.getFlows).toHaveBeenCalled();
+    expect(FlowsTrigger.getFlows).toHaveBeenCalledTimes(1);
 
     const selectOptions = wrapper.vm.templates;
     expect(selectOptions).toEqual([{ value: 'flow-1', label: 'Flow 1' }]);
   });
 
-  it('calls getFlows with verify_chats_tag=false by default', async () => {
+  it('calls getFlows with verify_chats_tag=true by default', async () => {
     await flushPromises();
 
     expect(FlowsTrigger.getFlows).toHaveBeenCalledWith(undefined, {
-      verify_chats_tag: false,
+      verify_chats_tag: true,
     });
   });
 
-  it('calls getFlows with verify_chats_tag=true when disableGetChatsTag prop is true', async () => {
-    FlowsTrigger.getFlows.mockClear();
-
+  it('calls getFlows with verify_chats_tag=false when disableGetChatsTag prop is true', async () => {
     const customWrapper = mount(SelectFlow, {
       props: { modelValue: '', disableGetChatsTag: true },
     });
     await flushPromises();
 
     expect(FlowsTrigger.getFlows).toHaveBeenCalledWith(undefined, {
-      verify_chats_tag: true,
+      verify_chats_tag: false,
     });
 
     customWrapper.unmount();
+  });
+
+  it('does not fetch flows on mount when isDisabled is true', async () => {
+    vi.clearAllMocks();
+
+    const disabledWrapper = mount(SelectFlow, {
+      props: { modelValue: '', isDisabled: true },
+    });
+    await flushPromises();
+
+    expect(FlowsTrigger.getFlows).not.toHaveBeenCalled();
+    expect(disabledWrapper.vm.templates).toEqual([]);
+
+    disabledWrapper.unmount();
   });
 
   it('refetches flows with the new projectUuidFlow when the prop changes', async () => {
@@ -69,8 +82,19 @@ describe('SelectFlow', () => {
     await flushPromises();
 
     expect(FlowsTrigger.getFlows).toHaveBeenCalledWith('project-uuid-1', {
-      verify_chats_tag: false,
+      verify_chats_tag: true,
     });
+  });
+
+  it('clears selection and emits empty modelValue when projectUuidFlow changes', async () => {
+    await flushPromises();
+    FlowsTrigger.getFlows.mockClear();
+
+    await wrapper.setProps({ projectUuidFlow: 'project-uuid-1' });
+    await flushPromises();
+
+    expect(wrapper.vm.flowSelection).toBeNull();
+    expect(wrapper.emitted('update:modelValue')).toContainEqual(['']);
   });
 
   it('emits update:modelValue when a flow is selected', async () => {
@@ -85,9 +109,52 @@ describe('SelectFlow', () => {
     expect(emissions[emissions.length - 1]).toEqual(['flow-1']);
   });
 
+  it('syncs flowSelection from modelValue after templates load', async () => {
+    const syncedWrapper = mount(SelectFlow, {
+      props: { modelValue: 'flow-1' },
+    });
+    await flushPromises();
+
+    expect(syncedWrapper.vm.flowSelection).toEqual({
+      value: 'flow-1',
+      label: 'Flow 1',
+    });
+
+    syncedWrapper.unmount();
+  });
+
+  it('clears flowSelection when modelValue is empty', async () => {
+    await flushPromises();
+
+    await wrapper.setProps({ modelValue: 'flow-1' });
+    await flushPromises();
+    expect(wrapper.vm.flowSelection).toEqual({
+      value: 'flow-1',
+      label: 'Flow 1',
+    });
+
+    await wrapper.setProps({ modelValue: '' });
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.flowSelection).toBeNull();
+  });
+
+  it('clears flowSelection when modelValue does not match any template', async () => {
+    const unknownWrapper = mount(SelectFlow, {
+      props: { modelValue: 'unknown-flow' },
+    });
+    await flushPromises();
+
+    expect(unknownWrapper.vm.flowSelection).toBeNull();
+
+    unknownWrapper.unmount();
+  });
+
   it('handles API errors gracefully', async () => {
     FlowsTrigger.getFlows.mockRejectedValueOnce(new Error('API Error'));
-    const consoleLogSpy = vi.spyOn(console, 'error');
+    const consoleLogSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
 
     const errorWrapper = mount(SelectFlow, {
       props: { modelValue: '' },
@@ -97,9 +164,13 @@ describe('SelectFlow', () => {
     await flushPromises();
 
     expect(errorWrapper.vm.templates).toEqual([]);
+    expect(errorWrapper.vm.loadingFlows).toBe(false);
     expect(consoleLogSpy).toHaveBeenCalledWith(
       'Error getting flows',
       new Error('API Error'),
     );
+
+    consoleLogSpy.mockRestore();
+    errorWrapper.unmount();
   });
 });


### PR DESCRIPTION

## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
 correct logic for verify_chats_tag parameter in SelectFlow component

### Summary of Changes
<!--- Describe your changes in detail -->
- Updated the `verify_chats_tag` parameter in the `getFlows` method to use the negation of `disableGetChatsTag`, ensuring accurate behavior when retrieving chat tags based on the component's prop.

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File 1](link_to_design_file_1)

### Demonstration <!--- (If not appropriate, remove this topic) -->
<!--- Include a screenshot or video showcasing a feature or fix implemented in this pull request. -->
