### PR TITLE
[ENGAGE-8391] feat: enhance message input logic to support internal notes

### DIFF
--- a/src/components/chats/MessageManagerV2/TextBox/AiTextImprovement.vue
+++ b/src/components/chats/MessageManagerV2/TextBox/AiTextImprovement.vue
@@ -129,11 +129,13 @@ function handleMouseEnter() {
 }
 
 function handleButtonClick() {
-  if (isInternalNote.value || !inputMessage.value.trim()) {
+
+  if (isDisabled.value) {
     return;
   }
 
   isPopoverOpen.value = !isPopoverOpen.value;
+
 }
 
 async function selectOption(type: AiTextImprovementType) {

--- a/src/components/chats/MessageManagerV2/TextBox/AiTextImprovement.vue
+++ b/src/components/chats/MessageManagerV2/TextBox/AiTextImprovement.vue
@@ -94,9 +94,12 @@ const aiTextImprovement = useAiTextImprovement();
 const { isLoading, isPopoverOpen, showNewTag } = storeToRefs(aiTextImprovement);
 
 const messageManager = useMessageManager();
-const { inputMessage, isDisabledInput } = storeToRefs(messageManager);
+const { inputMessage, isDisabledInput, isInternalNote } =
+  storeToRefs(messageManager);
 
-const isDisabled = computed(() => !inputMessage.value.trim());
+const isDisabled = computed(
+  () => !inputMessage.value.trim() || isInternalNote.value,
+);
 
 const tooltipText = computed(() =>
   isDisabled.value
@@ -126,13 +129,17 @@ function handleMouseEnter() {
 }
 
 function handleButtonClick() {
-  if (!isDisabled.value) {
-    isPopoverOpen.value = !isPopoverOpen.value;
+  if (isInternalNote.value || !inputMessage.value.trim()) {
+    return;
   }
+
+  isPopoverOpen.value = !isPopoverOpen.value;
 }
 
 async function selectOption(type: AiTextImprovementType) {
   isPopoverOpen.value = false;
+
+  if (isInternalNote.value) return;
 
   const text = inputMessage.value.trim();
   if (!text) return;

--- a/src/components/chats/MessageManagerV2/TextBox/__tests__/AiTextImprovement.spec.js
+++ b/src/components/chats/MessageManagerV2/TextBox/__tests__/AiTextImprovement.spec.js
@@ -92,7 +92,12 @@ beforeAll(async () => {
 });
 
 const createWrapper = (options = {}) => {
-  const { inputMessage = '', isLoading = false, showNewTag = true } = options;
+  const {
+    inputMessage = '',
+    isInternalNote = false,
+    isLoading = false,
+    showNewTag = true,
+  } = options;
 
   const pinia = createPinia();
   setActivePinia(pinia);
@@ -103,6 +108,7 @@ const createWrapper = (options = {}) => {
 
   const msgStore = useMessageManager();
   msgStore.inputMessage = inputMessage;
+  msgStore.isInternalNote = isInternalNote;
 
   return mount(AiTextImprovement, {
     global: {
@@ -143,6 +149,28 @@ describe('AiTextImprovement', () => {
         '.ai-text-improvement__button-wrapper button',
       );
       expect(button.attributes('data-disabled')).toBe('false');
+    });
+
+    it('should disable button when isInternalNote is true even with text', () => {
+      const wrapper = createWrapper({
+        inputMessage: 'hello',
+        isInternalNote: true,
+      });
+      const button = wrapper.find(
+        '.ai-text-improvement__button-wrapper button',
+      );
+      expect(button.attributes('data-disabled')).toBe('true');
+    });
+
+    it('should show disabled tooltip when isInternalNote is true and has text', () => {
+      const wrapper = createWrapper({
+        inputMessage: 'hello',
+        isInternalNote: true,
+      });
+
+      expect(wrapper.vm.tooltipText).toBe(
+        'ai_text_improvement.tooltip_disabled',
+      );
     });
 
     it('should render 3 improvement options in the popover', () => {
@@ -242,6 +270,23 @@ describe('AiTextImprovement', () => {
 
     it('should not call requestImprovement when inputMessage is empty', async () => {
       const wrapper = createWrapper({ inputMessage: '   ' });
+      const store = useAiTextImprovement();
+      store.requestImprovement = vi.fn();
+
+      const firstOption = wrapper.find('.ai-text-improvement__popover-item');
+      if (firstOption.exists()) {
+        await firstOption.trigger('click');
+        await flushPromises();
+      }
+
+      expect(store.requestImprovement).not.toHaveBeenCalled();
+    });
+
+    it('should not call requestImprovement when isInternalNote is true', async () => {
+      const wrapper = createWrapper({
+        inputMessage: 'hello',
+        isInternalNote: true,
+      });
       const store = useAiTextImprovement();
       store.requestImprovement = vi.fn();
 

--- a/src/components/chats/MessageManagerV2/TextBox/__tests__/TextBox.spec.js
+++ b/src/components/chats/MessageManagerV2/TextBox/__tests__/TextBox.spec.js
@@ -13,6 +13,7 @@ import { setActivePinia } from 'pinia';
 
 import TextBox from '../index.vue';
 import { useMessageManager } from '@/store/modules/chats/messageManager';
+import { useAiTextImprovement } from '@/store/modules/chats/aiTextImprovement';
 import { useRoomMessages } from '@/store/modules/chats/roomMessages';
 import { useDiscussionMessages } from '@/store/modules/chats/discussionMessages';
 import i18n from '@/plugins/i18n';
@@ -303,6 +304,36 @@ describe('TextBox (index.vue)', () => {
       await wrapper.find('[data-testid="send-btn"]').trigger('click');
 
       expect(store.sendRoomMessage).toHaveBeenCalledWith(undefined);
+    });
+  });
+
+  describe('internal note mode', () => {
+    it('should reset AI store when isInternalNote becomes true', async () => {
+      const wrapper = createWrapper({
+        improvedText: 'improved',
+        originalText: 'original',
+        isAiLoading: true,
+      });
+      const messageManagerStore = useMessageManager();
+      const aiStore = useAiTextImprovement();
+
+      messageManagerStore.isInternalNote = true;
+      await wrapper.vm.$nextTick();
+
+      expect(aiStore.improvedText).toBe('');
+      expect(aiStore.isLoading).toBe(false);
+    });
+
+    it('should hide BackToOriginal when isInternalNote is true with improved text', () => {
+      const wrapper = createWrapper({
+        improvedText: 'improved',
+        originalText: 'original',
+        isInternalNote: true,
+      });
+
+      expect(wrapper.find('[data-testid="back-to-original"]').exists()).toBe(
+        false,
+      );
     });
   });
 });

--- a/src/components/chats/MessageManagerV2/TextBox/index.vue
+++ b/src/components/chats/MessageManagerV2/TextBox/index.vue
@@ -96,7 +96,7 @@ const { isLoading: isAiImproving, hasImprovedText } = storeToRefs(
 );
 
 const showBackToOriginal = computed(
-  () => hasImprovedText.value && !isAiImproving.value,
+  () => hasImprovedText.value && !isAiImproving.value && !isInternalNote.value,
 );
 
 const textareaRef = useTemplateRef('textArea');
@@ -155,8 +155,12 @@ const clearTextarea = () => {
   audioRecorderStatus.value = 'idle';
 };
 
-watch(isInternalNote, () => {
+watch(isInternalNote, (active) => {
   clearTextarea();
+
+  if (active) {
+    aiTextImprovementStore.reset();
+  }
 });
 
 defineExpose({


### PR DESCRIPTION
## Description

### Type of Change

```
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Tests
- [ ] Other
```

### Motivation and Context

The AI Text Improvement feature was accessible and functional even when the user was composing an internal note. Since AI-assisted improvements are not appropriate in the context of internal notes, the feature should be disabled and any active improvement state should be cleared when switching to internal note mode.

### Summary of Changes

- The AI Text Improvement button is now disabled when `isInternalNote` is `true`, regardless of whether there is text in the input.
- The disabled tooltip is shown when `isInternalNote` is active, even if the input contains text.
- Clicking the improvement button or selecting an improvement option while in internal note mode is now a no-op.
- The "Back to Original" option is hidden when `isInternalNote` is `true`.
- When switching to internal note mode, the AI Text Improvement store is reset, clearing any improved text and loading state.
- Tests were added to cover all of the above scenarios.