### PR TITLE
[ENGAGE-8080] Feat: last interaction adjustments

### DIFF
--- a/src/components/chats/FlowsTrigger/ModalVariableMapping.vue
+++ b/src/components/chats/FlowsTrigger/ModalVariableMapping.vue
@@ -202,7 +202,7 @@ const onConfirm = () => {
   &__form {
     display: flex;
     flex-direction: column;
-    gap: $unnnic-space-2;
+    gap: $unnnic-space-3;
   }
 
   &__form-title {

--- a/src/components/chats/chat/ModalCloseRooms.vue
+++ b/src/components/chats/chat/ModalCloseRooms.vue
@@ -100,7 +100,6 @@ import i18n from '@/plugins/i18n';
 
 import { useRooms } from '@/store/modules/chats/rooms';
 import { useRoomCounters } from '@/store/modules/chats/roomCounters';
-import { useFeatureFlag } from '@/store/modules/featureFlag';
 import Room from '@/services/api/resources/chats/room';
 import Queue from '@/services/api/resources/settings/queue';
 
@@ -373,15 +372,7 @@ const refetchRoomsIfEmpty = async () => {
   });
 };
 
-const isNewRoomUpdateEnabled = () => {
-  const featureFlagStore = useFeatureFlag();
-  return !!featureFlagStore.featureFlags?.active_features?.includes(
-    'WeniChatsNewRoomUpdate',
-  );
-};
-
 const scheduleReconciliation = () => {
-  if (!isNewRoomUpdateEnabled()) return;
   setTimeout(() => {
     const tab = activeTab.value;
     roomsStore
@@ -415,7 +406,6 @@ const clearSelectionsAndClose = async () => {
 };
 
 const applyOptimisticClose = (uuids) => {
-  if (!isNewRoomUpdateEnabled()) return;
   const counters = useRoomCounters();
   for (const uuid of uuids) {
     const roomType = roomsStore.applyClose(uuid);
@@ -485,23 +475,18 @@ const executeBulkClose = async () => {
   isLoadingBulkClose.value = true;
 
   const roomsToClose = collectRoomsToClose();
-  const useNewLogic = isNewRoomUpdateEnabled();
 
-  if (useNewLogic) {
-    for (const { uuid } of roomsToClose) markPendingClose(uuid);
-  }
+  for (const { uuid } of roomsToClose) markPendingClose(uuid);
 
   const chunks = chunkRoomsToClose(roomsToClose);
   const { totalSuccess, totalFailed, successUuids } =
     await submitBulkCloseChunks(chunks);
 
-  if (useNewLogic) {
-    applyOptimisticClose(successUuids);
-    reconcilePendingMarks(
-      roomsToClose.map((r) => r.uuid),
-      successUuids,
-    );
-  }
+  applyOptimisticClose(successUuids);
+  reconcilePendingMarks(
+    roomsToClose.map((r) => r.uuid),
+    successUuids,
+  );
 
   if (totalFailed === 0 && totalSuccess > 0) {
     unnnicCallAlert({

--- a/src/components/chats/chat/__tests__/ModalCloseRooms.spec.js
+++ b/src/components/chats/chat/__tests__/ModalCloseRooms.spec.js
@@ -247,10 +247,9 @@ describe('ModalCloseRooms.vue', () => {
     });
   });
 
-  describe('optimistic close (new pipeline)', () => {
-    const createWrapperWithFeatureFlag = ({
+  describe('optimistic close', () => {
+    const createWrapperForOptimisticClose = ({
       bulkCloseResponse,
-      featureFlags = ['WeniChatsNewRoomUpdate'],
       tags = emptyTagsResponse,
     } = {}) => {
       Queue.tags.mockReset();
@@ -267,9 +266,6 @@ describe('ModalCloseRooms.vue', () => {
             selectedOngoingRooms: ['room-1'],
             selectedWaitingRooms: [],
             rooms: [roomWithQueue],
-          },
-          featureFlag: {
-            featureFlags: { active_features: featureFlags },
           },
         },
       });
@@ -300,7 +296,7 @@ describe('ModalCloseRooms.vue', () => {
     });
 
     it('marks pending closes, applies optimistic close on success, and decrements the counter', async () => {
-      const wrapper = createWrapperWithFeatureFlag({
+      const wrapper = createWrapperForOptimisticClose({
         bulkCloseResponse: {
           data: {
             success_count: 1,
@@ -332,7 +328,7 @@ describe('ModalCloseRooms.vue', () => {
     });
 
     it('unmarks pending close for uuids that failed in the API response', async () => {
-      const wrapper = createWrapperWithFeatureFlag({
+      const wrapper = createWrapperForOptimisticClose({
         bulkCloseResponse: {
           data: { success_count: 0, failed_count: 1, success_uuids: [] },
         },
@@ -350,32 +346,6 @@ describe('ModalCloseRooms.vue', () => {
 
       expect(markPendingClose).toHaveBeenCalledWith('room-1');
       expect(unmarkPendingClose).toHaveBeenCalledWith('room-1');
-      expect(roomsStore.applyClose).not.toHaveBeenCalled();
-    });
-
-    it('skips optimistic close when feature flag is off (legacy path)', async () => {
-      const wrapper = createWrapperWithFeatureFlag({
-        bulkCloseResponse: {
-          data: {
-            success_count: 1,
-            failed_count: 0,
-            success_uuids: ['room-1'],
-          },
-        },
-        featureFlags: [],
-      });
-
-      await flushPromises();
-      await wrapper.vm.$nextTick();
-
-      const roomsStore = useRooms();
-      roomsStore.applyClose = vi.fn();
-      roomsStore.setSelectedOngoingRooms = vi.fn();
-
-      await wrapper.find('[data-testid="primary-button"]').trigger('click');
-      await flushPromises();
-
-      expect(markPendingClose).not.toHaveBeenCalled();
       expect(roomsStore.applyClose).not.toHaveBeenCalled();
     });
   });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -856,13 +856,13 @@
     "contact_already_exists": "The number {contact} is already saved in your contact list",
     "variable_mapping": {
       "title": "Variable mapping",
-      "description": "Variables will be populated in the preview below using values from the selected contacts whenever they reference contact fields",
+      "description": "Variables will be populated in the preview below using values from the selected contacts whenever they reference contact fields.",
       "define_variables": "Define the variables",
       "variable_label": "Variable {name}",
       "input_placeholder": "Type the value for this variable",
       "preview_title": "Template preview",
       "preview_variable_tooltip": "Variable {placeholder}",
-      "confirmation_helper": "Check if each field is correctly mapped, this is how your message will look to each selected contact",
+      "confirmation_helper": "Check if each field is correctly mapped, this is how your message will look to each selected contact.",
       "confirmation_checkbox": "I've checked it and I'm ready to send it",
       "local_variables": {
         "contact_name": "Contact name",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -859,13 +859,13 @@
     "contact_already_exists": "El número {contact} ya está guardado en tu lista de contactos",
     "variable_mapping": {
       "title": "Mapeo de variables",
-      "description": "Las variables se completarán en la vista previa siguiente con valores de los contactos seleccionados cuando hagan referencia a campos del contacto",
+      "description": "Las variables se completarán en la vista previa siguiente con valores de los contactos seleccionados cuando hagan referencia a campos del contacto.",
       "define_variables": "Definir las variables",
       "variable_label": "Variable {name}",
       "input_placeholder": "Escribe el valor para esta variable",
       "preview_title": "Vista previa del template",
       "preview_variable_tooltip": "Variable {placeholder}",
-      "confirmation_helper": "Verifica si cada campo está mapeado correctamente; así se mostrará el mensaje a cada contacto seleccionado",
+      "confirmation_helper": "Verifica si cada campo está mapeado correctamente; así se mostrará el mensaje a cada contacto seleccionado.",
       "confirmation_checkbox": "Lo verifiqué y estoy listo para enviar",
       "local_variables": {
         "contact_name": "Nombre del contacto",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -861,13 +861,13 @@
     "contact_already_exists": "O número {contact} já está salvo em sua lista de contatos",
     "variable_mapping": {
       "title": "Mapeamento de variáveis",
-      "description": "As variáveis serão preenchidas na pré-visualização abaixo usando valores dos contatos selecionados sempre que fizerem referência a campos do contato",
+      "description": "As variáveis serão preenchidas na pré-visualização abaixo usando valores dos contatos selecionados sempre que fizerem referência a campos do contato.",
       "define_variables": "Definir as variáveis",
       "variable_label": "Variável {name}",
       "input_placeholder": "Digite o valor para esta variável",
       "preview_title": "Pré-visualização do template",
       "preview_variable_tooltip": "Variável {placeholder}",
-      "confirmation_helper": "Verifique se cada campo está mapeado corretamente; é assim que a mensagem será exibida para cada contato selecionado",
+      "confirmation_helper": "Verifique se cada campo está mapeado corretamente; é assim que a mensagem será exibida para cada contato selecionado.",
       "confirmation_checkbox": "Verifiquei e estou pronto para enviar",
       "local_variables": {
         "contact_name": "Nome do contato",

--- a/src/services/api/websocket/listeners/room/__tests__/delete.unit.spec.js
+++ b/src/services/api/websocket/listeners/room/__tests__/delete.unit.spec.js
@@ -7,7 +7,6 @@ import {
 } from '@/services/api/websocket/listeners/room/update';
 import { useRooms } from '@/store/modules/chats/rooms';
 import { useRoomCounters } from '@/store/modules/chats/roomCounters';
-import { useFeatureFlag } from '@/store/modules/featureFlag';
 
 vi.mock('@/store/modules/chats/rooms', () => ({
   useRooms: vi.fn(),
@@ -15,10 +14,6 @@ vi.mock('@/store/modules/chats/rooms', () => ({
 
 vi.mock('@/store/modules/chats/roomCounters', () => ({
   useRoomCounters: vi.fn(),
-}));
-
-vi.mock('@/store/modules/featureFlag', () => ({
-  useFeatureFlag: vi.fn(),
 }));
 
 const buildAppMock = () => ({
@@ -37,7 +32,7 @@ const buildRoomsStoreMock = () => ({
   activeTab: 'ongoing',
 });
 
-describe('Room delete (legacy path)', () => {
+describe('Room delete', () => {
   let roomsStoreMock;
   let countersMock;
 
@@ -51,47 +46,6 @@ describe('Room delete (legacy path)', () => {
     };
     useRooms.mockReturnValue(roomsStoreMock);
     useRoomCounters.mockReturnValue(countersMock);
-    useFeatureFlag.mockReturnValue({
-      featureFlags: { active_features: [] },
-    });
-  });
-
-  afterEach(() => {
-    resetBatchState();
-  });
-
-  it('calls removeRoom synchronously and decrements counter when feature flag is off', async () => {
-    const room = {
-      uuid: 'room1',
-      user: { email: 'agent@example.com' },
-      is_waiting: false,
-    };
-    roomsStoreMock.rooms = [room];
-
-    await wsDeleteRoom(room, { app: buildAppMock() });
-
-    expect(roomsStoreMock.removeRoom).toHaveBeenCalledWith('room1');
-    expect(countersMock.handleClose).toHaveBeenCalledWith('ongoing');
-  });
-});
-
-describe('Room delete (new unified pipeline)', () => {
-  let roomsStoreMock;
-  let countersMock;
-
-  beforeEach(() => {
-    resetBatchState();
-    roomsStoreMock = buildRoomsStoreMock();
-    countersMock = {
-      handleClose: vi.fn(),
-      handleRoomUpdate: vi.fn(),
-      clearTypeCache: vi.fn(),
-    };
-    useRooms.mockReturnValue(roomsStoreMock);
-    useRoomCounters.mockReturnValue(countersMock);
-    useFeatureFlag.mockReturnValue({
-      featureFlags: { active_features: ['WeniChatsNewRoomUpdate'] },
-    });
   });
 
   afterEach(() => {

--- a/src/services/api/websocket/listeners/room/__tests__/update.unit.spec.js
+++ b/src/services/api/websocket/listeners/room/__tests__/update.unit.spec.js
@@ -8,7 +8,6 @@ import wsRoomUpdate, {
 import wsDeleteRoom from '@/services/api/websocket/listeners/room/delete';
 import { useRooms } from '@/store/modules/chats/rooms';
 import { useRoomCounters } from '@/store/modules/chats/roomCounters';
-import { useFeatureFlag } from '@/store/modules/featureFlag';
 import SoundNotification from '@/services/api/websocket/soundNotification';
 
 vi.mock('@/store/modules/dashboard', () => ({
@@ -23,10 +22,6 @@ vi.mock('@/store/modules/chats/rooms', () => ({
 
 vi.mock('@/store/modules/chats/roomCounters', () => ({
   useRoomCounters: vi.fn(),
-}));
-
-vi.mock('@/store/modules/featureFlag', () => ({
-  useFeatureFlag: vi.fn(),
 }));
 
 vi.mock('@/services/api/websocket/soundNotification', () => ({
@@ -71,17 +66,7 @@ const buildCountersMock = () => ({
   clearTypeCache: vi.fn(),
 });
 
-const enableNewLogic = () =>
-  useFeatureFlag.mockReturnValue({
-    featureFlags: { active_features: ['WeniChatsNewRoomUpdate'] },
-  });
-
-const disableNewLogic = () =>
-  useFeatureFlag.mockReturnValue({
-    featureFlags: { active_features: [] },
-  });
-
-describe('Room update (legacy path)', () => {
+describe('Room update', () => {
   let appMock;
   let roomsStoreMock;
   let countersMock;
@@ -94,130 +79,6 @@ describe('Room update (legacy path)', () => {
     countersMock = buildCountersMock();
     useRooms.mockReturnValue(roomsStoreMock);
     useRoomCounters.mockReturnValue(countersMock);
-    disableNewLogic();
-    soundNotificationMock = new SoundNotification('achievement-confirmation');
-    SoundNotification.mockReturnValue(soundNotificationMock);
-  });
-
-  afterEach(() => {
-    resetBatchState();
-  });
-
-  it('updates the room synchronously when the feature flag is off', async () => {
-    const room = {
-      uuid: 'room1',
-      transfer_history: { action: 'forward' },
-      unread_msgs: 1,
-    };
-
-    await wsRoomUpdate(room, { app: appMock });
-
-    expect(roomsStoreMock.updateRoom).toHaveBeenCalledWith({
-      room,
-      userEmail: appMock.me.email,
-      routerReplace: expect.any(Function),
-      viewedAgentEmail: appMock.viewedAgent.email,
-    });
-  });
-
-  it('plays the achievement sound when transfer action is "transfer"', async () => {
-    const room = {
-      uuid: 'room1',
-      transfer_history: { action: 'transfer' },
-      unread_msgs: 1,
-    };
-
-    await wsRoomUpdate(room, { app: appMock });
-
-    expect(soundNotificationMock.notify).toHaveBeenCalledWith();
-  });
-
-  it('resets new messages when unread_msgs is 0', async () => {
-    const room = {
-      uuid: 'room1',
-      unread_msgs: 0,
-      transfer_history: { action: 'forward' },
-    };
-
-    await wsRoomUpdate(room, { app: appMock });
-
-    expect(roomsStoreMock.resetNewMessagesByRoom).toHaveBeenCalledWith({
-      room: room.uuid,
-    });
-  });
-
-  it('marks isNewChatReceived when the room transitions to ongoing for the current agent', async () => {
-    roomsStoreMock.updateRoom.mockReturnValueOnce({
-      wasInArray: false,
-      isNowInArray: true,
-      oldType: null,
-      newType: 'ongoing',
-      roomUuid: 'room1',
-    });
-    const room = {
-      uuid: 'room1',
-      user: { email: 'user@example.com' },
-      unread_msgs: 0,
-    };
-
-    await wsRoomUpdate(room, { app: appMock });
-
-    expect(roomsStoreMock.markNewChatReceived).toHaveBeenCalledWith('room1');
-  });
-
-  it('does not mark isNewChatReceived when the room was already ongoing', async () => {
-    roomsStoreMock.updateRoom.mockReturnValueOnce({
-      wasInArray: true,
-      isNowInArray: true,
-      oldType: 'ongoing',
-      newType: 'ongoing',
-      roomUuid: 'room1',
-    });
-    const room = {
-      uuid: 'room1',
-      user: { email: 'user@example.com' },
-      unread_msgs: 0,
-    };
-
-    await wsRoomUpdate(room, { app: appMock });
-
-    expect(roomsStoreMock.markNewChatReceived).not.toHaveBeenCalled();
-  });
-
-  it('does not mark isNewChatReceived when the room is not for the current agent', async () => {
-    roomsStoreMock.updateRoom.mockReturnValueOnce({
-      wasInArray: false,
-      isNowInArray: true,
-      oldType: null,
-      newType: 'ongoing',
-      roomUuid: 'room1',
-    });
-    const room = {
-      uuid: 'room1',
-      user: { email: 'other@example.com' },
-      unread_msgs: 0,
-    };
-
-    await wsRoomUpdate(room, { app: appMock });
-
-    expect(roomsStoreMock.markNewChatReceived).not.toHaveBeenCalled();
-  });
-});
-
-describe('Room update (new unified pipeline)', () => {
-  let appMock;
-  let roomsStoreMock;
-  let countersMock;
-  let soundNotificationMock;
-
-  beforeEach(() => {
-    resetBatchState();
-    appMock = buildAppMock();
-    roomsStoreMock = buildRoomsStoreMock();
-    countersMock = buildCountersMock();
-    useRooms.mockReturnValue(roomsStoreMock);
-    useRoomCounters.mockReturnValue(countersMock);
-    enableNewLogic();
     soundNotificationMock = new SoundNotification('achievement-confirmation');
     SoundNotification.mockReturnValue(soundNotificationMock);
   });
@@ -242,6 +103,45 @@ describe('Room update (new unified pipeline)', () => {
     expect(roomsStoreMock.updateRoom).toHaveBeenCalledWith(
       expect.objectContaining({ room }),
     );
+    expect(roomsStoreMock.resetNewMessagesByRoom).toHaveBeenCalledWith({
+      room: room.uuid,
+    });
+  });
+
+  it('plays the achievement sound when transfer action is "transfer"', async () => {
+    const room = {
+      uuid: 'room1',
+      transfer_history: { action: 'transfer' },
+      unread_msgs: 1,
+    };
+
+    await wsRoomUpdate(room, { app: appMock });
+
+    expect(soundNotificationMock.notify).toHaveBeenCalledWith();
+  });
+
+  it('plays the select sound when transfer action is "forward"', async () => {
+    const room = {
+      uuid: 'room1',
+      transfer_history: { action: 'forward' },
+      unread_msgs: 1,
+    };
+
+    await wsRoomUpdate(room, { app: appMock });
+
+    expect(SoundNotification).toHaveBeenCalledWith('select-sound');
+  });
+
+  it('resets new messages when unread_msgs is 0', async () => {
+    const room = {
+      uuid: 'room1',
+      unread_msgs: 0,
+      transfer_history: { action: 'forward' },
+    };
+
+    await wsRoomUpdate(room, { app: appMock });
+    flushPendingUpdates();
+
     expect(roomsStoreMock.resetNewMessagesByRoom).toHaveBeenCalledWith({
       room: room.uuid,
     });

--- a/src/services/api/websocket/listeners/room/delete.js
+++ b/src/services/api/websocket/listeners/room/delete.js
@@ -1,34 +1,9 @@
-import { useFeatureFlag } from '@/store/modules/featureFlag';
-import { useRooms } from '@/store/modules/chats/rooms';
-import { useRoomCounters } from '@/store/modules/chats/roomCounters';
-import { getRoomType } from '@/utils/room';
-
 import { enqueueRoomEvent, setAppRef } from './update';
 
 const handleRoomClose = async (room, context) => {
   if (!room?.uuid) return;
 
   if (context?.app) setAppRef(context.app);
-
-  const featureFlagStore = useFeatureFlag();
-  const useNewRoomUpdate =
-    featureFlagStore.featureFlags?.active_features?.includes(
-      'WeniChatsNewRoomUpdate',
-    );
-
-  if (!useNewRoomUpdate) {
-    const roomsStore = useRooms();
-    const counters = useRoomCounters();
-
-    const existingRoom = roomsStore.rooms.find((r) => r.uuid === room.uuid);
-    const roomType = existingRoom
-      ? getRoomType(existingRoom)
-      : getRoomType(room);
-
-    roomsStore.removeRoom(room.uuid);
-    counters.handleClose(roomType);
-    return;
-  }
 
   enqueueRoomEvent({ kind: 'close', room });
 };

--- a/src/services/api/websocket/listeners/room/update.js
+++ b/src/services/api/websocket/listeners/room/update.js
@@ -1,6 +1,5 @@
 import SoundNotification from '@/services/api/websocket/soundNotification';
 
-import { useFeatureFlag } from '@/store/modules/featureFlag';
 import { useRooms } from '@/store/modules/chats/rooms';
 import { useRoomCounters } from '@/store/modules/chats/roomCounters';
 import { useDashboard } from '@/store/modules/dashboard';
@@ -265,14 +264,8 @@ export function setAppRef(app) {
 export default async (room, { app }) => {
   const roomsStore = useRooms();
   const dashboardStore = useDashboard();
-  const featureFlagStore = useFeatureFlag();
 
   lastAppRef = app;
-
-  const useNewRoomUpdate =
-    featureFlagStore.featureFlags?.active_features?.includes(
-      'WeniChatsNewRoomUpdate',
-    );
 
   const isViewMode = dashboardStore.viewedAgent.email !== '';
 
@@ -291,10 +284,6 @@ export default async (room, { app }) => {
 
   if (!isValidRoomFilterQueue && (isWaitingRoom || isViewMode)) {
     return;
-  }
-
-  if (!useNewRoomUpdate) {
-    return handleUpdateLegacy(room, app, roomsStore);
   }
 
   if (!isKnown && !notifiedRoomUuids.has(room.uuid)) {
@@ -317,52 +306,3 @@ export default async (room, { app }) => {
 
   enqueueRoomEvent({ kind: 'update', room });
 };
-
-function handleUpdateLegacy(room, app, roomsStore) {
-  const isExistingRoom = roomsStore.rooms.find(
-    (mappedRoom) => mappedRoom.uuid === room.uuid,
-  );
-
-  const roomType = getRoomType(room);
-  const isOngoingTab = roomsStore.activeTab === 'ongoing';
-  const isRoomForMe = room.user?.email === app.me.email;
-
-  if (!isExistingRoom) {
-    roomsStore.addRoom(room);
-
-    if (room.transfer_history?.action === 'transfer') {
-      new SoundNotification('achievement-confirmation').notify();
-    }
-    if (room.transfer_history?.action === 'forward') {
-      new SoundNotification('select-sound').notify();
-    }
-  }
-
-  if (roomType === 'ongoing' && !isOngoingTab && isRoomForMe) {
-    roomsStore.showOngoingDot = true;
-  }
-
-  const result = roomsStore.updateRoom({
-    room,
-    userEmail: app.me.email,
-    routerReplace: () => app.$router.replace({ name: 'home' }),
-    viewedAgentEmail: app.viewedAgent.email,
-  });
-
-  if (result) {
-    const counters = useRoomCounters();
-    counters.handleRoomUpdate(result);
-
-    if (
-      result.newType === 'ongoing' &&
-      result.oldType !== 'ongoing' &&
-      room.user?.email === app.me.email
-    ) {
-      roomsStore.markNewChatReceived(room.uuid);
-    }
-  }
-
-  if (room.unread_msgs === 0) {
-    roomsStore.resetNewMessagesByRoom({ room: room.uuid });
-  }
-}

--- a/src/store/modules/chats/__tests__/rooms.spec.js
+++ b/src/store/modules/chats/__tests__/rooms.spec.js
@@ -5,7 +5,6 @@ import { setActivePinia, createPinia } from 'pinia';
 import { useRooms } from '@/store/modules/chats/rooms';
 import { useProfile } from '@/store/modules/profile';
 import { useDashboard } from '@/store/modules/dashboard';
-import { useFeatureFlag } from '@/store/modules/featureFlag';
 
 import { roomsMock } from './mocks/roomsMock';
 import {
@@ -620,10 +619,11 @@ describe('State Rooms', () => {
       it('should show modal for assumed chat', async () => {
         await updateRoom(
           {
-            id: '5',
+            uuid: '5',
             user: { email: 'testing-adm@weni.ai' },
             transfer_history: { from: { type: 'user' } },
             contact: { name: 'Cliente 1' },
+            queue: { uuid: '1' },
           },
           {
             app: {
@@ -697,10 +697,6 @@ describe('State Rooms', () => {
       mocks.useProfile.mockReturnValue(mockProfileAdminState);
       roomsStore = useRooms();
       roomsStore.$patch({ rooms: [] });
-      const featureFlagStore = useFeatureFlag();
-      featureFlagStore.$patch({
-        featureFlags: { active_features: ['WeniChatsNewRoomUpdate'] },
-      });
     });
 
     it('does not re-add a closed room when alreadyClosedThisBatch is true', () => {
@@ -794,6 +790,42 @@ describe('State Rooms', () => {
     it('setActiveRoom does not throw when the room has no uuid', () => {
       expect(() => roomsStore.setActiveRoom({})).not.toThrow();
       expect(roomsStore.activeRoom).toEqual({});
+    });
+
+    it('updateRoom preserves isNewChatReceived when the same room receives a subsequent payload from the socket', () => {
+      const userEmail = 'me@weni.ai';
+      const initialRoom = {
+        uuid: 'transferred',
+        user: { email: userEmail },
+        is_waiting: false,
+      };
+
+      roomsStore.$patch({ rooms: [initialRoom] });
+      roomsStore.markNewChatReceived('transferred');
+      expect(
+        roomsStore.rooms.find((r) => r.uuid === 'transferred')
+          ?.isNewChatReceived,
+      ).toBe(true);
+
+      // a follow-up rooms.update for the same room (e.g. the second event the
+      // backend emits right after a transfer) must not wipe the client-side
+      // indicator
+      roomsStore.updateRoom({
+        room: {
+          uuid: 'transferred',
+          user: { email: userEmail },
+          is_waiting: false,
+          modified_on: '2026-05-27T10:59:49.500Z',
+        },
+        userEmail,
+        routerReplace: vi.fn(),
+        viewedAgentEmail: null,
+      });
+
+      expect(
+        roomsStore.rooms.find((r) => r.uuid === 'transferred')
+          ?.isNewChatReceived,
+      ).toBe(true);
     });
   });
 });

--- a/src/store/modules/chats/rooms.js
+++ b/src/store/modules/chats/rooms.js
@@ -1,7 +1,6 @@
 import { defineStore } from 'pinia';
 
 import { useDashboard } from '../dashboard';
-import { useFeatureFlag } from '../featureFlag';
 import { useProfile } from '../profile';
 import { useRoomCounters } from './roomCounters';
 
@@ -250,49 +249,6 @@ export const useRooms = defineStore('rooms', {
       viewedAgentEmail,
       alreadyClosedThisBatch = false,
     }) {
-      const featureFlagStore = useFeatureFlag();
-      const useNewRoomUpdate =
-        featureFlagStore.featureFlags?.active_features?.includes(
-          'WeniChatsNewRoomUpdate',
-        );
-      if (!useNewRoomUpdate) {
-        return this._updateRoomLegacy({
-          room,
-          userEmail,
-          routerReplace,
-          viewedAgentEmail,
-        });
-      }
-      return this._updateRoomSafe({
-        room,
-        userEmail,
-        routerReplace,
-        viewedAgentEmail,
-        alreadyClosedThisBatch,
-      });
-    },
-
-    applyClose(uuid, fallbackRoom) {
-      if (!uuid) return null;
-      const existingRoom = this.rooms.find((r) => r.uuid === uuid);
-      let roomType = null;
-      if (existingRoom) {
-        roomType = getRoomType(existingRoom);
-      } else if (fallbackRoom) {
-        roomType = getRoomType(fallbackRoom);
-      }
-
-      this.removeRoom(uuid);
-      return roomType;
-    },
-
-    _updateRoomSafe({
-      room,
-      userEmail,
-      routerReplace,
-      viewedAgentEmail,
-      alreadyClosedThisBatch = false,
-    }) {
       const shouldBeVisible = this.checkUserSeenRoom({
         room,
         viewedAgentEmail,
@@ -305,8 +261,14 @@ export const useRooms = defineStore('rooms', {
 
       if (roomIndex !== -1) {
         if (shouldBeVisible) {
+          const existing = this.rooms[roomIndex];
+          // Preserve client-side flags (is_pinned, isNewChatReceived) that the
+          // websocket payload does not include. Without this, a follow-up
+          // rooms.update for the same room would clear isNewChatReceived
+          // before the user has a chance to see the indicator.
           this.rooms[roomIndex] = {
-            is_pinned: this.rooms[roomIndex]?.is_pinned,
+            is_pinned: existing?.is_pinned,
+            isNewChatReceived: existing?.isNewChatReceived,
             ...room,
           };
         } else {
@@ -342,54 +304,18 @@ export const useRooms = defineStore('rooms', {
       };
     },
 
-    _updateRoomLegacy({ room, userEmail, routerReplace, viewedAgentEmail }) {
-      const existingRoom = this.rooms.find((r) => r.uuid === room.uuid);
-      const wasInArray = !!existingRoom;
-      const oldType = existingRoom ? getRoomType(existingRoom) : null;
-
-      if (!existingRoom) {
-        this.rooms.push({ ...room });
+    applyClose(uuid, fallbackRoom) {
+      if (!uuid) return null;
+      const existingRoom = this.rooms.find((r) => r.uuid === uuid);
+      let roomType = null;
+      if (existingRoom) {
+        roomType = getRoomType(existingRoom);
+      } else if (fallbackRoom) {
+        roomType = getRoomType(fallbackRoom);
       }
 
-      const filteredRooms = this.rooms
-        .map((mappedRoom) =>
-          mappedRoom.uuid === room.uuid
-            ? { is_pinned: mappedRoom?.is_pinned, ...room }
-            : mappedRoom,
-        )
-        .filter((filteredRoom) => {
-          return this.checkUserSeenRoom({
-            room: filteredRoom,
-            viewedAgentEmail,
-            userEmail,
-          });
-        })
-        .sort((a, b) => {
-          if (a.is_pinned !== undefined && b.is_pinned !== undefined) {
-            return b.is_pinned - a.is_pinned;
-          }
-          return 0;
-        });
-
-      this.rooms = filteredRooms;
-
-      const isNowInArray = this.rooms.some((r) => r.uuid === room.uuid);
-      const newType = getRoomType(room);
-
-      this._handleTransferSideEffects({
-        room,
-        userEmail,
-        routerReplace,
-        viewedAgentEmail,
-      });
-
-      return {
-        wasInArray,
-        isNowInArray,
-        oldType,
-        newType,
-        roomUuid: room.uuid,
-      };
+      this.removeRoom(uuid);
+      return roomType;
     },
 
     _handleTransferSideEffects({

--- a/src/views/chats/Home/ModalCloseChat.vue
+++ b/src/views/chats/Home/ModalCloseChat.vue
@@ -74,7 +74,6 @@ import ChatClassifier from '@/components/chats/ChatClassifier.vue';
 
 import { useRooms } from '@/store/modules/chats/rooms';
 import { useRoomCounters } from '@/store/modules/chats/roomCounters';
-import { useFeatureFlag } from '@/store/modules/featureFlag';
 import { useFeedback } from '@/store/modules/feedback';
 
 import {
@@ -149,7 +148,6 @@ export default {
 
   methods: {
     ...mapActions(useFeedback, ['setIsRenderFeedbackModal']),
-    ...mapActions(useRooms, ['removeRoom']),
     async loadRoomTags() {
       try {
         const roomUuid = this.room.uuid;
@@ -182,39 +180,28 @@ export default {
         else this.isLoadingTags = false;
       }
     },
-    isNewRoomUpdateEnabled() {
-      const featureFlagStore = useFeatureFlag();
-      return !!featureFlagStore.featureFlags?.active_features?.includes(
-        'WeniChatsNewRoomUpdate',
-      );
-    },
     async closeRoom() {
       this.isLoadingCloseRoom = true;
       const { uuid } = this.room;
 
-      const useNewLogic = this.isNewRoomUpdateEnabled();
-      if (useNewLogic) markPendingClose(uuid);
+      markPendingClose(uuid);
 
       const tagsUuids = this.tags.map((tag) => tag.uuid);
 
       try {
         await Room.close(uuid, tagsUuids);
       } catch (error) {
-        if (useNewLogic) unmarkPendingClose(uuid);
+        unmarkPendingClose(uuid);
         this.isLoadingCloseRoom = false;
         throw error;
       }
 
-      if (useNewLogic) {
-        const roomsStore = useRooms();
-        const counters = useRoomCounters();
-        const roomType = roomsStore.applyClose(uuid, this.room);
-        if (roomType) {
-          counters.handleClose(roomType);
-          counters.clearTypeCache(uuid);
-        }
-      } else {
-        this.removeRoom(uuid);
+      const roomsStore = useRooms();
+      const counters = useRoomCounters();
+      const roomType = roomsStore.applyClose(uuid, this.room);
+      if (roomType) {
+        counters.handleClose(roomType);
+        counters.clearTypeCache(uuid);
       }
 
       this.isLoadingCloseRoom = false;


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

The "new chat received" indicator was not being shown in the room card when a chat was transferred from another agent, while it worked correctly when picking from the queue or via automatic distribution.

Root cause: when the backend emits two `rooms.update` events in quick succession during a transfer (the user assignment update followed by a small follow-up update ~130ms later), the events end up in different batches of the websocket update pipeline. The first batch correctly added the room and set `isNewChatReceived = true`. The second batch, however, replaced the room in the store with the spread `{ is_pinned, ...room }`, where `room` is the websocket payload. Since `isNewChatReceived` is a client-side flag and is not part of the payload, it was wiped out before the user had a chance to see it. The subsequent check `result.oldType !== 'ongoing'` then failed (the room was already ongoing in the array), so `markNewChatReceived` was not called again.

In addition, the `WeniChatsNewRoomUpdate` feature flag has been fully validated in production and was kept only for backwards compatibility, with two parallel code paths (`_updateRoomSafe` / `_updateRoomLegacy`, `handleUpdateLegacy`, legacy synchronous close, etc.) adding complexity to the codebase.

### Summary of Changes
<!--- Describe your changes in detail -->

**Bugfix — `isNewChatReceived` no longer gets wiped by a follow-up `rooms.update`**
- In `updateRoom` (store), when overwriting an existing room in the array, the spread now preserves `isNewChatReceived` along with `is_pinned`. Both are client-side flags not present in the websocket payload.
- Added a regression test in `rooms.spec.js` covering the scenario where a second `rooms.update` arrives for the same room and the indicator must stay visible.

**Refactor — removal of the `WeniChatsNewRoomUpdate` feature flag**
- `src/services/api/websocket/listeners/room/update.js`: removed `handleUpdateLegacy`, the `useFeatureFlag` import and the flag check. The default export always goes through the batched pipeline now.
- `src/services/api/websocket/listeners/room/delete.js`: reduced to a single `enqueueRoomEvent({ kind: 'close', room })` call. Removed the synchronous legacy branch and the `useFeatureFlag` import.
- `src/store/modules/chats/rooms.js`: removed `_updateRoomLegacy` and `_updateRoomSafe` along with the flag-based routing. The pipeline logic was inlined directly into `updateRoom`. Removed the `useFeatureFlag` import.
- `src/views/chats/Home/ModalCloseChat.vue`: removed `isNewRoomUpdateEnabled`, the `useNewLogic` branch, the `useFeatureFlag` import and the now-unused `removeRoom` mapping. `closeRoom` always uses `markPendingClose` + `applyClose` + counters.
- `src/components/chats/chat/ModalCloseRooms.vue`: removed `isNewRoomUpdateEnabled`, `useNewLogic` and all the conditional guards in `scheduleReconciliation`, `applyOptimisticClose` and `executeBulkClose`, plus the `useFeatureFlag` import.

**Tests**
- `update.unit.spec.js`: merged the "legacy path" and "new unified pipeline" describes into a single `describe('Room update')`. Removed the `useFeatureFlag` mock, the `enableNewLogic` / `disableNewLogic` helpers and the legacy-only test cases. Coverage of the unified pipeline is preserved.
- `delete.unit.spec.js`: removed the legacy describe and the flag mocks, simplified into a single `describe('Room delete')`.
- `rooms.spec.js`: removed the `useFeatureFlag` import and the `$patch` of the flag. Adjusted the "should show modal for assumed chat" test to include a `uuid` (the new pipeline filters out payloads without `uuid` at `enqueueRoomEvent`).
- `ModalCloseRooms.spec.js`: renamed `optimistic close (new pipeline)` to `optimistic close`, removed the flag-driven setup and the "skips optimistic close when feature flag is off (legacy path)" case.