### PR TITLE
[ENGAGE-8257] fix: Discussion agents list

### DIFF
--- a/src/components/chats/DiscussionSidebar/DiscussionAbout.vue
+++ b/src/components/chats/DiscussionSidebar/DiscussionAbout.vue
@@ -32,6 +32,7 @@
         :text="$t('discussions.about.add_agent')"
         iconLeft="add-1"
         type="secondary"
+        :disabled="agentsInvolved?.length >= 5"
         data-testid="add-agent-button"
         @click="handleAddAgentModal"
       />

--- a/src/components/chats/DiscussionSidebar/DiscussionAbout.vue
+++ b/src/components/chats/DiscussionSidebar/DiscussionAbout.vue
@@ -16,10 +16,7 @@
         {{ $t('discussions.about.agents_involved') }}
       </h2>
 
-      <ul
-        class="discussion-about__section__agents-list"
-        style="max-height: 75vh; overflow-y: auto"
-      >
+      <ul class="discussion-about__section__agents-list">
         <li
           v-for="user in agentsInvolved"
           :key="getUserFullName(user)"
@@ -302,7 +299,7 @@ export default {
     flex-direction: column;
 
     &__agents-list {
-      max-height: 70vh;
+      max-height: 78vh;
       overflow-y: auto;
     }
 

--- a/src/components/chats/DiscussionSidebar/DiscussionAbout.vue
+++ b/src/components/chats/DiscussionSidebar/DiscussionAbout.vue
@@ -15,7 +15,11 @@
       <h2 class="discussion-about__section__title">
         {{ $t('discussions.about.agents_involved') }}
       </h2>
-      <ul>
+
+      <ul
+        class="discussion-about__section__agents-list"
+        style="max-height: 75vh; overflow-y: auto"
+      >
         <li
           v-for="user in agentsInvolved"
           :key="getUserFullName(user)"
@@ -28,7 +32,6 @@
         :text="$t('discussions.about.add_agent')"
         iconLeft="add-1"
         type="secondary"
-        :disabled="agentsInvolved?.length >= 5"
         data-testid="add-agent-button"
         @click="handleAddAgentModal"
       />
@@ -100,8 +103,9 @@ import SelectedMember from '@/views/Settings/Forms/SelectedMember.vue';
 
 import { mapActions, mapState } from 'pinia';
 import { useDiscussions } from '@/store/modules/chats/discussions';
-
 import { useProfile } from '@/store/modules/profile';
+
+import { removeDuplicatedItems } from '@/utils/array';
 export default {
   name: 'DiscussionAbout',
 
@@ -119,7 +123,11 @@ export default {
 
   data() {
     return {
-      agentsInvolved: null,
+      agentsInvolved: [],
+
+      agentsInvolvedPage: 0,
+      agentsInvolvedLimitPerPage: 100,
+      agentsInvolvedHasNext: false,
 
       isAddAgentModalOpen: false,
       addAgentLoading: false,
@@ -130,6 +138,7 @@ export default {
   },
 
   computed: {
+    ...mapState(useDiscussions, ['activeDiscussion']),
     ...mapState(useProfile, ['me']),
     discussionStartDate() {
       const { created_on } = this.details;
@@ -140,6 +149,17 @@ export default {
   },
 
   watch: {
+    'activeDiscussion.uuid': {
+      immediate: true,
+      handler(activeDiscussionUuid) {
+        this.agentsInvolved = [];
+        this.agentsInvolvedPage = 0;
+        this.agentsInvolvedHasNext = false;
+        if (activeDiscussionUuid) {
+          this.listAllInvolvedAgents();
+        }
+      },
+    },
     async isAddAgentModalOpen(newIsAddAgentModalOpen) {
       if (!newIsAddAgentModalOpen) {
         this.agentSelected = null;
@@ -167,16 +187,6 @@ export default {
       );
       this.agentsToSelect = newAgents;
     },
-    details: {
-      immediate: true,
-      async handler() {
-        const responseAgents = await this.getDiscussionAgents();
-        if (responseAgents.results) {
-          this.agentsInvolved = responseAgents.results;
-        }
-        this.agentsToSelect = [];
-      },
-    },
   },
 
   unmounted() {
@@ -185,6 +195,46 @@ export default {
 
   methods: {
     ...mapActions(useDiscussions, ['addAgent', 'getDiscussionAgents']),
+    async listAllInvolvedAgents() {
+      try {
+        const offset =
+          this.agentsInvolvedPage * this.agentsInvolvedLimitPerPage;
+
+        const responseAgents = await this.getDiscussionAgents({
+          limit: this.agentsInvolvedLimitPerPage,
+          offset,
+        });
+
+        this.agentsInvolvedHasNext = !!responseAgents.next;
+
+        if (responseAgents.results && responseAgents.results.length > 0) {
+          const concatenatedAgents = [
+            ...this.agentsInvolved,
+            ...responseAgents.results,
+          ];
+
+          this.agentsInvolved = concatenatedAgents;
+        }
+
+        if (this.agentsInvolvedHasNext) {
+          this.agentsInvolvedPage += 1;
+          await this.listAllInvolvedAgents();
+        } else {
+          this.agentsInvolved = removeDuplicatedItems(
+            this.agentsInvolved,
+            'email',
+          );
+          this.agentsInvolvedPage = 0;
+        }
+
+        this.agentsToSelect = [];
+      } catch (error) {
+        console.error(
+          'An error occurred when trying to get discussion agents:',
+          error,
+        );
+      }
+    },
     handlingRemoveAgent() {
       this.agentSelected = null;
     },
@@ -246,6 +296,14 @@ export default {
     color: $unnnic-color-fg-emphasized;
     font-size: $unnnic-font-size-body-gt;
     font-weight: $unnnic-font-weight-regular;
+
+    display: flex;
+    flex-direction: column;
+
+    &__agents-list {
+      max-height: 70vh;
+      overflow-y: auto;
+    }
 
     &__title {
       font-size: $unnnic-font-size-body-gt;

--- a/src/components/chats/DiscussionSidebar/DiscussionAbout.vue
+++ b/src/components/chats/DiscussionSidebar/DiscussionAbout.vue
@@ -222,7 +222,6 @@ export default {
             this.agentsInvolved,
             'email',
           );
-          this.agentsInvolvedPage = 0;
         }
 
         this.agentsToSelect = [];

--- a/src/services/api/resources/chats/__tests__/discussion.unit.spec.js
+++ b/src/services/api/resources/chats/__tests__/discussion.unit.spec.js
@@ -90,10 +90,18 @@ describe('discussionService', () => {
 
     const result = await discussionService.getDiscussionAgents({
       discussionUuid: mockDiscussionUuid,
+      limit: 20,
+      offset: 0,
     });
 
     expect(http.get).toHaveBeenCalledWith(
       `discussion/${mockDiscussionUuid}/list_agents/`,
+      {
+        params: {
+          limit: 20,
+          offset: 0,
+        },
+      },
     );
     expect(result).toEqual(mockResponse);
   });

--- a/src/services/api/resources/chats/discussion.js
+++ b/src/services/api/resources/chats/discussion.js
@@ -33,9 +33,15 @@ export default {
     const response = await http.get(`discussion/${discussionUuid}/`);
     return response.data;
   },
-  async getDiscussionAgents({ discussionUuid }) {
+  async getDiscussionAgents({ discussionUuid, limit = 20, offset = 0 }) {
     const response = await http.get(
       `discussion/${discussionUuid}/list_agents/`,
+      {
+        params: {
+          limit,
+          offset,
+        },
+      },
     );
     return response.data;
   },

--- a/src/store/modules/chats/__tests__/discussions.spec.js
+++ b/src/store/modules/chats/__tests__/discussions.spec.js
@@ -151,10 +151,15 @@ describe('useDiscussions Store', () => {
 
     Discussion.getDiscussionAgents.mockResolvedValue({ data: 'agents' });
 
-    const result = await discussions.getDiscussionAgents();
+    const result = await discussions.getDiscussionAgents({
+      limit: 20,
+      offset: 0,
+    });
 
     expect(Discussion.getDiscussionAgents).toHaveBeenCalledWith({
       discussionUuid: '123',
+      limit: 20,
+      offset: 0,
     });
     expect(result).toEqual({ data: 'agents' });
   });

--- a/src/store/modules/chats/discussions.js
+++ b/src/store/modules/chats/discussions.js
@@ -132,9 +132,11 @@ export const useDiscussions = defineStore('discussions', {
       });
     },
 
-    getDiscussionAgents() {
+    getDiscussionAgents({ limit, offset } = {}) {
       return Discussion.getDiscussionAgents({
         discussionUuid: this.activeDiscussion.uuid,
+        limit,
+        offset,
       });
     },
 


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Adding a recursive call to list all agents in the discussion; previously it wasn't possible to list them all, which gave the impression of a problem related to a lack of agents.