### PR TITLE
[ENGAGE-8315] Feat: adjust view mode with last interaction

### DIFF
--- a/src/layouts/ChatsLayout/components/TheCardGroups/CardGroup/RoomCard.vue
+++ b/src/layouts/ChatsLayout/components/TheCardGroups/CardGroup/RoomCard.vue
@@ -77,6 +77,7 @@ import { useRooms } from '@/store/modules/chats/rooms';
 import { useConfig } from '@/store/modules/config';
 import { useFeatureFlag } from '@/store/modules/featureFlag';
 import { useProfile } from '@/store/modules/profile';
+import { useDashboard } from '@/store/modules/dashboard';
 
 import ChatContact from '@/components/chats/ChatContact.vue';
 
@@ -146,6 +147,10 @@ export default {
     ...mapState(useProfile, {
       me: 'me',
     }),
+    ...mapState(useDashboard, ['viewedAgent']),
+    isViewMode() {
+      return this.viewedAgent?.email !== '';
+    },
     isPendingResponseFeatureEnabled() {
       return !!this.featureFlags?.active_features?.includes(
         'weniChatsPendingResponse',
@@ -158,6 +163,8 @@ export default {
       return !!this.room.last_message?.contact && !this.room.last_message?.user;
     },
     isLastMessageFromAnotherAgent() {
+      if (this.isViewMode) return false;
+
       const isUserHaveEmail = this.room.last_message?.user?.email;
 
       const verifyEmail = isUserHaveEmail
@@ -167,6 +174,8 @@ export default {
       return !!this.room.last_message?.user && verifyEmail;
     },
     isLastMessageFromBot() {
+      if (this.isViewMode) return false;
+
       return !this.room.last_message?.contact && !this.room.last_message?.user;
     },
     showPendingResponse() {

--- a/src/layouts/ChatsLayout/components/TheCardGroups/CardGroup/tests/RoomCard.spec.js
+++ b/src/layouts/ChatsLayout/components/TheCardGroups/CardGroup/tests/RoomCard.spec.js
@@ -7,6 +7,7 @@ import { useRooms } from '@/store/modules/chats/rooms';
 import { useConfig } from '@/store/modules/config';
 import { useFeatureFlag } from '@/store/modules/featureFlag';
 import { useProfile } from '@/store/modules/profile';
+import { useDashboard } from '@/store/modules/dashboard';
 
 import RoomCard from '../RoomCard.vue';
 
@@ -128,6 +129,9 @@ describe('RoomCard.vue', () => {
 
     const profileStore = useProfile();
     profileStore.me = { email: 'agent@weni.ai' };
+
+    const dashboardStore = useDashboard();
+    dashboardStore.viewedAgent = { email: '', name: '' };
   });
 
   afterEach(() => {
@@ -428,6 +432,51 @@ describe('RoomCard.vue', () => {
       };
       const wrapper = createWrapper({ room });
 
+      expect(wrapper.vm.isLastMessageFromBot).toBe(false);
+
+      wrapper.unmount();
+    });
+
+    it('calculates isLastMessageFromAnotherAgent as false in view mode even when last message is from another agent', () => {
+      const dashboardStore = useDashboard();
+      dashboardStore.viewedAgent = {
+        email: 'other-agent@weni.ai',
+        name: 'Other Agent',
+      };
+
+      const room = {
+        ...mockRoom,
+        last_message: {
+          ...mockRoom.last_message,
+          user: { email: 'other-agent@weni.ai' },
+        },
+      };
+      const wrapper = createWrapper({ room });
+
+      expect(wrapper.vm.isViewMode).toBe(true);
+      expect(wrapper.vm.isLastMessageFromAnotherAgent).toBe(false);
+
+      wrapper.unmount();
+    });
+
+    it('calculates isLastMessageFromBot as false in view mode even when last message has no contact and no user', () => {
+      const dashboardStore = useDashboard();
+      dashboardStore.viewedAgent = {
+        email: 'other-agent@weni.ai',
+        name: 'Other Agent',
+      };
+
+      const room = {
+        ...mockRoom,
+        last_message: {
+          ...mockRoom.last_message,
+          user: null,
+          contact: null,
+        },
+      };
+      const wrapper = createWrapper({ room });
+
+      expect(wrapper.vm.isViewMode).toBe(true);
       expect(wrapper.vm.isLastMessageFromBot).toBe(false);
 
       wrapper.unmount();


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
In view mode, managers can observe another agent's rooms without participating in the conversation. The pending response indicator was still being triggered by last messages from another agent or from the bot, which is incorrect in that context. These checks should be disabled when the room list is being viewed in view mode.

### Summary of Changes
- Updated [`src/layouts/ChatsLayout/components/TheCardGroups/CardGroup/RoomCard.vue`](src/layouts/ChatsLayout/components/TheCardGroups/CardGroup/RoomCard.vue) to read `viewedAgent` from the dashboard store and compute `isViewMode`.
- Adjusted `isLastMessageFromAnotherAgent` and `isLastMessageFromBot` to return `false` when `isViewMode` is active.
- Added unit tests in [`src/layouts/ChatsLayout/components/TheCardGroups/CardGroup/tests/RoomCard.spec.js`](src/layouts/ChatsLayout/components/TheCardGroups/CardGroup/tests/RoomCard.spec.js) to cover both computed properties in view mode.