### PR TITLE
[ENGAGE-8320] fix: chats medias sizes

### DIFF
--- a/src/components/chats/chat/ChatMessages/index.vue
+++ b/src/components/chats/chat/ChatMessages/index.vue
@@ -950,7 +950,6 @@ export default {
     &.is-video {
       max-width: 250px;
       max-height: 200px;
-      /* object-fit: cover; */
     }
 
     .image {

--- a/src/components/chats/chat/ChatMessages/index.vue
+++ b/src/components/chats/chat/ChatMessages/index.vue
@@ -947,8 +947,17 @@ export default {
       }
     }
 
+    &.is-video {
+      max-width: 250px;
+      max-height: 200px;
+      /* object-fit: cover; */
+    }
+
     .image {
       cursor: pointer;
+      max-width: 200px;
+      max-height: 200px;
+      object-fit: cover;
     }
 
     .audio {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Chat media was being displayed too large; now it will be displayed at a maximum width of 200px for images and 250px for videos.

### Demonstration <!--- (If not appropriate, remove this topic) -->
<!--- Include a screenshot or video showcasing a feature or fix implemented in this pull request. -->
Before:
<img width="819" height="599" alt="image" src="https://github.com/user-attachments/assets/0b836d7f-cc7d-4f8e-8c84-b7f90b3fe10e" />

After:
<img width="1185" height="772" alt="image" src="https://github.com/user-attachments/assets/467b0620-7545-47e2-a96d-bfa90a8113d4" />
