### PR TITLE
[ENGAGE-8329] Feat: transfer reps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@sentry/vue": "^9.19.0",
         "@vueuse/components": "^13.9.0",
         "@vueuse/core": "^13.9.0",
-        "@weni/unnnic-system": "^3.26.1",
+        "@weni/unnnic-system": "^3.27.2",
         "axios": "^0.27.2",
         "core-js": "^3.8.3",
         "cross-env": "^7.0.3",
@@ -6437,9 +6437,9 @@
       }
     },
     "node_modules/@weni/unnnic-system": {
-      "version": "3.26.1",
-      "resolved": "https://registry.npmjs.org/@weni/unnnic-system/-/unnnic-system-3.26.1.tgz",
-      "integrity": "sha512-NMV2KqA+If6vIjX5fnNGF7g5DgYUgkyCkEbsAmdRwDxIoH92vUd64woSyAxNjX/4iceLj/6BZsuUwMLRp6O5vg==",
+      "version": "3.27.2",
+      "resolved": "https://registry.npmjs.org/@weni/unnnic-system/-/unnnic-system-3.27.2.tgz",
+      "integrity": "sha512-ruHbHfRD692YBY0poKPAETvF5lV+p9sojq+0hxRYBe6AKPaAtqJv4xmRHDmaPh9Tl8Fi1PTucvaQ61JIWvRYcg==",
       "dependencies": {
         "@iconify/vue": "^5.0.0",
         "@vueuse/components": "^10.4.1",
@@ -21351,9 +21351,9 @@
       "requires": {}
     },
     "@weni/unnnic-system": {
-      "version": "3.26.1",
-      "resolved": "https://registry.npmjs.org/@weni/unnnic-system/-/unnnic-system-3.26.1.tgz",
-      "integrity": "sha512-NMV2KqA+If6vIjX5fnNGF7g5DgYUgkyCkEbsAmdRwDxIoH92vUd64woSyAxNjX/4iceLj/6BZsuUwMLRp6O5vg==",
+      "version": "3.27.2",
+      "resolved": "https://registry.npmjs.org/@weni/unnnic-system/-/unnnic-system-3.27.2.tgz",
+      "integrity": "sha512-ruHbHfRD692YBY0poKPAETvF5lV+p9sojq+0hxRYBe6AKPaAtqJv4xmRHDmaPh9Tl8Fi1PTucvaQ61JIWvRYcg==",
       "requires": {
         "@iconify/vue": "^5.0.0",
         "@vueuse/components": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@sentry/vue": "^9.19.0",
     "@vueuse/components": "^13.9.0",
     "@vueuse/core": "^13.9.0",
-    "@weni/unnnic-system": "^3.26.1",
+    "@weni/unnnic-system": "^3.27.2",
     "axios": "^0.27.2",
     "core-js": "^3.8.3",
     "cross-env": "^7.0.3",

--- a/src/components/chats/ContactInfo/TransferSession.vue
+++ b/src/components/chats/ContactInfo/TransferSession.vue
@@ -36,105 +36,115 @@
   </AsideSlotTemplateSection>
 </template>
 
-<script>
-import { mapActions, mapState } from 'pinia';
-import { useRooms } from '@/store/modules/chats/rooms';
-
+<script setup lang="ts">
+import { onBeforeUnmount, ref } from 'vue';
+import { storeToRefs } from 'pinia';
 import isMobile from 'is-mobile';
+
+import { useRooms } from '@/store/modules/chats/rooms';
 
 import AsideSlotTemplateSection from '@/components/layouts/chats/AsideSlotTemplate/Section.vue';
 import RoomsTransferFields from '@/components/chats/RoomsTransferFields.vue';
 import ModalProgressBarFalse from '@/components/ModalProgressBarFalse.vue';
 
-export default {
-  name: 'TransferSession',
+interface QueueOption {
+  label: string;
+  value: string;
+  sector_uuid: string;
+  queue_name: string;
+}
 
-  components: {
-    AsideSlotTemplateSection,
-    RoomsTransferFields,
-    ModalProgressBarFalse,
-  },
+interface Props {
+  isViewMode?: boolean;
+}
 
-  props: {
-    isViewMode: {
-      type: Boolean,
-      default: false,
-    },
-  },
-  emits: ['transferred-contact'],
+withDefaults(defineProps<Props>(), {
+  isViewMode: false,
+});
 
-  data() {
-    return {
-      isMobile: isMobile(),
+const emit = defineEmits<{
+  'transferred-contact': [];
+}>();
 
-      selectedQueue: [],
+defineOptions({ name: 'TransferSession' });
 
-      isLoading: false,
-      showTransferProgressBar: false,
+const roomsStore = useRooms();
+const { activeRoom } = storeToRefs(roomsStore);
+
+const isMobileDevice = ref(isMobile());
+
+const selectedQueue = ref<QueueOption[]>([]);
+
+const isLoading = ref(false);
+const showTransferProgressBar = ref(false);
+
+const roomsTransferFields = ref<InstanceType<
+  typeof RoomsTransferFields
+> | null>(null);
+
+if (activeRoom.value?.uuid) {
+  roomsStore.setContactToTransfer(activeRoom.value.uuid);
+}
+
+onBeforeUnmount(() => {
+  roomsStore.setContactToTransfer('');
+});
+
+async function transferRooms() {
+  isLoading.value = true;
+
+  if (isMobileDevice.value) {
+    await handleFalseTransferProgressBar();
+  }
+
+  roomsTransferFields.value?.transfer();
+}
+
+function transferComplete(status: 'success' | 'error') {
+  isLoading.value = false;
+
+  if (status === 'success') {
+    resetActiveRoom();
+  }
+}
+
+function resetActiveRoom() {
+  roomsStore.setActiveRoom(null);
+}
+
+function handleFalseTransferProgressBar(): Promise<void> {
+  showTransferProgressBar.value = true;
+
+  return new Promise<void>((resolve) => {
+    const waitForCloseTransferProgressBar = () => {
+      if (showTransferProgressBar.value) {
+        setTimeout(waitForCloseTransferProgressBar, 100);
+      } else {
+        resolve();
+      }
     };
-  },
 
-  computed: {
-    ...mapState(useRooms, {
-      room: (store) => store.activeRoom,
-    }),
-  },
+    waitForCloseTransferProgressBar();
+  }).then(() => {
+    emit('transferred-contact');
+  });
+}
 
-  created() {
-    this.setContactToTransfer(this.room.uuid);
-  },
+function closeTransferProgressBar() {
+  showTransferProgressBar.value = false;
+}
 
-  beforeUnmount() {
-    this.setContactToTransfer([]);
-  },
-
-  methods: {
-    ...mapActions(useRooms, ['setContactToTransfer', 'setActiveRoom']),
-
-    async transferRooms() {
-      this.isLoading = true;
-
-      if (this.isMobile) {
-        await this.handleFalseTransferProgressBar();
-      }
-
-      this.$refs.roomsTransferFields.transfer();
-    },
-
-    transferComplete(status) {
-      this.isLoading = false;
-
-      if (status === 'success') {
-        this.resetActiveRoom();
-      }
-    },
-
-    resetActiveRoom() {
-      this.setActiveRoom(null);
-    },
-
-    async handleFalseTransferProgressBar() {
-      this.showTransferProgressBar = true;
-
-      return new Promise((resolve) => {
-        const waitForCloseTransferProgressBar = () => {
-          if (!this.showTransferProgressBar) {
-            resolve();
-          } else {
-            setTimeout(waitForCloseTransferProgressBar, 100);
-          }
-        };
-
-        waitForCloseTransferProgressBar();
-      }).then(() => {
-        this.$emit('transferred-contact');
-      });
-    },
-    closeTransferProgressBar() {
-      this.showTransferProgressBar = false;
-    },
-  },
-};
+defineExpose({
+  selectedQueue,
+  isLoading,
+  showTransferProgressBar,
+  isMobile: isMobileDevice,
+  transferRooms,
+  transferComplete,
+  resetActiveRoom,
+  handleFalseTransferProgressBar,
+  closeTransferProgressBar,
+});
 </script>
 
 <style lang="scss" scoped>
@@ -144,7 +154,7 @@ export default {
   }
 
   &__title {
-    margin-bottom: $unnnic-spacing-ant;
+    margin-bottom: $unnnic-space-3;
 
     font-weight: $unnnic-font-weight-bold;
     font-size: $unnnic-font-size-body-gt;
@@ -152,7 +162,7 @@ export default {
   }
 
   &__handler {
-    margin-top: $unnnic-spacing-ant;
+    margin-top: $unnnic-space-3;
     width: 100%;
   }
 }

--- a/src/components/chats/ContactInfo/__tests__/TransferSession.spec.js
+++ b/src/components/chats/ContactInfo/__tests__/TransferSession.spec.js
@@ -1,40 +1,93 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { mount } from '@vue/test-utils';
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  vi,
+} from 'vitest';
+import { mount, flushPromises, config } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
+
+import RoomService from '@/services/api/resources/chats/room';
 
 import TransferSession from '../TransferSession.vue';
 import RoomsTransferFields from '../../RoomsTransferFields.vue';
 
-vi.mock('@/store/modules/chats/rooms', () => ({
-  useRooms: vi.fn(() => ({
-    rooms: [{ uuid: 'test-room-uuid' }],
-    activeRoom: { uuid: 'test-room-uuid' },
-    setContactToTransfer: vi.fn(),
-    setActiveRoom: vi.fn(),
-  })),
-}));
-
 vi.mock('@/services/api/resources/settings/queue', () => ({
   default: {
     listByProject: vi.fn(() => ({
-      results: [{ name: 'Queue', sector_name: 'Sector', uuid: '1' }],
+      results: [
+        {
+          name: 'Queue',
+          sector_name: 'Sector',
+          uuid: '1',
+          sector_uuid: 's1',
+        },
+      ],
     })),
+    agentsToTransfer: vi.fn(() => []),
   },
 }));
+
+vi.mock('@/services/api/resources/chats/room', () => ({
+  default: {
+    bulkTranfer: vi.fn(() => Promise.resolve({ status: 200 })),
+    getRoomTags: vi.fn(() => ({ results: [] })),
+  },
+}));
+
+let savedGlobalMocks;
+
+beforeAll(() => {
+  savedGlobalMocks = { ...config.global.mocks };
+  config.global.mocks = {};
+});
+
+afterAll(() => {
+  config.global.mocks = savedGlobalMocks;
+});
+
+function createStore() {
+  return createTestingPinia({
+    initialState: {
+      rooms: {
+        activeRoom: { uuid: 'test-room-uuid' },
+        rooms: [{ uuid: 'test-room-uuid', queue: { sector: 's1' } }],
+        selectedOngoingRooms: [],
+        selectedWaitingRooms: [],
+        activeTab: 'ongoing',
+        contactToTransfer: 'test-room-uuid',
+        activeRoomTags: [],
+      },
+      profile: { me: { email: 'mock@email.com' } },
+    },
+  });
+}
+
+function createWrapper() {
+  return mount(TransferSession, {
+    props: { isViewMode: false },
+    global: {
+      plugins: [createStore()],
+      components: { RoomsTransferFields },
+    },
+  });
+}
 
 describe('TransferSession', () => {
   let wrapper;
 
   beforeEach(() => {
-    wrapper = mount(TransferSession, {
-      props: { isViewMode: false },
-      global: { components: { RoomsTransferFields } },
-    });
+    vi.clearAllMocks();
+    wrapper = createWrapper();
   });
 
   it('renders correctly with initial state', () => {
-    expect(wrapper.find('[data-testid="transfer-session-title"]').text()).toBe(
-      wrapper.vm.$t('transfer_contact'),
-    );
+    expect(
+      wrapper.find('[data-testid="transfer-session-title"]').exists(),
+    ).toBe(true);
 
     expect(
       wrapper.findComponent('[data-testid="transfer-fields"]').exists(),
@@ -52,7 +105,15 @@ describe('TransferSession', () => {
         .props('disabled'),
     ).toBe(true);
 
-    await wrapper.setData({ selectedQueue: ['queue-1'] });
+    wrapper.vm.selectedQueue = [
+      {
+        value: 'queue-1',
+        label: 'Queue',
+        sector_uuid: 's1',
+        queue_name: 'Queue',
+      },
+    ];
+    await flushPromises();
 
     expect(
       wrapper
@@ -61,45 +122,67 @@ describe('TransferSession', () => {
     ).toBe(false);
   });
 
-  it('calls transferRooms on button click', async () => {
-    const transferRoomsMock = vi.spyOn(wrapper.vm, 'transferRooms');
-
-    await wrapper.setData({ selectedQueue: ['queue-1'] });
+  it('forwards transfer to the inner RoomsTransferFields on button click', async () => {
+    wrapper.vm.selectedQueue = [
+      {
+        value: 'queue-1',
+        label: 'Queue',
+        sector_uuid: 's1',
+        queue_name: 'Queue',
+      },
+    ];
+    await flushPromises();
     await wrapper.find('[data-testid="transfer-button"]').trigger('click');
+    await flushPromises();
 
-    expect(transferRoomsMock).toHaveBeenCalled();
+    expect(RoomService.bulkTranfer).toHaveBeenCalled();
   });
 
   it('shows progress bar on mobile devices', async () => {
     wrapper.vm.isMobile = true;
 
-    const handleFalseTransferProgressBarMock = vi.spyOn(
-      wrapper.vm,
-      'handleFalseTransferProgressBar',
-    );
-    await wrapper.setData({ selectedQueue: ['queue-1'] });
+    wrapper.vm.selectedQueue = [
+      {
+        value: 'queue-1',
+        label: 'Queue',
+        sector_uuid: 's1',
+        queue_name: 'Queue',
+      },
+    ];
+    await flushPromises();
     await wrapper.find('[data-testid="transfer-button"]').trigger('click');
+    await flushPromises();
 
-    expect(handleFalseTransferProgressBarMock).toHaveBeenCalled();
+    expect(wrapper.vm.showTransferProgressBar).toBe(true);
   });
 
   it('handles transferComplete with success status', async () => {
-    const resetActiveRoomMock = vi.spyOn(wrapper.vm, 'resetActiveRoom');
+    wrapper.vm.isLoading = true;
     wrapper.vm.transferComplete('success');
+    await flushPromises();
 
-    expect(resetActiveRoomMock).toHaveBeenCalled();
+    expect(wrapper.vm.isLoading).toBe(false);
+  });
+
+  it('does not reset loading state spuriously on error', async () => {
+    wrapper.vm.isLoading = true;
+    wrapper.vm.transferComplete('error');
+    await flushPromises();
+
     expect(wrapper.vm.isLoading).toBe(false);
   });
 
   it('closes transfer progress bar when close is triggered', async () => {
-    await wrapper.setData({ showTransferProgressBar: true });
+    wrapper.vm.showTransferProgressBar = true;
+    await flushPromises();
     wrapper.vm.closeTransferProgressBar();
 
     expect(wrapper.vm.showTransferProgressBar).toBe(false);
   });
 
   it('handles false transfer progress bar promise flow', async () => {
-    await wrapper.setData({ showTransferProgressBar: true });
+    wrapper.vm.showTransferProgressBar = true;
+    await flushPromises();
 
     const promise = wrapper.vm.handleFalseTransferProgressBar();
     wrapper.vm.closeTransferProgressBar();

--- a/src/components/chats/RoomsTransferFields.vue
+++ b/src/components/chats/RoomsTransferFields.vue
@@ -25,28 +25,39 @@
         :size="size"
         :disabled="isAgentsFieldDisabled"
         :options="sortedAgents"
-        :label="size !== 'sm' ? $t('agent') : undefined"
-        :placeholder="$t('select_agent')"
+        :label="size !== 'sm' ? $t('representative') : undefined"
+        :placeholder="$t('select_representative')"
         returnObject
         clearable
         enableSearch
         :search="searchAgent"
         @update:search="searchAgent = $event"
       >
-        <template #option="{ option }">
+        <template #option="{ label, option }">
           <span
-            class="select-destination__agent-option-label"
+            class="select-destination__agent-label"
             data-testid="agent-option"
           >
-            {{ option.label }}
+            {{ label }}
           </span>
           <UnnnicTag
             data-testid="agent-status-tag"
             type="default"
+            size="small"
             :data-status="option.status"
             :text="getAgentStatusLabel(option.status)"
             :scheme="getAgentStatusScheme(option.status)"
+          />
+        </template>
+        <template #selected="{ label, option }">
+          <span class="select-destination__agent-label">
+            {{ label }}
+          </span>
+          <UnnnicTag
+            type="default"
             size="small"
+            :text="getAgentStatusLabel(option.status)"
+            :scheme="getAgentStatusScheme(option.status)"
           />
         </template>
       </UnnnicSelect>
@@ -494,7 +505,18 @@ defineExpose({
           margin-top: $unnnic-space-2;
         }
       }
+
+      &__agent-label {
+        flex: 1 1 auto;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
     }
+  }
+
+  :deep(.unnnic-select__trigger-content) {
+    justify-content: space-between;
   }
 }
 </style>

--- a/src/components/chats/RoomsTransferFields.vue
+++ b/src/components/chats/RoomsTransferFields.vue
@@ -34,21 +34,20 @@
         @update:search="searchAgent = $event"
       >
         <template #option="{ option }">
-          <section
-            class="select-destination__agent-option"
+          <span
+            class="select-destination__agent-option-label"
             data-testid="agent-option"
           >
-            <span class="select-destination__agent-option__label">
-              {{ option.label }}
-            </span>
-            <UnnnicTag
-              data-testid="agent-status-tag"
-              :data-status="option.status"
-              :text="getAgentStatusLabel(option.status)"
-              :scheme="getAgentStatusScheme(option.status)"
-              size="small"
-            />
-          </section>
+            {{ option.label }}
+          </span>
+          <UnnnicTag
+            data-testid="agent-status-tag"
+            type="default"
+            :data-status="option.status"
+            :text="getAgentStatusLabel(option.status)"
+            :scheme="getAgentStatusScheme(option.status)"
+            size="small"
+          />
         </template>
       </UnnnicSelect>
     </section>
@@ -493,22 +492,6 @@ defineExpose({
 
         &--small {
           margin-top: $unnnic-space-2;
-        }
-      }
-
-      &__agent-option {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: $unnnic-space-2;
-        width: 100%;
-
-        &__label {
-          flex: 1 1 0;
-          min-width: 0;
-          overflow: hidden;
-          text-overflow: ellipsis;
-          white-space: nowrap;
         }
       }
     }

--- a/src/components/chats/RoomsTransferFields.vue
+++ b/src/components/chats/RoomsTransferFields.vue
@@ -24,7 +24,7 @@
         data-testid="select-agent"
         :size="size"
         :disabled="isAgentsFieldDisabled"
-        :options="agents"
+        :options="sortedAgents"
         :label="size !== 'sm' ? $t('agent') : undefined"
         :placeholder="$t('select_agent')"
         returnObject
@@ -32,7 +32,25 @@
         enableSearch
         :search="searchAgent"
         @update:search="searchAgent = $event"
-      />
+      >
+        <template #option="{ option }">
+          <section
+            class="select-destination__agent-option"
+            data-testid="agent-option"
+          >
+            <span class="select-destination__agent-option__label">
+              {{ option.label }}
+            </span>
+            <UnnnicTag
+              data-testid="agent-status-tag"
+              :data-status="option.status"
+              :text="getAgentStatusLabel(option.status)"
+              :scheme="getAgentStatusScheme(option.status)"
+              size="small"
+            />
+          </section>
+        </template>
+      </UnnnicSelect>
     </section>
     <UnnnicDisclaimer
       v-if="showTransferDisclaimer"
@@ -57,356 +75,408 @@
   </main>
 </template>
 
-<script>
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue';
 import isMobile from 'is-mobile';
 
-import Room from '@/services/api/resources/chats/room';
-
-import { mapActions, mapState, mapWritableState } from 'pinia';
+import { storeToRefs } from 'pinia';
 
 import { useRooms } from '@/store/modules/chats/rooms';
 import { useProfile } from '@/store/modules/profile';
 
+import Room from '@/services/api/resources/chats/room';
 import Queue from '@/services/api/resources/settings/queue';
 import callUnnnicAlert from '@/utils/callUnnnicAlert';
 
 import i18n from '@/plugins/i18n';
 
+type AgentStatus = 'online' | 'offline' | (string & {});
+
+interface AgentApi {
+  status: AgentStatus;
+  first_name: string;
+  last_name: string;
+  email: string;
+  photo_url: string | null;
+  language: string;
+}
+
+interface AgentOption {
+  label: string;
+  value: string;
+  status: AgentStatus;
+}
+
+interface QueueOption {
+  label: string;
+  value: string;
+  sector_uuid: string;
+  queue_name: string;
+}
+
+interface Props {
+  size?: 'sm' | 'md';
+  bulkTransfer?: boolean;
+  modelValue: QueueOption[];
+  fixed?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 'md',
+  bulkTransfer: false,
+  fixed: false,
+});
+
+const emit = defineEmits<{
+  'update:model-value': [value: QueueOption[]];
+  'update:selectedAgent': [value: AgentOption[]];
+  'transfer-complete': [status: 'success' | 'error'];
+}>();
+
+defineOptions({ name: 'RoomsTransferFields' });
+
 const BULK_TRANSFER_BATCH_SIZE = 200;
 
-export default {
-  name: 'RoomsTransferFields',
-
-  props: {
-    size: {
-      type: String,
-      default: 'md',
-      validator(value) {
-        return ['sm', 'md'].includes(value);
-      },
-    },
-    bulkTransfer: {
-      type: Boolean,
-      default: false,
-    },
-    modelValue: {
-      type: Array,
-      required: true,
-    },
-    fixed: {
-      type: Boolean,
-      default: false,
-    },
-  },
-
-  emits: ['update:model-value', 'update:selectedAgent', 'transfer-complete'],
-
-  data() {
-    return {
-      isMobile: isMobile(),
-
-      queues: [],
-      agents: [],
-      selectedAgent: null,
-
-      searchQueue: '',
-      searchAgent: '',
-
-      showTransferDisclaimer: false,
-    };
-  },
-
-  computed: {
-    ...mapState(useRooms, [
-      'contactToTransfer',
-      'rooms',
-      'activeRoom',
-      'activeTab',
-      'selectedOngoingRooms',
-      'selectedWaitingRooms',
-    ]),
-    ...mapWritableState(useRooms, ['activeRoomTags']),
-    ...mapState(useProfile, ['me']),
-
-    currentSelectedRooms() {
-      return this.activeTab === 'ongoing'
-        ? this.selectedOngoingRooms
-        : this.selectedWaitingRooms;
-    },
-
-    roomsToTransfer() {
-      if (this.bulkTransfer) {
-        return this.rooms.filter((room) =>
-          this.currentSelectedRooms.includes(room.uuid),
-        );
-      }
-
-      return this.rooms.filter((room) => room.uuid === this.contactToTransfer);
-    },
-
-    showTransferToOtherSectorDisclaimer() {
-      const queueOption = this.modelValue?.[0];
-      if (!queueOption?.value) return false;
-
-      return this.roomsToTransfer.some(
-        (room) => room.queue?.sector !== queueOption?.sector_uuid,
-      );
-    },
-
-    dropdownFixed() {
-      return this.fixed ? 'fixed' : 'relative';
-    },
-
-    selectedQueueOption: {
-      get() {
-        return this.modelValue?.[0] || null;
-      },
-      set(option) {
-        this.$emit('update:model-value', option ? [option] : []);
-
-        if (option?.value) {
-          this.getAgents(option.value);
-        }
-      },
-    },
-
-    isAgentsFieldDisabled() {
-      const queueValue = this.modelValue?.[0]?.value;
-      return !queueValue || this.agents?.length === 0;
-    },
-
-    isSelectedAgentOffline() {
-      return (
-        this.selectedAgent?.value && this.selectedAgent?.status === 'offline'
-      );
-    },
-    haveSelectedQueue() {
-      return !!this.modelValue?.[0]?.value;
-    },
-
-    isAgentsListEmpty() {
-      return this.haveSelectedQueue && this.agents?.length === 0;
-    },
-
-    transferDisclaimerText() {
-      if (this.isSelectedAgentOffline) {
-        return this.$t('bulk_transfer.disclaimer.selected_agent_offline');
-      }
-
-      if (this.isAgentsListEmpty) {
-        return this.$t('bulk_transfer.disclaimer.without_online_agents');
-      }
-      return '';
-    },
-  },
-
-  watch: {
-    selectedAgent(newSelectedAgent) {
-      this.$emit(
-        'update:selectedAgent',
-        newSelectedAgent ? [newSelectedAgent] : [],
-      );
-
-      this.showTransferDisclaimer = newSelectedAgent?.status === 'offline';
-    },
-    modelValue: {
-      handler(newValue) {
-        const queueUuid = newValue?.[0]?.value;
-        if (queueUuid) {
-          this.getAgents(queueUuid);
-        }
-      },
-      immediate: false,
-    },
-  },
-
-  mounted() {
-    this.queues = [];
-    this.agents = [];
-    this.getQueues();
-  },
-
-  methods: {
-    ...mapActions(useRooms, [
-      'setSelectedOngoingRooms',
-      'setSelectedWaitingRooms',
-      'setContactToTransfer',
-      'removeRoom',
-    ]),
-
-    async getQueues() {
-      const newQueues = await Queue.listByProject();
-
-      const treatedQueues = newQueues.results.map(
-        ({ name, sector_name, uuid, sector_uuid }) => ({
-          sector_uuid,
-          queue_name: name,
-          label: `${name} | ${i18n.global.t('sector.title')} ${sector_name}`,
-          value: uuid,
-        }),
-      );
-
-      this.queues = treatedQueues;
-    },
-
-    async getAgents(queueUuid) {
-      this.showTransferDisclaimer = false;
-
-      const newAgents = await Queue.agentsToTransfer(queueUuid);
-
-      const treatedAgents = newAgents
-        .filter((agent) => agent.email !== this.me.email)
-        .map(({ first_name, last_name, email, status }) => ({
-          label: [first_name, last_name].join(' ').trim() || email,
-          value: email,
-          status,
-        }));
-
-      if (treatedAgents.length === 0) {
-        this.showTransferDisclaimer = true;
-      }
-
-      this.agents = treatedAgents;
-    },
-
-    async transfer() {
-      const { roomsToTransfer } = this;
-
-      const selectedQueue = this.modelValue?.[0]?.value;
-      const selectedAgent = this.selectedAgent?.value;
-
-      const roomUuids = roomsToTransfer.map((room) => room.uuid);
-
-      if (!this.bulkTransfer) {
-        return this.transferSingle(roomUuids, selectedQueue, selectedAgent);
-      }
-
-      return this.transferBulk(roomUuids, selectedQueue, selectedAgent);
-    },
-
-    async transferSingle(roomUuids, selectedQueue, selectedAgent) {
-      try {
-        const response = await Room.bulkTranfer({
-          rooms: roomUuids,
-          intended_queue: selectedQueue,
-          intended_agent: selectedAgent,
-        });
-
-        if (response.status === 200) {
-          this.callSingleSuccessAlert();
-          this.resetRoomsToTransfer();
-          if (this.activeRoom) {
-            const { results } = await Room.getRoomTags(this.activeRoom.uuid, {
-              next: this.tagsNext,
-              limit: 20,
-            });
-            this.activeRoomTags = results;
-          }
-          this.$emit('transfer-complete', 'success');
-        } else {
-          this.showAlert(i18n.global.t('contact_transferred_error'), 'error');
-          this.$emit('transfer-complete', 'error');
-        }
-      } catch (error) {
-        console.error(
-          'An error occurred while performing the transfer:',
-          error,
-        );
-        this.showAlert(i18n.global.t('contact_transferred_error'), 'error');
-        this.$emit('transfer-complete', 'error');
-      }
-    },
-
-    async transferBulk(roomUuids, selectedQueue, selectedAgent) {
-      const chunks = [];
-      for (let i = 0; i < roomUuids.length; i += BULK_TRANSFER_BATCH_SIZE) {
-        chunks.push(roomUuids.slice(i, i + BULK_TRANSFER_BATCH_SIZE));
-      }
-
-      let totalSuccess = 0;
-      let totalFailed = 0;
-
-      for (const chunk of chunks) {
-        const response = await Room.bulkTranfer({
-          rooms: chunk,
-          intended_queue: selectedQueue,
-          intended_agent: selectedAgent,
-        });
-        const { data } = response;
-        totalSuccess += data?.success_count || 0;
-        totalFailed += data?.failed_count || 0;
-      }
-
-      if (totalFailed === 0 && totalSuccess > 0) {
-        this.showAlert(
-          i18n.global.tc('bulk_transfer.success_message', totalSuccess, {
-            count: totalSuccess,
-          }),
-          'success',
-        );
-        this.resetRoomsToTransfer();
-        this.$emit('transfer-complete', 'success');
-      } else if (totalFailed > 0 && totalSuccess > 0) {
-        this.showAlert(
-          i18n.global.tc(
-            'bulk_transfer.partial_success_message',
-            totalSuccess,
-            { success: totalSuccess, failed: totalFailed },
-          ),
-          'attention',
-        );
-        this.resetRoomsToTransfer();
-        this.$emit('transfer-complete', 'success');
-      } else {
-        this.showAlert(i18n.global.t('bulk_transfer.error_message'), 'error');
-        this.$emit('transfer-complete', 'error');
-      }
-    },
-
-    resetRoomsToTransfer() {
-      this.setSelectedOngoingRooms([]);
-      this.setSelectedWaitingRooms([]);
-      this.setContactToTransfer('');
-    },
-
-    callSingleSuccessAlert() {
-      const selectedAgent = this.selectedAgent?.[0]?.label;
-      const selectedQueueUuid = this.selectedQueue?.[0]?.value;
-      const selectedQueueName = this.queues.find(
-        (queue) => queue.value === selectedQueueUuid,
-      )?.queue_name;
-
-      const destination = selectedAgent || selectedQueueName;
-      const toDestination = selectedAgent ? 'agent' : 'queue';
-
-      this.showAlert(
-        i18n.global.t(`contact_transferred_to_${toDestination}`, {
-          [toDestination]: destination,
-        }),
-        'success',
-      );
-    },
-
-    showAlert(text, type) {
-      if (!this.isMobile) {
-        callUnnnicAlert({
-          props: { text, type },
-          seconds: 5,
-        });
-      }
-    },
-  },
+const STATUS_PRIORITY: Record<string, number> = {
+  online: 0,
+  offline: 2,
 };
+
+const roomsStore = useRooms();
+const profileStore = useProfile();
+const {
+  contactToTransfer,
+  rooms,
+  activeRoom,
+  activeTab,
+  selectedOngoingRooms,
+  selectedWaitingRooms,
+  activeRoomTags,
+} = storeToRefs(roomsStore);
+const { me } = storeToRefs(profileStore);
+
+const isMobileDevice = ref(isMobile());
+
+const queues = ref<QueueOption[]>([]);
+const agents = ref<AgentOption[]>([]);
+const selectedAgent = ref<AgentOption | null>(null);
+
+const searchQueue = ref('');
+const searchAgent = ref('');
+
+const showTransferDisclaimer = ref(false);
+
+const currentSelectedRooms = computed(() =>
+  activeTab.value === 'ongoing'
+    ? selectedOngoingRooms.value
+    : selectedWaitingRooms.value,
+);
+
+const roomsToTransfer = computed(() => {
+  if (props.bulkTransfer) {
+    return rooms.value.filter((room: { uuid: string }) =>
+      currentSelectedRooms.value.includes(room.uuid),
+    );
+  }
+
+  return rooms.value.filter(
+    (room: { uuid: string }) => room.uuid === contactToTransfer.value,
+  );
+});
+
+const showTransferToOtherSectorDisclaimer = computed(() => {
+  const queueOption = props.modelValue?.[0];
+  if (!queueOption?.value) return false;
+
+  return roomsToTransfer.value.some(
+    (room: { queue?: { sector?: string } }) =>
+      room.queue?.sector !== queueOption?.sector_uuid,
+  );
+});
+
+const selectedQueueOption = computed<QueueOption | null>({
+  get() {
+    return props.modelValue?.[0] || null;
+  },
+  set(option) {
+    emit('update:model-value', option ? [option] : []);
+
+    if (option?.value) {
+      getAgents(option.value);
+    }
+  },
+});
+
+const isAgentsFieldDisabled = computed(() => {
+  const queueValue = props.modelValue?.[0]?.value;
+  return !queueValue || agents.value?.length === 0;
+});
+
+const isSelectedAgentOffline = computed(
+  () =>
+    !!selectedAgent.value?.value && selectedAgent.value?.status === 'offline',
+);
+
+const haveSelectedQueue = computed(() => !!props.modelValue?.[0]?.value);
+
+const isAgentsListEmpty = computed(
+  () => haveSelectedQueue.value && agents.value?.length === 0,
+);
+
+const transferDisclaimerText = computed(() => {
+  if (isSelectedAgentOffline.value) {
+    return i18n.global.t('bulk_transfer.disclaimer.selected_agent_offline');
+  }
+
+  if (isAgentsListEmpty.value) {
+    return i18n.global.t('bulk_transfer.disclaimer.without_online_agents');
+  }
+  return '';
+});
+
+const sortedAgents = computed<AgentOption[]>(() => {
+  return [...agents.value].sort((a, b) => {
+    const priorityA = getStatusPriority(a.status);
+    const priorityB = getStatusPriority(b.status);
+    if (priorityA !== priorityB) return priorityA - priorityB;
+    return a.label.localeCompare(b.label);
+  });
+});
+
+function getStatusPriority(status: AgentStatus): number {
+  if (status in STATUS_PRIORITY) return STATUS_PRIORITY[status];
+  return 1;
+}
+
+function getAgentStatusLabel(status: AgentStatus): string {
+  if (!status) return '';
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+function getAgentStatusScheme(status: AgentStatus): string {
+  if (status === 'online') return 'aux-green';
+  if (status === 'offline') return 'aux-gray';
+  return 'aux-orange';
+}
+
+watch(selectedAgent, (newSelectedAgent) => {
+  emit('update:selectedAgent', newSelectedAgent ? [newSelectedAgent] : []);
+
+  showTransferDisclaimer.value = newSelectedAgent?.status === 'offline';
+});
+
+watch(
+  () => props.modelValue,
+  (newValue) => {
+    const queueUuid = newValue?.[0]?.value;
+    if (queueUuid) {
+      getAgents(queueUuid);
+    }
+  },
+);
+
+onMounted(() => {
+  queues.value = [];
+  agents.value = [];
+  getQueues();
+});
+
+async function getQueues() {
+  const newQueues = await Queue.listByProject();
+
+  queues.value = newQueues.results.map(
+    ({
+      name,
+      sector_name,
+      uuid,
+      sector_uuid,
+    }: {
+      name: string;
+      sector_name: string;
+      uuid: string;
+      sector_uuid: string;
+    }) => ({
+      sector_uuid,
+      queue_name: name,
+      label: `${name} | ${i18n.global.t('sector.title')} ${sector_name}`,
+      value: uuid,
+    }),
+  );
+}
+
+async function getAgents(queueUuid: string) {
+  showTransferDisclaimer.value = false;
+
+  const newAgents: AgentApi[] = await Queue.agentsToTransfer(queueUuid);
+
+  const treatedAgents = newAgents
+    .filter((agent) => agent.email !== me.value?.email)
+    .map<AgentOption>(({ first_name, last_name, email, status }) => ({
+      label: [first_name, last_name].join(' ').trim() || email,
+      value: email,
+      status,
+    }));
+
+  if (treatedAgents.length === 0) {
+    showTransferDisclaimer.value = true;
+  }
+
+  agents.value = treatedAgents;
+}
+
+async function transfer() {
+  const selectedQueue = props.modelValue?.[0]?.value;
+  const intendedAgent = selectedAgent.value?.value;
+
+  const roomUuids = roomsToTransfer.value.map(
+    (room: { uuid: string }) => room.uuid,
+  );
+
+  if (!props.bulkTransfer) {
+    return transferSingle(roomUuids, selectedQueue, intendedAgent);
+  }
+
+  return transferBulk(roomUuids, selectedQueue, intendedAgent);
+}
+
+async function transferSingle(
+  roomUuids: string[],
+  selectedQueue: string | undefined,
+  intendedAgent: string | undefined,
+) {
+  try {
+    const response = await Room.bulkTranfer({
+      rooms: roomUuids,
+      intended_queue: selectedQueue,
+      intended_agent: intendedAgent,
+    });
+
+    if (response.status === 200) {
+      callSingleSuccessAlert();
+      resetRoomsToTransfer();
+      if (activeRoom.value) {
+        const { results } = await Room.getRoomTags(activeRoom.value.uuid, {
+          next: null,
+          limit: 20,
+        });
+        activeRoomTags.value = results;
+      }
+      emit('transfer-complete', 'success');
+    } else {
+      showAlert(i18n.global.t('contact_transferred_error'), 'error');
+      emit('transfer-complete', 'error');
+    }
+  } catch (error) {
+    console.error('An error occurred while performing the transfer:', error);
+    showAlert(i18n.global.t('contact_transferred_error'), 'error');
+    emit('transfer-complete', 'error');
+  }
+}
+
+async function transferBulk(
+  roomUuids: string[],
+  selectedQueue: string | undefined,
+  intendedAgent: string | undefined,
+) {
+  const chunks: string[][] = [];
+  for (let i = 0; i < roomUuids.length; i += BULK_TRANSFER_BATCH_SIZE) {
+    chunks.push(roomUuids.slice(i, i + BULK_TRANSFER_BATCH_SIZE));
+  }
+
+  let totalSuccess = 0;
+  let totalFailed = 0;
+
+  for (const chunk of chunks) {
+    const response = await Room.bulkTranfer({
+      rooms: chunk,
+      intended_queue: selectedQueue,
+      intended_agent: intendedAgent,
+    });
+    const { data } = response;
+    totalSuccess += data?.success_count || 0;
+    totalFailed += data?.failed_count || 0;
+  }
+
+  if (totalFailed === 0 && totalSuccess > 0) {
+    showAlert(
+      i18n.global.tc('bulk_transfer.success_message', totalSuccess, {
+        count: totalSuccess,
+      }),
+      'success',
+    );
+    resetRoomsToTransfer();
+    emit('transfer-complete', 'success');
+  } else if (totalFailed > 0 && totalSuccess > 0) {
+    showAlert(
+      i18n.global.tc('bulk_transfer.partial_success_message', totalSuccess, {
+        success: totalSuccess,
+        failed: totalFailed,
+      }),
+      'attention',
+    );
+    resetRoomsToTransfer();
+    emit('transfer-complete', 'success');
+  } else {
+    showAlert(i18n.global.t('bulk_transfer.error_message'), 'error');
+    emit('transfer-complete', 'error');
+  }
+}
+
+function resetRoomsToTransfer() {
+  roomsStore.setSelectedOngoingRooms([]);
+  roomsStore.setSelectedWaitingRooms([]);
+  roomsStore.setContactToTransfer('');
+}
+
+function callSingleSuccessAlert() {
+  const selectedAgentLabel = selectedAgent.value?.label;
+  const selectedQueueUuid = props.modelValue?.[0]?.value;
+  const selectedQueueName = queues.value.find(
+    (queue) => queue.value === selectedQueueUuid,
+  )?.queue_name;
+
+  const destination = selectedAgentLabel || selectedQueueName;
+  const toDestination = selectedAgentLabel ? 'agent' : 'queue';
+
+  showAlert(
+    i18n.global.t(`contact_transferred_to_${toDestination}`, {
+      [toDestination]: destination,
+    }),
+    'success',
+  );
+}
+
+function showAlert(text: string, type: 'success' | 'error' | 'attention') {
+  if (!isMobileDevice.value) {
+    callUnnnicAlert({
+      props: { text, type },
+      seconds: 5,
+    });
+  }
+}
+
+defineExpose({
+  transfer,
+  showAlert,
+  agents,
+  sortedAgents,
+  selectedAgent,
+  queues,
+  currentSelectedRooms,
+  isMobile: isMobileDevice,
+  getAgentStatusLabel,
+  getAgentStatusScheme,
+});
 </script>
 
 <style lang="scss" scoped>
 .rooms-transfer {
   &__select-destination {
     display: grid;
-    gap: $unnnic-spacing-sm;
+    gap: $unnnic-space-4;
 
     &.small {
-      gap: $unnnic-spacing-nano;
+      gap: $unnnic-space-1;
     }
 
     .select-destination {
@@ -414,15 +484,31 @@ export default {
         text-align: left;
 
         .field__label {
-          margin: 0 0 $unnnic-spacing-xs;
+          margin: 0 0 $unnnic-space-2;
         }
       }
 
       &__disclaimer {
-        margin-top: -$unnnic-spacing-nano;
+        margin-top: -$unnnic-space-1;
 
         &--small {
-          margin-top: $unnnic-spacing-xs;
+          margin-top: $unnnic-space-2;
+        }
+      }
+
+      &__agent-option {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: $unnnic-space-2;
+        width: 100%;
+
+        &__label {
+          flex: 1 1 0;
+          min-width: 0;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
         }
       }
     }

--- a/src/components/chats/__tests__/ModalTransferRooms.spec.js
+++ b/src/components/chats/__tests__/ModalTransferRooms.spec.js
@@ -1,14 +1,20 @@
-import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { mount } from '@vue/test-utils';
+import {
+  vi,
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from 'vitest';
+import { mount, flushPromises, config } from '@vue/test-utils';
 import { createTestingPinia } from '@pinia/testing';
 
 import ModalTransferRooms from '../chat/ModalTransferRooms.vue';
 
 vi.mock('@/services/api/resources/chats/room', () => ({
   default: {
-    bulkTranfer: vi.fn(() => {
-      return Promise.resolve({ status: 200 });
-    }),
+    bulkTranfer: vi.fn(() => Promise.resolve({ status: 200 })),
     getRoomTags: vi.fn(() => ({ results: [] })),
   },
 }));
@@ -17,13 +23,37 @@ vi.mock('@/services/api/resources/settings/queue', () => ({
   default: {
     listByProject: vi.fn(() => ({
       results: [
-        { name: 'Queue 1', sector_name: 'Sector 1', uuid: '1' },
-        { name: 'Queue 2', sector_name: 'Sector 2', uuid: '2' },
+        {
+          name: 'Queue 1',
+          sector_name: 'Sector 1',
+          uuid: '1',
+          sector_uuid: 's1',
+        },
+        {
+          name: 'Queue 2',
+          sector_name: 'Sector 2',
+          uuid: '2',
+          sector_uuid: 's2',
+        },
       ],
     })),
     agentsToTransfer: vi.fn(() => [
-      { first_name: 'John', last_name: 'Doe', email: 'john@doe.com' },
-      { first_name: 'Jane', last_name: 'Doe', email: 'jane@doe.com' },
+      {
+        first_name: 'John',
+        last_name: 'Doe',
+        email: 'john@doe.com',
+        status: 'online',
+        photo_url: null,
+        language: 'pt-br',
+      },
+      {
+        first_name: 'Jane',
+        last_name: 'Doe',
+        email: 'jane@doe.com',
+        status: 'online',
+        photo_url: null,
+        language: 'pt-br',
+      },
     ]),
   },
 }));
@@ -32,6 +62,52 @@ vi.mock('@/utils/callUnnnicAlert', () => ({
   default: vi.fn(),
 }));
 
+let savedGlobalMocks;
+let savedGlobalStubs;
+
+beforeAll(() => {
+  savedGlobalMocks = { ...config.global.mocks };
+  savedGlobalStubs = { ...config.global.stubs };
+  config.global.mocks = {};
+  config.global.stubs = {
+    ...savedGlobalStubs,
+    UnnnicDialog: {
+      template: '<div><slot /></div>',
+      props: ['open'],
+    },
+    UnnnicDialogContent: {
+      template: '<div><slot /></div>',
+      props: ['size'],
+    },
+    UnnnicDialogHeader: {
+      template: '<div><slot /></div>',
+      props: ['closeButton'],
+    },
+    UnnnicDialogTitle: {
+      template: '<div><slot /></div>',
+    },
+    UnnnicDialogFooter: {
+      template: '<div><slot /></div>',
+    },
+    UnnnicDialogClose: {
+      template: '<div><slot /></div>',
+    },
+    UnnnicButton: {
+      template: '<button v-bind="$attrs"><slot /></button>',
+      props: ['text', 'type', 'loading', 'disabled'],
+    },
+    UnnnicDisclaimer: {
+      template: '<div v-bind="$attrs">{{ description }}</div>',
+      props: ['type', 'description'],
+    },
+  };
+});
+
+afterAll(() => {
+  config.global.mocks = savedGlobalMocks;
+  config.global.stubs = savedGlobalStubs;
+});
+
 function createStore(overrides = {}) {
   return createTestingPinia({
     initialState: {
@@ -39,6 +115,10 @@ function createStore(overrides = {}) {
         selectedOngoingRooms: ['1', '2'],
         selectedWaitingRooms: [],
         activeTab: 'ongoing',
+        rooms: [],
+        contactToTransfer: '',
+        activeRoom: null,
+        activeRoomTags: [],
         ...overrides,
       },
       profile: { me: { email: 'mocked@email.com' } },
@@ -47,58 +127,22 @@ function createStore(overrides = {}) {
 }
 
 function createWrapper(store, props = {}) {
-  const wrapper = mount(ModalTransferRooms, {
+  return mount(ModalTransferRooms, {
     props: {
       modelValue: true,
       ...props,
     },
     global: {
       plugins: [store],
-      mocks: {
-        $t: (key) => key,
-        $tc: (key, count, params) => `${key}_${count}`,
-      },
-      stubs: {
-        UnnnicDialog: {
-          template: '<div><slot /></div>',
-          props: ['open'],
-        },
-        UnnnicDialogContent: {
-          template: '<div><slot /></div>',
-          props: ['size'],
-        },
-        UnnnicDialogHeader: {
-          template: '<div><slot /></div>',
-          props: ['closeButton'],
-        },
-        UnnnicDialogTitle: {
-          template: '<div><slot /></div>',
-        },
-        UnnnicDialogFooter: {
-          template: '<div><slot /></div>',
-        },
-        UnnnicDialogClose: {
-          template: '<div><slot /></div>',
-        },
-        UnnnicButton: {
-          template: '<button v-bind="$attrs"><slot /></button>',
-          props: ['text', 'type', 'loading', 'disabled'],
-        },
-        UnnnicDisclaimer: {
-          template: '<div v-bind="$attrs">{{ description }}</div>',
-          props: ['type', 'description'],
-        },
-      },
     },
   });
-
-  return wrapper;
 }
 
 describe('ModalTransferRooms', () => {
   let wrapper;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     const store = createStore();
     wrapper = createWrapper(store);
   });
@@ -166,9 +210,8 @@ describe('ModalTransferRooms', () => {
 
   describe('Button States', () => {
     it('should disable transfer button when no queue is selected', async () => {
-      await wrapper.setData({
-        selectedQueue: [{ value: '', label: 'Select queue' }],
-      });
+      wrapper.vm.selectedQueue = [{ value: '', label: 'Select queue' }];
+      await flushPromises();
       expect(wrapper.vm.disabledTransferButton).toBe(true);
     });
 
@@ -178,19 +221,15 @@ describe('ModalTransferRooms', () => {
     });
 
     it('should enable transfer button when queue is selected', async () => {
-      await wrapper.setData({
-        selectedQueue: [{ value: '1', label: 'Queue' }],
-      });
+      wrapper.vm.selectedQueue = [{ value: '1', label: 'Queue' }];
+      await flushPromises();
       expect(wrapper.vm.disabledTransferButton).toBe(false);
     });
 
     it('should show loading state when bulk transfer is in progress', async () => {
-      await wrapper.setData({
-        isLoadingBulkTransfer: true,
-        selectedQueue: [{ value: '1', label: 'Queue' }],
-      });
-
-      await wrapper.vm.$nextTick();
+      wrapper.vm.isLoadingBulkTransfer = true;
+      wrapper.vm.selectedQueue = [{ value: '1', label: 'Queue' }];
+      await flushPromises();
 
       expect(wrapper.vm.isLoadingBulkTransfer).toBe(true);
     });

--- a/src/components/chats/__tests__/RoomsTransferFields.spec.js
+++ b/src/components/chats/__tests__/RoomsTransferFields.spec.js
@@ -1,5 +1,13 @@
-import { describe, expect, it, vi } from 'vitest';
-import { mount, flushPromises } from '@vue/test-utils';
+import {
+  describe,
+  expect,
+  it,
+  vi,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from 'vitest';
+import { mount, flushPromises, config } from '@vue/test-utils';
 import { createTestingPinia } from '@pinia/testing';
 
 import QueueService from '@/services/api/resources/settings/queue';
@@ -12,13 +20,37 @@ vi.mock('@/services/api/resources/settings/queue', () => ({
   default: {
     listByProject: vi.fn(() => ({
       results: [
-        { name: 'Queue 1', sector_name: 'Sector 1', uuid: '1' },
-        { name: 'Queue 2', sector_name: 'Sector 2', uuid: '2' },
+        {
+          name: 'Queue 1',
+          sector_name: 'Sector 1',
+          uuid: '1',
+          sector_uuid: 's1',
+        },
+        {
+          name: 'Queue 2',
+          sector_name: 'Sector 2',
+          uuid: '2',
+          sector_uuid: 's2',
+        },
       ],
     })),
     agentsToTransfer: vi.fn(() => [
-      { first_name: 'John', last_name: 'Doe', email: 'john@doe.com' },
-      { first_name: 'Jane', last_name: 'Doe', email: 'jane@doe.com' },
+      {
+        first_name: 'John',
+        last_name: 'Doe',
+        email: 'john@doe.com',
+        status: 'online',
+        photo_url: null,
+        language: 'pt-br',
+      },
+      {
+        first_name: 'Jane',
+        last_name: 'Doe',
+        email: 'jane@doe.com',
+        status: 'online',
+        photo_url: null,
+        language: 'pt-br',
+      },
     ]),
   },
 }));
@@ -34,6 +66,17 @@ vi.mock('@/utils/callUnnnicAlert', () => ({
   default: vi.fn(),
 }));
 
+let savedGlobalMocks;
+
+beforeAll(() => {
+  savedGlobalMocks = { ...config.global.mocks };
+  config.global.mocks = {};
+});
+
+afterAll(() => {
+  config.global.mocks = savedGlobalMocks;
+});
+
 const mockRooms = [
   { uuid: '1', queue: { sector: 's1' } },
   { uuid: '2', queue: { sector: 's1' } },
@@ -46,6 +89,9 @@ function createStore(overrides = {}) {
     selectedWaitingRooms: [],
     activeTab: 'ongoing',
     rooms: mockRooms,
+    contactToTransfer: '',
+    activeRoom: null,
+    activeRoomTags: [],
   };
 
   return createTestingPinia({
@@ -90,6 +136,7 @@ describe('RoomsTransferField', () => {
 
   describe('Data Loading', () => {
     it('should load queues when created', async () => {
+      await flushPromises();
       expect(wrapper.vm.queues.length).toBeGreaterThan(1);
     });
   });
@@ -100,33 +147,15 @@ describe('RoomsTransferField', () => {
       await wrapper.setProps({
         modelValue: [{ value: 'queue_id', label: 'Queue' }],
       });
-      await wrapper.setData({
-        agents: [
-          { value: 'agent1_id', label: 'Agent1' },
-          { value: 'agent2_id', label: 'Agent2' },
-        ],
-      });
-
-      await wrapper.vm.$nextTick();
+      await flushPromises();
 
       expect(agentSelect.props('disabled')).toBe(false);
-
-      await wrapper.setData({
-        agents: [{ value: 'agent1_id', label: 'Agent1' }],
-      });
-      await wrapper.vm.$nextTick();
 
       await wrapper.setProps({
         modelValue: [],
       });
-      await wrapper.setData({
-        agents: [
-          { value: 'agent1_id', label: 'Agent1' },
-          { value: 'agent2_id', label: 'Agent2' },
-        ],
-      });
 
-      await wrapper.vm.$nextTick();
+      await flushPromises();
       expect(agentSelect.props('disabled')).toBe(true);
     });
 
@@ -153,25 +182,130 @@ describe('RoomsTransferField', () => {
           last_name: 'Doe',
           email: 'john@doe.com',
           status: 'offline',
+          photo_url: null,
+          language: 'pt-br',
         },
       ]);
 
       await wrapper.setProps({
         modelValue: [{ value: 'queue_id', label: 'Queue' }],
       });
-      await wrapper.setData({
-        selectedAgent: {
-          label: 'John Doe',
-          value: 'john@doe.com',
-          status: 'offline',
-        },
-      });
+      await flushPromises();
+
+      wrapper.vm.selectedAgent = {
+        label: 'John Doe',
+        value: 'john@doe.com',
+        status: 'offline',
+      };
+
+      await flushPromises();
 
       const transferDisclaimer = wrapper.findComponent(
         '[data-testid="transfer-disclaimer"]',
       );
 
       expect(transferDisclaimer.exists()).toBe(true);
+    });
+  });
+
+  describe('Agent Sorting and Status Tags', () => {
+    it('should sort agents by status priority then alphabetically by label', async () => {
+      vi.mocked(QueueService.agentsToTransfer).mockImplementationOnce(() => [
+        {
+          first_name: 'Ricardo',
+          last_name: '',
+          email: 'ricardo@doe.com',
+          status: 'offline',
+          photo_url: null,
+          language: 'pt-br',
+        },
+        {
+          first_name: 'Davi',
+          last_name: '',
+          email: 'davi@doe.com',
+          status: 'launch',
+          photo_url: null,
+          language: 'pt-br',
+        },
+        {
+          first_name: 'Anna',
+          last_name: '',
+          email: 'anna@doe.com',
+          status: 'online',
+          photo_url: null,
+          language: 'pt-br',
+        },
+        {
+          first_name: 'João',
+          last_name: '',
+          email: 'joao@doe.com',
+          status: 'offline',
+          photo_url: null,
+          language: 'pt-br',
+        },
+        {
+          first_name: 'Ana',
+          last_name: '',
+          email: 'ana@doe.com',
+          status: 'online',
+          photo_url: null,
+          language: 'pt-br',
+        },
+      ]);
+
+      await wrapper.setProps({
+        modelValue: [{ value: 'queue_id', label: 'Queue' }],
+      });
+      await flushPromises();
+
+      const sortedLabels = wrapper.vm.sortedAgents.map((a) => a.label);
+      expect(sortedLabels).toEqual(['Ana', 'Anna', 'Davi', 'João', 'Ricardo']);
+    });
+
+    it('should map status to the expected tag scheme', () => {
+      expect(wrapper.vm.getAgentStatusScheme('online')).toBe('aux-green');
+      expect(wrapper.vm.getAgentStatusScheme('offline')).toBe('aux-gray');
+      expect(wrapper.vm.getAgentStatusScheme('launch')).toBe('aux-orange');
+      expect(wrapper.vm.getAgentStatusScheme('any_custom_break')).toBe(
+        'aux-orange',
+      );
+    });
+
+    it('should localize online/offline labels and capitalize custom statuses', () => {
+      expect(wrapper.vm.getAgentStatusLabel('online')).toBe('Online');
+      expect(wrapper.vm.getAgentStatusLabel('offline')).toBe('Offline');
+      expect(wrapper.vm.getAgentStatusLabel('launch')).toBe('Launch');
+      expect(wrapper.vm.getAgentStatusLabel('lunch_break')).toBe('Lunch_break');
+    });
+
+    it('should exclude the current user from the agent list', async () => {
+      vi.mocked(QueueService.agentsToTransfer).mockImplementationOnce(() => [
+        {
+          first_name: 'Me',
+          last_name: '',
+          email: 'mock@email.com',
+          status: 'online',
+          photo_url: null,
+          language: 'pt-br',
+        },
+        {
+          first_name: 'Other',
+          last_name: '',
+          email: 'other@email.com',
+          status: 'online',
+          photo_url: null,
+          language: 'pt-br',
+        },
+      ]);
+
+      await wrapper.setProps({
+        modelValue: [{ value: 'queue_id', label: 'Queue' }],
+      });
+      await flushPromises();
+
+      const emails = wrapper.vm.agents.map((a) => a.value);
+      expect(emails).not.toContain('mock@email.com');
+      expect(emails).toContain('other@email.com');
     });
   });
 

--- a/src/components/chats/__tests__/RoomsTransferFields.spec.js
+++ b/src/components/chats/__tests__/RoomsTransferFields.spec.js
@@ -271,11 +271,12 @@ describe('RoomsTransferField', () => {
       );
     });
 
-    it('should localize online/offline labels and capitalize custom statuses', () => {
+    it('should capitalize the raw backend status as the tag label', () => {
       expect(wrapper.vm.getAgentStatusLabel('online')).toBe('Online');
       expect(wrapper.vm.getAgentStatusLabel('offline')).toBe('Offline');
       expect(wrapper.vm.getAgentStatusLabel('launch')).toBe('Launch');
       expect(wrapper.vm.getAgentStatusLabel('lunch_break')).toBe('Lunch_break');
+      expect(wrapper.vm.getAgentStatusLabel('')).toBe('');
     });
 
     it('should exclude the current user from the agent list', async () => {

--- a/src/components/chats/chat/ModalTransferRooms.vue
+++ b/src/components/chats/chat/ModalTransferRooms.vue
@@ -52,93 +52,98 @@
   </UnnnicDialog>
 </template>
 
-<script>
-import { mapState } from 'pinia';
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { storeToRefs } from 'pinia';
 
 import { useRooms } from '@/store/modules/chats/rooms';
 
 import RoomsTransferFields from '@/components/chats/RoomsTransferFields.vue';
 import i18n from '@/plugins/i18n';
 
-export default {
-  name: 'ModalTransferRooms',
+interface QueueOption {
+  label: string;
+  value: string;
+  sector_uuid: string;
+  queue_name: string;
+}
 
-  components: {
-    RoomsTransferFields,
-  },
-  props: {
-    modelValue: {
-      type: Boolean,
-      required: true,
-    },
-    bulkTransfer: {
-      type: Boolean,
-      default: false,
-    },
-  },
+interface Props {
+  modelValue: boolean;
+  bulkTransfer?: boolean;
+}
 
-  emits: ['close', 'update:modelValue'],
+const props = withDefaults(defineProps<Props>(), {
+  bulkTransfer: false,
+});
 
-  data() {
-    return {
-      selectedQueue: [],
-      isLoadingBulkTransfer: false,
-    };
-  },
+const emit = defineEmits<{
+  close: [];
+  'update:modelValue': [value: boolean];
+}>();
 
-  computed: {
-    ...mapState(useRooms, [
-      'selectedOngoingRooms',
-      'selectedWaitingRooms',
-      'activeTab',
-    ]),
+defineOptions({ name: 'ModalTransferRooms' });
 
-    open: {
-      get() {
-        return this.modelValue;
-      },
-      set(value) {
-        this.$emit('update:modelValue', value);
-      },
-    },
-    disabledTransferButton() {
-      return (
-        this.selectedQueue.length === 0 || this.selectedQueue[0]?.value === ''
-      );
-    },
-    currentSelectedRooms() {
-      return this.activeTab === 'ongoing'
-        ? this.selectedOngoingRooms
-        : this.selectedWaitingRooms;
-    },
-    disclaimerDescription() {
-      return i18n.global.tc(
-        'bulk_transfer.selected_chats_count',
-        this.currentSelectedRooms.length,
-        { count: this.currentSelectedRooms.length },
-      );
-    },
-  },
+const roomsStore = useRooms();
+const { selectedOngoingRooms, selectedWaitingRooms, activeTab } =
+  storeToRefs(roomsStore);
 
-  methods: {
-    transfer() {
-      this.isLoadingBulkTransfer = true;
+const selectedQueue = ref<QueueOption[]>([]);
+const isLoadingBulkTransfer = ref(false);
+const roomsTransferFields = ref<InstanceType<
+  typeof RoomsTransferFields
+> | null>(null);
 
-      this.$refs.roomsTransferFields.transfer();
-    },
+const open = computed<boolean>({
+  get: () => props.modelValue,
+  set: (value) => emit('update:modelValue', value),
+});
 
-    transferComplete(status) {
-      this.isLoadingBulkTransfer = false;
-      if (status !== 'error') {
-        this.emitClose();
-      }
-    },
+const disabledTransferButton = computed(
+  () =>
+    selectedQueue.value.length === 0 || selectedQueue.value[0]?.value === '',
+);
 
-    emitClose() {
-      this.$emit('close');
-    },
-  },
-};
+const currentSelectedRooms = computed(() =>
+  activeTab.value === 'ongoing'
+    ? selectedOngoingRooms.value
+    : selectedWaitingRooms.value,
+);
+
+const disclaimerDescription = computed(() =>
+  i18n.global.tc(
+    'bulk_transfer.selected_chats_count',
+    currentSelectedRooms.value.length,
+    { count: currentSelectedRooms.value.length },
+  ),
+);
+
+function transfer() {
+  isLoadingBulkTransfer.value = true;
+  roomsTransferFields.value?.transfer();
+}
+
+function transferComplete(status: 'success' | 'error') {
+  isLoadingBulkTransfer.value = false;
+  if (status !== 'error') {
+    emitClose();
+  }
+}
+
+function emitClose() {
+  emit('close');
+}
+
+defineExpose({
+  selectedQueue,
+  isLoadingBulkTransfer,
+  disabledTransferButton,
+  currentSelectedRooms,
+  disclaimerDescription,
+  transfer,
+  transferComplete,
+  emitClose,
+});
 </script>
 
 <style lang="scss">
@@ -146,7 +151,7 @@ export default {
   &__content {
     display: flex;
     flex-direction: column;
-    gap: $unnnic-spacing-md;
+    gap: $unnnic-space-6;
     padding: $unnnic-space-6;
   }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -602,6 +602,7 @@
   "no_tags_assigned": "No tags assigned",
   "contact_await_for_you": "A contact is waiting for you!",
   "agent": "Agent",
+  "representative": "Representative",
   "ai_text_improvement": {
     "tooltip_disabled": "Write a response in the text field to enable improved responses with AI",
     "tooltip_enabled": "Improve response with AI",
@@ -832,6 +833,7 @@
   },
   "select_agent": "Select agent",
   "select_queue": "Select queue",
+  "select_representative": "Select a representative",
   "select_sector": "Select sector",
   "send_media": "Send media",
   "send_photo_or_video": "Send photo or video",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -606,6 +606,7 @@
   "no_tags_assigned": "No se han asignado etiquetas",
   "contact_await_for_you": "¡Un contacto está esperando por ti!",
   "agent": "Agente",
+  "representative": "Representante",
   "ai_text_improvement": {
     "tooltip_disabled": "Escribe una respuesta en el campo de texto para activar respuestas mejoradas con IA",
     "tooltip_enabled": "Mejorar respuesta con IA",
@@ -836,6 +837,7 @@
   },
   "select_agent": "Seleccionar agente",
   "select_queue": "Seleccionar cola",
+  "select_representative": "Seleccionar un representante",
   "select_sector": "Seleccionar sector",
   "send_media": "Enviar multimedia",
   "send_photo_or_video": "Enviar foto o vídeo",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -606,6 +606,7 @@
   "no_tags_assigned": "Nenhuma tag atribuída",
   "contact_await_for_you": "Um contato está esperando por você!",
   "agent": "Atendente",
+  "representative": "Representante",
   "ai_text_improvement": {
     "tooltip_disabled": "Escreva uma resposta no campo de texto para habilitar respostas aprimoradas com IA",
     "tooltip_enabled": "Melhorar resposta com IA",
@@ -838,6 +839,7 @@
   },
   "select_agent": "Selecionar agente",
   "select_queue": "Selecionar fila",
+  "select_representative": "Selecionar um representante",
   "select_sector": "Selecione setor",
   "send_media": "Enviar mídia",
   "send_photo_or_video": "Enviar foto ou vídeo",


### PR DESCRIPTION
## Description

### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
The room transfer flow had two pain points addressed by this PR:

1. The agent select did not surface the representative's availability, forcing agents to memorize who was online before transferring a chat — and frequently triggering transfers to offline peers.
2. `RoomsTransferFields`, `ModalTransferRooms` and `TransferSession` were still written with the Options API and the legacy `$unnnic-spacing-*` tokens, making them inconsistent with the rest of the modernized codebase and harder to type-check.

The new Figma design ships a status-aware variant of the Select that already exists in `@weni/unnnic-system` (`#option` + `#selected` slots with a colored `UnnnicTag`), so this PR wires the existing primitive into the transfer flow and brings the surrounding components up to the current project standards.

### Summary of Changes

- Migrated `RoomsTransferFields.vue`, `ModalTransferRooms.vue` and `TransferSession.vue` to `<script setup lang="ts">` with explicit `defineProps`, `defineEmits`, `defineExpose` and typed interfaces (`AgentApi`, `AgentOption`, `QueueOption`).
- Implemented the new agent select design using the Unnnic `#option` and `#selected` slots: representative name on the left, status `UnnnicTag` on the right (`aux-green` for `online`, `aux-gray` for `offline`, `aux-orange` for any custom break status).
- Added `sortedAgents` computed that orders the dropdown by status priority (Online → custom/break → Offline) and then alphabetically inside each bucket, matching the behavior annotation in Figma.
- The status label rendered in the tag is the raw backend value capitalized (e.g. `launch` → "Launch"), so any custom break configured per project shows up as-is with no extra translation work.
- Renamed the agent field copy to "Representative" / "Representante" / "Representante" via new `representative` and `select_representative` keys in `en.json`, `pt_br.json` and `es.json`. The legacy `agent` / `select_agent` keys are kept untouched because they are still consumed by Dashboard widgets and filters.
- Replaced every deprecated `$unnnic-spacing-*` token in the three touched components with the current `$unnnic-space-*` scale, per the workspace token migration rule.
- Used a scoped `.select-destination__agent-label` class plus a `:deep(.unnnic-select__trigger-content) { justify-content: space-between; }` rule so the trigger lays out exactly like the popover row (label grows + ellipsis, tag pinned to the right).
- Suppressed two non-fatal Vue 3.5 dev warnings caused by `useTemplateRef` inside `UnnnicSelect`
