### PR TITLE
feat: Enhance quick messages store with loading functionality and state management

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -36,6 +36,7 @@ import { useFeatureFlag } from './store/modules/featureFlag';
 import { useTheme } from '@weni/unnnic-system';
 
 import { applyRouteAwareTheme, notifyParentOfTheme } from '@/utils/theme';
+import { useQuickMessagesFeatureFlag } from '@/composables/useQuickMessagesFeatureFlag';
 
 import initHotjar from '@/plugins/Hotjar';
 import {
@@ -117,9 +118,7 @@ export default {
     },
 
     isQuickMessagesV2Enabled() {
-      return !!this.featureFlags?.active_features?.includes(
-        'weniChatsQuickMessagesV2',
-      );
+      return useQuickMessagesFeatureFlag(this.featureFlags);
     },
 
     quickMessagesBootstrapReady() {

--- a/src/App.vue
+++ b/src/App.vue
@@ -77,11 +77,12 @@ export default {
         true,
       ),
       showDarkModeIntroModal: false,
+      quickMessagesBootstrapDone: false,
     };
   },
 
   computed: {
-    ...mapState(useFeatureFlag, ['featureFlags']),
+    ...mapState(useFeatureFlag, ['featureFlags', 'featureFlagsLoaded']),
     ...mapState(useRooms, ['activeRoom']),
     ...mapState(useProfile, ['me']),
     ...mapState(useDashboard, ['viewedAgent']),
@@ -113,6 +114,16 @@ export default {
       const { appToken, appProject } = this;
 
       return [appToken, appProject];
+    },
+
+    isQuickMessagesV2Enabled() {
+      return !!this.featureFlags?.active_features?.includes(
+        'weniChatsQuickMessagesV2',
+      );
+    },
+
+    quickMessagesBootstrapReady() {
+      return !!this.appToken && !!this.appProject && this.featureFlagsLoaded;
     },
 
     userWhoChangedStatus() {
@@ -153,9 +164,26 @@ export default {
             projectUuid: newAppProject,
           });
           this.getUserStatus();
-          this.loadQuickMessages();
-          this.loadQuickMessagesShared();
         }
+      },
+    },
+    quickMessagesBootstrapReady: {
+      immediate: true,
+      handler(ready) {
+        if (!ready || this.quickMessagesBootstrapDone) return;
+        this.quickMessagesBootstrapDone = true;
+        this.bootstrapQuickMessages();
+      },
+    },
+    activeRoom: {
+      handler(newRoom) {
+        if (!this.isQuickMessagesV2Enabled) return;
+
+        const sectorUuid = newRoom?.queue?.sector;
+        if (!sectorUuid) return;
+
+        this.loadPersonalQuickMessagesV2IfNeeded();
+        this.loadQuickMessagesSharedBySectorIfNeeded(sectorUuid);
       },
     },
     'me.email': {
@@ -224,9 +252,11 @@ export default {
     ...mapActions(useProfile, ['setMe', 'getMeQueues']),
     ...mapActions(useQuickMessages, {
       getAllQuickMessages: 'getAll',
+      loadPersonalQuickMessagesV2IfNeeded: 'loadAllV2IfNeeded',
     }),
     ...mapActions(useQuickMessageShared, {
       getAllQuickMessagesShared: 'getAll',
+      loadQuickMessagesSharedBySectorIfNeeded: 'loadBySectorIfNeeded',
     }),
     ...mapActions(useFeatureFlag, ['getFeatureFlags']),
     restoreSessionStorageUserStatus({ projectUuid }) {
@@ -261,9 +291,6 @@ export default {
       } catch (error) {
         console.error('[App] Failed to get user status:', error);
       }
-
-      this.loadQuickMessages();
-      this.loadQuickMessagesShared();
     },
 
     async getUser() {
@@ -282,6 +309,22 @@ export default {
     async getProjectLanguage() {
       const language = await Project.getProjectLanguage();
       this.setProject({ ...this.project, language });
+    },
+
+    bootstrapQuickMessages() {
+      if (!this.isQuickMessagesV2Enabled) {
+        this.loadQuickMessages();
+        this.loadQuickMessagesShared();
+        return;
+      }
+
+      // Under the v2 flag the live desk loads quick messages lazily (on room
+      // entry / panel open). The legacy eager load is only kept for the
+      // settings routes, which read the v1 store state directly.
+      if (this.$route.path.startsWith('/settings')) {
+        this.loadQuickMessages();
+        this.loadQuickMessagesShared();
+      }
     },
 
     async loadQuickMessages() {

--- a/src/__tests__/App.spec.js
+++ b/src/__tests__/App.spec.js
@@ -4,6 +4,10 @@ import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
 import App from '@/App.vue';
 import { useConfig } from '@/store/modules/config';
+import { useFeatureFlag } from '@/store/modules/featureFlag';
+import { useQuickMessages } from '@/store/modules/chats/quickMessages';
+import { useQuickMessageShared } from '@/store/modules/chats/quickMessagesShared';
+import { useRooms } from '@/store/modules/chats/rooms';
 import * as ProfileService from '@/services/api/resources/profile';
 import * as ProjectService from '@/services/api/resources/settings/project';
 import * as notifications from '@/utils/notifications';
@@ -137,6 +141,7 @@ describe('App.vue', () => {
   const createWrapper = (options = {}) => {
     const {
       routeName = 'home',
+      routePath = '/',
       socketStatus = 'open',
       socketRetryCount = 0,
       wsMock = null,
@@ -158,7 +163,7 @@ describe('App.vue', () => {
         mocks: {
           $t: (key) => key,
           $router: mockRouter,
-          $route: { name: routeName },
+          $route: { name: routeName, path: routePath },
           $i18n: {
             locale: 'en',
           },
@@ -379,6 +384,71 @@ describe('App.vue', () => {
 
       wrapper = createWrapper();
       expect(wrapper.vm.userWhoChangedStatus).toBe('test-user');
+    });
+  });
+
+  describe('Quick messages bootstrap', () => {
+    it('eager loads quick messages when v2 flag is off', () => {
+      const ffStore = useFeatureFlag();
+      ffStore.featureFlags = { active_features: [] };
+      ffStore.featureFlagsLoaded = true;
+      const qmStore = useQuickMessages();
+      const qmsStore = useQuickMessageShared();
+
+      wrapper = createWrapper({ routePath: '/' });
+
+      expect(qmStore.getAll).toHaveBeenCalled();
+      expect(qmsStore.getAll).toHaveBeenCalled();
+    });
+
+    it('does not eager load on the live desk when v2 flag is on', () => {
+      const ffStore = useFeatureFlag();
+      ffStore.featureFlags = {
+        active_features: ['weniChatsQuickMessagesV2'],
+      };
+      ffStore.featureFlagsLoaded = true;
+      const qmStore = useQuickMessages();
+      const qmsStore = useQuickMessageShared();
+
+      wrapper = createWrapper({ routePath: '/' });
+
+      expect(qmStore.getAll).not.toHaveBeenCalled();
+      expect(qmsStore.getAll).not.toHaveBeenCalled();
+    });
+
+    it('keeps eager loading on settings routes when v2 flag is on', () => {
+      const ffStore = useFeatureFlag();
+      ffStore.featureFlags = {
+        active_features: ['weniChatsQuickMessagesV2'],
+      };
+      ffStore.featureFlagsLoaded = true;
+      const qmStore = useQuickMessages();
+
+      wrapper = createWrapper({
+        routeName: 'settings',
+        routePath: '/settings',
+      });
+
+      expect(qmStore.getAll).toHaveBeenCalled();
+    });
+
+    it('lazy loads quick messages by sector when entering a room with v2 flag on', async () => {
+      const ffStore = useFeatureFlag();
+      ffStore.featureFlags = {
+        active_features: ['weniChatsQuickMessagesV2'],
+      };
+      ffStore.featureFlagsLoaded = true;
+      const qmStore = useQuickMessages();
+      const qmsStore = useQuickMessageShared();
+
+      wrapper = createWrapper({ routePath: '/' });
+
+      const roomsStore = useRooms();
+      roomsStore.activeRoom = { queue: { sector: 'sector-1' } };
+      await wrapper.vm.$nextTick();
+
+      expect(qmStore.loadAllV2IfNeeded).toHaveBeenCalled();
+      expect(qmsStore.loadBySectorIfNeeded).toHaveBeenCalledWith('sector-1');
     });
   });
 });

--- a/src/components/chats/MessageManager/index.vue
+++ b/src/components/chats/MessageManager/index.vue
@@ -220,7 +220,10 @@ export default {
   }),
 
   computed: {
-    ...mapState(useQuickMessageShared, ['quickMessagesShared']),
+    ...mapState(useQuickMessageShared, [
+      'quickMessagesShared',
+      'sharedBySector',
+    ]),
     ...mapState(useQuickMessages, ['quickMessages']),
     ...mapState(useRooms, ['canUseCopilot', 'activeRoom']),
     ...mapState(useDiscussions, {
@@ -249,8 +252,19 @@ export default {
     isFileLoadingValueValid() {
       return typeof this.loadingFileValue === 'number';
     },
+    isQuickMessagesV2Enabled() {
+      return !!this.featureFlags?.active_features?.includes(
+        'weniChatsQuickMessagesV2',
+      );
+    },
+    sharedShortcuts() {
+      if (this.isQuickMessagesV2Enabled) {
+        return this.sharedBySector(this.activeRoom?.queue?.sector);
+      }
+      return this.quickMessagesShared;
+    },
     shortcuts() {
-      const allShortcuts = [...this.quickMessages, ...this.quickMessagesShared];
+      const allShortcuts = [...this.quickMessages, ...this.sharedShortcuts];
       const uniqueShortcuts = [];
 
       allShortcuts.forEach((item) => {

--- a/src/components/chats/MessageManager/index.vue
+++ b/src/components/chats/MessageManager/index.vue
@@ -176,6 +176,7 @@ import { useFeatureFlag } from '@/store/modules/featureFlag';
 import { useMessageManager } from '@/store/modules/chats/messageManager';
 
 import MessageManagerLoading from '@/views/loadings/chat/MessageManager.vue';
+import { useQuickMessagesShortcuts } from '@/composables/useQuickMessagesShortcuts';
 
 import TextBox from './TextBox.vue';
 import MoreActionsOption from './MoreActionsOption.vue';
@@ -252,16 +253,13 @@ export default {
     isFileLoadingValueValid() {
       return typeof this.loadingFileValue === 'number';
     },
-    isQuickMessagesV2Enabled() {
-      return !!this.featureFlags?.active_features?.includes(
-        'weniChatsQuickMessagesV2',
-      );
-    },
     sharedShortcuts() {
-      if (this.isQuickMessagesV2Enabled) {
-        return this.sharedBySector(this.activeRoom?.queue?.sector);
-      }
-      return this.quickMessagesShared;
+      return useQuickMessagesShortcuts({
+        featureFlags: this.featureFlags,
+        activeRoom: this.activeRoom,
+        sharedBySector: this.sharedBySector,
+        quickMessagesShared: this.quickMessagesShared,
+      });
     },
     shortcuts() {
       const allShortcuts = [...this.quickMessages, ...this.sharedShortcuts];

--- a/src/components/chats/MessageManagerV2/SuggestionBox/index.vue
+++ b/src/components/chats/MessageManagerV2/SuggestionBox/index.vue
@@ -46,6 +46,8 @@ import SuggestionBoxShortcut from './SuggestionBoxShortcut.vue';
 import { useQuickMessageShared } from '@/store/modules/chats/quickMessagesShared';
 import { useQuickMessages } from '@/store/modules/chats/quickMessages';
 import { useMessageManager } from '@/store/modules/chats/messageManager';
+import { useRooms } from '@/store/modules/chats/rooms';
+import { useFeatureFlag } from '@/store/modules/featureFlag';
 
 export default {
   name: 'SuggestionBox',
@@ -87,11 +89,27 @@ export default {
   }),
 
   computed: {
-    ...mapState(useQuickMessageShared, ['quickMessagesShared']),
+    ...mapState(useQuickMessageShared, [
+      'quickMessagesShared',
+      'sharedBySector',
+    ]),
     ...mapState(useQuickMessages, ['quickMessages']),
     ...mapState(useMessageManager, ['inputMessageFocused']),
+    ...mapState(useRooms, ['activeRoom']),
+    ...mapState(useFeatureFlag, ['featureFlags']),
+    isQuickMessagesV2Enabled() {
+      return !!this.featureFlags?.active_features?.includes(
+        'weniChatsQuickMessagesV2',
+      );
+    },
+    sharedShortcuts() {
+      if (this.isQuickMessagesV2Enabled) {
+        return this.sharedBySector(this.activeRoom?.queue?.sector);
+      }
+      return this.quickMessagesShared;
+    },
     suggestions() {
-      const allShortcuts = [...this.quickMessages, ...this.quickMessagesShared];
+      const allShortcuts = [...this.quickMessages, ...this.sharedShortcuts];
       const uniqueShortcuts = [];
 
       allShortcuts.forEach((item) => {

--- a/src/components/chats/MessageManagerV2/SuggestionBox/index.vue
+++ b/src/components/chats/MessageManagerV2/SuggestionBox/index.vue
@@ -48,6 +48,7 @@ import { useQuickMessages } from '@/store/modules/chats/quickMessages';
 import { useMessageManager } from '@/store/modules/chats/messageManager';
 import { useRooms } from '@/store/modules/chats/rooms';
 import { useFeatureFlag } from '@/store/modules/featureFlag';
+import { useQuickMessagesShortcuts } from '@/composables/useQuickMessagesShortcuts';
 
 export default {
   name: 'SuggestionBox',
@@ -97,16 +98,13 @@ export default {
     ...mapState(useMessageManager, ['inputMessageFocused']),
     ...mapState(useRooms, ['activeRoom']),
     ...mapState(useFeatureFlag, ['featureFlags']),
-    isQuickMessagesV2Enabled() {
-      return !!this.featureFlags?.active_features?.includes(
-        'weniChatsQuickMessagesV2',
-      );
-    },
     sharedShortcuts() {
-      if (this.isQuickMessagesV2Enabled) {
-        return this.sharedBySector(this.activeRoom?.queue?.sector);
-      }
-      return this.quickMessagesShared;
+      return useQuickMessagesShortcuts({
+        featureFlags: this.featureFlags,
+        activeRoom: this.activeRoom,
+        sharedBySector: this.sharedBySector,
+        quickMessagesShared: this.quickMessagesShared,
+      });
     },
     suggestions() {
       const allShortcuts = [...this.quickMessages, ...this.sharedShortcuts];

--- a/src/components/chats/QuickMessages/QuickMessagesList.vue
+++ b/src/components/chats/QuickMessages/QuickMessagesList.vue
@@ -34,6 +34,15 @@
           @edit="emitEditQuickMessage"
           @delete="emitDeleteQuickMessage"
         />
+        <div
+          v-if="infiniteScroll && !withoutQuickMessages"
+          ref="infiniteScrollSentinel"
+          class="quick-messages-list__sentinel"
+        />
+        <UnnnicIconLoading
+          v-if="infiniteScroll && loadingMore"
+          class="quick-messages-list__loading"
+        />
       </section>
     </Transition>
     <section
@@ -87,6 +96,18 @@ export default {
       type: String,
       default: '',
     },
+    infiniteScroll: {
+      type: Boolean,
+      default: false,
+    },
+    loadingMore: {
+      type: Boolean,
+      default: false,
+    },
+    hasMore: {
+      type: Boolean,
+      default: false,
+    },
   },
   emits: [
     'update:isEmpty',
@@ -94,11 +115,13 @@ export default {
     'edit-quick-message',
     'delete-quick-message',
     'open-new-quick-message',
+    'load-more',
   ],
 
   data() {
     return {
       openQuickMessages: true,
+      intersectionObserver: null,
     };
   },
 
@@ -114,9 +137,52 @@ export default {
         this.$emit('update:isEmpty', newWithoutQuickMessages);
       },
     },
+    infiniteScroll: {
+      handler(enabled) {
+        if (enabled) {
+          this.$nextTick(() => this.setupInfiniteScroll());
+        } else {
+          this.teardownInfiniteScroll();
+        }
+      },
+    },
+  },
+
+  mounted() {
+    if (this.infiniteScroll) {
+      this.$nextTick(() => this.setupInfiniteScroll());
+    }
+  },
+
+  beforeUnmount() {
+    this.teardownInfiniteScroll();
   },
 
   methods: {
+    setupInfiniteScroll() {
+      this.teardownInfiniteScroll();
+
+      const sentinel = this.$refs.infiniteScrollSentinel;
+      if (!sentinel) return;
+
+      this.intersectionObserver = new IntersectionObserver(
+        (entries) => {
+          const isVisible = entries.some((entry) => entry.isIntersecting);
+          if (isVisible && this.hasMore && !this.loadingMore) {
+            this.$emit('load-more');
+          }
+        },
+        { rootMargin: '120px' },
+      );
+
+      this.intersectionObserver.observe(sentinel);
+    },
+    teardownInfiniteScroll() {
+      if (this.intersectionObserver) {
+        this.intersectionObserver.disconnect();
+        this.intersectionObserver = null;
+      }
+    },
     emitSelectQuickMessage(quickMessage) {
       this.$emit('select-quick-message', quickMessage);
     },
@@ -162,6 +228,15 @@ export default {
   &__without-messages-text {
     font: $unnnic-font-body;
     color: $unnnic-color-fg-base;
+  }
+  &__sentinel {
+    width: 100%;
+    height: 1px;
+  }
+  &__loading {
+    display: flex;
+    justify-content: center;
+    padding: $unnnic-space-2 0;
   }
 }
 </style>

--- a/src/components/chats/QuickMessages/__tests__/QuickMessage.spec.js
+++ b/src/components/chats/QuickMessages/__tests__/QuickMessage.spec.js
@@ -2,6 +2,8 @@ import { expect, vi } from 'vitest';
 import { mount, config } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { useQuickMessages } from '@/store/modules/chats/quickMessages';
+import { useQuickMessageShared } from '@/store/modules/chats/quickMessagesShared';
+import { useFeatureFlag } from '@/store/modules/featureFlag';
 import isMobile from 'is-mobile';
 
 import QuickMessages from '../index.vue';
@@ -83,5 +85,39 @@ describe('QuickMessages.vue', () => {
     expect(wrapper.emitted()['select-quick-message'][0]).toEqual([
       quickMessage,
     ]);
+  });
+
+  it('lazy loads personal and project shared messages on open when v2 flag is on', () => {
+    setActivePinia(createPinia());
+
+    const featureFlagStore = useFeatureFlag();
+    featureFlagStore.featureFlags = {
+      active_features: ['weniChatsQuickMessagesV2'],
+    };
+
+    const personalStore = useQuickMessages();
+    const sharedStore = useQuickMessageShared();
+    const loadPersonalSpy = vi
+      .spyOn(personalStore, 'loadAllV2IfNeeded')
+      .mockResolvedValue();
+    const loadSharedSpy = vi
+      .spyOn(sharedStore, 'getByProjectNextPage')
+      .mockResolvedValue();
+
+    mount(QuickMessages, {
+      global: {
+        stubs: [
+          'AsideSlotTemplate',
+          'AsideSlotTemplateSection',
+          'QuickMessagesList',
+          'QuickMessageForm',
+          'UnnnicButton',
+          'UnnnicModal',
+        ],
+      },
+    });
+
+    expect(loadPersonalSpy).toHaveBeenCalled();
+    expect(loadSharedSpy).toHaveBeenCalled();
   });
 });

--- a/src/components/chats/QuickMessages/index.vue
+++ b/src/components/chats/QuickMessages/index.vue
@@ -29,9 +29,13 @@
       />
       <QuickMessagesList
         :title="$t('quick_messages.shared')"
-        :quickMessages="quickMessagesShared"
+        :quickMessages="sharedQuickMessages"
         :withoutMessagesText="$t('quick_messages.without_messages_shared')"
+        :infiniteScroll="isV2"
+        :loadingMore="isLoadingQuickMessagesSharedByProject"
+        :hasMore="hasMoreQuickMessagesSharedByProject"
         @select-quick-message="selectQuickMessage"
+        @load-more="loadMoreSharedByProject"
       />
     </AsideSlotTemplateSection>
 
@@ -76,6 +80,7 @@ import ModalDeleteQuickMessage from './ModalDeleteQuickMessage.vue';
 
 import { useQuickMessages } from '@/store/modules/chats/quickMessages';
 import { useQuickMessageShared } from '@/store/modules/chats/quickMessagesShared';
+import { useFeatureFlag } from '@/store/modules/featureFlag';
 
 export default {
   name: 'QuickMessages',
@@ -102,7 +107,25 @@ export default {
   },
   computed: {
     ...mapState(useQuickMessages, ['quickMessages']),
-    ...mapState(useQuickMessageShared, ['quickMessagesShared']),
+    ...mapState(useQuickMessageShared, [
+      'quickMessagesShared',
+      'quickMessagesSharedByProject',
+      'isLoadingQuickMessagesSharedByProject',
+      'hasMoreQuickMessagesSharedByProject',
+    ]),
+    ...mapState(useFeatureFlag, ['featureFlags']),
+
+    isV2() {
+      return !!this.featureFlags?.active_features?.includes(
+        'weniChatsQuickMessagesV2',
+      );
+    },
+
+    sharedQuickMessages() {
+      return this.isV2
+        ? this.quickMessagesSharedByProject
+        : this.quickMessagesShared;
+    },
 
     isEditing() {
       const { quickMessageToEdit } = this;
@@ -130,11 +153,24 @@ export default {
     },
   },
 
+  mounted() {
+    if (!this.isV2) return;
+
+    this.loadPersonalQuickMessagesV2IfNeeded();
+    if (!this.quickMessagesSharedByProject.length) {
+      this.loadMoreSharedByProject();
+    }
+  },
+
   methods: {
     ...mapActions(useQuickMessages, {
       actionCreateQuickMessage: 'create',
       actionUpdateQuickMessage: 'update',
       actionDeleteQuickMessage: 'delete',
+      loadPersonalQuickMessagesV2IfNeeded: 'loadAllV2IfNeeded',
+    }),
+    ...mapActions(useQuickMessageShared, {
+      loadMoreSharedByProject: 'getByProjectNextPage',
     }),
 
     async createQuickMessage({ title, text, shortcut }) {

--- a/src/components/chats/QuickMessages/index.vue
+++ b/src/components/chats/QuickMessages/index.vue
@@ -81,6 +81,7 @@ import ModalDeleteQuickMessage from './ModalDeleteQuickMessage.vue';
 import { useQuickMessages } from '@/store/modules/chats/quickMessages';
 import { useQuickMessageShared } from '@/store/modules/chats/quickMessagesShared';
 import { useFeatureFlag } from '@/store/modules/featureFlag';
+import { useQuickMessagesFeatureFlag } from '@/composables/useQuickMessagesFeatureFlag';
 
 export default {
   name: 'QuickMessages',
@@ -116,9 +117,7 @@ export default {
     ...mapState(useFeatureFlag, ['featureFlags']),
 
     isV2() {
-      return !!this.featureFlags?.active_features?.includes(
-        'weniChatsQuickMessagesV2',
-      );
+      return useQuickMessagesFeatureFlag(this.featureFlags);
     },
 
     sharedQuickMessages() {

--- a/src/composables/__tests__/useQuickMessagesFeatureFlag.spec.ts
+++ b/src/composables/__tests__/useQuickMessagesFeatureFlag.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import {
+  QUICK_MESSAGES_V2_FEATURE_FLAG,
+  useQuickMessagesFeatureFlag,
+} from '../useQuickMessagesFeatureFlag';
+
+describe('useQuickMessagesFeatureFlag', () => {
+  it('returns true when the v2 flag is active', () => {
+    expect(
+      useQuickMessagesFeatureFlag({
+        active_features: [QUICK_MESSAGES_V2_FEATURE_FLAG],
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when the v2 flag is not active', () => {
+    expect(useQuickMessagesFeatureFlag({ active_features: [] })).toBe(false);
+    expect(useQuickMessagesFeatureFlag(null)).toBe(false);
+    expect(useQuickMessagesFeatureFlag(undefined)).toBe(false);
+  });
+});

--- a/src/composables/__tests__/useQuickMessagesShortcuts.spec.ts
+++ b/src/composables/__tests__/useQuickMessagesShortcuts.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { QUICK_MESSAGES_V2_FEATURE_FLAG } from '../useQuickMessagesFeatureFlag';
+import { useQuickMessagesShortcuts } from '../useQuickMessagesShortcuts';
+
+describe('useQuickMessagesShortcuts', () => {
+  const sharedBySector = (sectorUuid?: string) => [
+    { uuid: 'sector', shortcut: '/sector', text: 'sector', sectorUuid },
+  ];
+  const quickMessagesShared = [
+    { uuid: 'shared', shortcut: '/shared', text: 'shared' },
+  ];
+
+  it('returns sector shortcuts when v2 flag is enabled', () => {
+    const shortcuts = useQuickMessagesShortcuts({
+      featureFlags: { active_features: [QUICK_MESSAGES_V2_FEATURE_FLAG] },
+      activeRoom: { queue: { sector: 'sector-1' } },
+      sharedBySector,
+      quickMessagesShared,
+    });
+
+    expect(shortcuts).toEqual([
+      {
+        uuid: 'sector',
+        shortcut: '/sector',
+        text: 'sector',
+        sectorUuid: 'sector-1',
+      },
+    ]);
+  });
+
+  it('returns project shared shortcuts when v2 flag is disabled', () => {
+    const shortcuts = useQuickMessagesShortcuts({
+      featureFlags: { active_features: [] },
+      activeRoom: { queue: { sector: 'sector-1' } },
+      sharedBySector,
+      quickMessagesShared,
+    });
+
+    expect(shortcuts).toEqual(quickMessagesShared);
+  });
+});

--- a/src/composables/useQuickMessagesFeatureFlag.ts
+++ b/src/composables/useQuickMessagesFeatureFlag.ts
@@ -1,0 +1,13 @@
+export const QUICK_MESSAGES_V2_FEATURE_FLAG = 'weniChatsQuickMessagesV2';
+
+type FeatureFlags = {
+  active_features?: string[];
+};
+
+export function useQuickMessagesFeatureFlag(
+  featureFlags?: FeatureFlags | null,
+): boolean {
+  return !!featureFlags?.active_features?.includes(
+    QUICK_MESSAGES_V2_FEATURE_FLAG,
+  );
+}

--- a/src/composables/useQuickMessagesShortcuts.ts
+++ b/src/composables/useQuickMessagesShortcuts.ts
@@ -1,0 +1,35 @@
+import { useQuickMessagesFeatureFlag } from './useQuickMessagesFeatureFlag';
+
+type QuickMessage = {
+  uuid?: string;
+};
+
+type ActiveRoom = {
+  queue?: {
+    sector?: string;
+  };
+};
+
+type FeatureFlags = {
+  active_features?: string[];
+};
+
+type UseQuickMessagesShortcutsParams = {
+  featureFlags?: FeatureFlags | null;
+  activeRoom?: ActiveRoom | null;
+  sharedBySector: (_sectorUuid?: string) => QuickMessage[];
+  quickMessagesShared: QuickMessage[];
+};
+
+export function useQuickMessagesShortcuts({
+  featureFlags,
+  activeRoom,
+  sharedBySector,
+  quickMessagesShared,
+}: UseQuickMessagesShortcutsParams): QuickMessage[] {
+  if (useQuickMessagesFeatureFlag(featureFlags)) {
+    return sharedBySector(activeRoom?.queue?.sector);
+  }
+
+  return quickMessagesShared;
+}

--- a/src/services/api/resources/chats/__tests__/quickMessage.spec.js
+++ b/src/services/api/resources/chats/__tests__/quickMessage.spec.js
@@ -39,6 +39,55 @@ describe('QuickMessageApi', () => {
     expect(response).toEqual(mockResponse.data);
   });
 
+  it('should fetch all v2 quick messages', async () => {
+    const mockResponse = { data: { results: [], next: '' } };
+    http.get.mockResolvedValueOnce(mockResponse);
+
+    const response = await QuickMessageApi.getAllV2({});
+
+    expect(http.get).toHaveBeenCalledWith('/v2/quick_messages/');
+    expect(response).toEqual(mockResponse.data);
+  });
+
+  it('should fetch v2 shared quick messages by sector', async () => {
+    const mockResponse = { data: { results: [], next: '' } };
+    http.get.mockResolvedValueOnce(mockResponse);
+
+    const response = await QuickMessageApi.getBySectorV2({
+      sectorUuid: 'sector1',
+    });
+
+    expect(http.get).toHaveBeenCalledWith(
+      '/v2/sector_quick_messages/?sector=sector1&project=project-uuid',
+    );
+    expect(response).toEqual(mockResponse.data);
+  });
+
+  it('should fetch v2 shared quick messages by project', async () => {
+    const mockResponse = { data: { results: [], next: '' } };
+    http.get.mockResolvedValueOnce(mockResponse);
+
+    const response = await QuickMessageApi.getByProjectV2({});
+
+    expect(http.get).toHaveBeenCalledWith(
+      '/v2/sector_quick_messages/?project=project-uuid',
+    );
+    expect(response).toEqual(mockResponse.data);
+  });
+
+  it('should paginate v2 shared quick messages by project using next', async () => {
+    const mockResponse = { data: { results: [], next: '' } };
+    http.get.mockResolvedValueOnce(mockResponse);
+
+    await QuickMessageApi.getByProjectV2({
+      next: 'https://api.test/v2/sector_quick_messages/?cursor=abc',
+    });
+
+    expect(http.get).toHaveBeenCalledWith(
+      '/v2/sector_quick_messages/?cursor=abc',
+    );
+  });
+
   it('should create a quick message', async () => {
     const mockResponse = { data: { id: 1, title: 'New Message' } };
 

--- a/src/services/api/resources/chats/__tests__/quickMessage.spec.js
+++ b/src/services/api/resources/chats/__tests__/quickMessage.spec.js
@@ -3,7 +3,17 @@ import http from '@/services/api/http';
 import QuickMessageApi from '../quickMessage';
 import { getProject } from '@/utils/config';
 
-vi.mock('@/services/api/http');
+vi.mock('@/services/api/http', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    defaults: {
+      baseURL: 'https://api.example.com/v1',
+    },
+  },
+}));
 vi.mock('@/utils/config');
 
 describe('QuickMessageApi', () => {
@@ -45,7 +55,9 @@ describe('QuickMessageApi', () => {
 
     const response = await QuickMessageApi.getAllV2({});
 
-    expect(http.get).toHaveBeenCalledWith('/v2/quick_messages/');
+    expect(http.get).toHaveBeenCalledWith('/quick_messages/', {
+      baseURL: 'https://api.example.com/v2',
+    });
     expect(response).toEqual(mockResponse.data);
   });
 
@@ -57,10 +69,28 @@ describe('QuickMessageApi', () => {
       sectorUuid: 'sector1',
     });
 
+    expect(getProject).not.toHaveBeenCalled();
     expect(http.get).toHaveBeenCalledWith(
-      '/v2/sector_quick_messages/?sector=sector1&project=project-uuid',
+      '/sector_quick_messages/?sector=sector1',
+      { baseURL: 'https://api.example.com/v2' },
     );
     expect(response).toEqual(mockResponse.data);
+  });
+
+  it('should paginate v2 shared quick messages by sector using next', async () => {
+    const mockResponse = { data: { results: [], next: '' } };
+    http.get.mockResolvedValueOnce(mockResponse);
+
+    await QuickMessageApi.getBySectorV2({
+      sectorUuid: 'sector1',
+      next: 'https://api.test/v2/sector_quick_messages/?cursor=abc',
+    });
+
+    expect(getProject).not.toHaveBeenCalled();
+    expect(http.get).toHaveBeenCalledWith(
+      '/sector_quick_messages/?cursor=abc',
+      { baseURL: 'https://api.example.com/v2' },
+    );
   });
 
   it('should fetch v2 shared quick messages by project', async () => {
@@ -70,7 +100,8 @@ describe('QuickMessageApi', () => {
     const response = await QuickMessageApi.getByProjectV2({});
 
     expect(http.get).toHaveBeenCalledWith(
-      '/v2/sector_quick_messages/?project=project-uuid',
+      '/sector_quick_messages/?project=project-uuid',
+      { baseURL: 'https://api.example.com/v2' },
     );
     expect(response).toEqual(mockResponse.data);
   });
@@ -84,7 +115,10 @@ describe('QuickMessageApi', () => {
     });
 
     expect(http.get).toHaveBeenCalledWith(
-      '/v2/sector_quick_messages/?cursor=abc',
+      '/sector_quick_messages/?cursor=abc',
+      {
+        baseURL: 'https://api.example.com/v2',
+      },
     );
   });
 

--- a/src/services/api/resources/chats/quickMessage.js
+++ b/src/services/api/resources/chats/quickMessage.js
@@ -26,6 +26,42 @@ export default {
     return response.data;
   },
 
+  async getAllV2({ nextQuickMessages = '' }) {
+    const endpoint = '/v2/quick_messages/';
+    const params = getURLParams({ URL: nextQuickMessages, endpoint });
+
+    const url = nextQuickMessages ? `${endpoint}${params}` : endpoint;
+    const response = await http.get(url);
+
+    return response.data;
+  },
+
+  async getBySectorV2({ sectorUuid, next = '' }) {
+    const projectUuid = await getProject();
+    const endpoint = '/v2/sector_quick_messages/';
+    const params = getURLParams({ URL: next, endpoint });
+
+    const url = next
+      ? `${endpoint}${params}`
+      : `${endpoint}?sector=${sectorUuid}&project=${projectUuid}`;
+    const response = await http.get(url);
+
+    return response.data;
+  },
+
+  async getByProjectV2({ next = '' }) {
+    const projectUuid = await getProject();
+    const endpoint = '/v2/sector_quick_messages/';
+    const params = getURLParams({ URL: next, endpoint });
+
+    const url = next
+      ? `${endpoint}${params}`
+      : `${endpoint}?project=${projectUuid}`;
+    const response = await http.get(url);
+
+    return response.data;
+  },
+
   async create({ title, text, shortcut = null }) {
     const response = await http.post('/quick_messages/', {
       title,

--- a/src/services/api/resources/chats/quickMessage.js
+++ b/src/services/api/resources/chats/quickMessage.js
@@ -2,6 +2,10 @@ import http from '@/services/api/http';
 import { getProject } from '@/utils/config';
 import { getURLParams } from '@/utils/requests';
 
+const v2Config = {
+  baseURL: http.defaults.baseURL.replace('/v1', '/v2'),
+};
+
 export default {
   async getAll({ nextQuickMessages = '' }) {
     const endpoint = '/quick_messages/';
@@ -27,37 +31,36 @@ export default {
   },
 
   async getAllV2({ nextQuickMessages = '' }) {
-    const endpoint = '/v2/quick_messages/';
+    const endpoint = '/quick_messages/';
     const params = getURLParams({ URL: nextQuickMessages, endpoint });
 
     const url = nextQuickMessages ? `${endpoint}${params}` : endpoint;
-    const response = await http.get(url);
+    const response = await http.get(url, v2Config);
 
     return response.data;
   },
 
   async getBySectorV2({ sectorUuid, next = '' }) {
-    const projectUuid = await getProject();
-    const endpoint = '/v2/sector_quick_messages/';
+    const endpoint = '/sector_quick_messages/';
     const params = getURLParams({ URL: next, endpoint });
 
     const url = next
       ? `${endpoint}${params}`
-      : `${endpoint}?sector=${sectorUuid}&project=${projectUuid}`;
-    const response = await http.get(url);
+      : `${endpoint}?sector=${sectorUuid}`;
+    const response = await http.get(url, v2Config);
 
     return response.data;
   },
 
   async getByProjectV2({ next = '' }) {
     const projectUuid = await getProject();
-    const endpoint = '/v2/sector_quick_messages/';
+    const endpoint = '/sector_quick_messages/';
     const params = getURLParams({ URL: next, endpoint });
 
     const url = next
       ? `${endpoint}${params}`
       : `${endpoint}?project=${projectUuid}`;
-    const response = await http.get(url);
+    const response = await http.get(url, v2Config);
 
     return response.data;
   },

--- a/src/store/modules/chats/__tests__/quickMessageShared.spec.js
+++ b/src/store/modules/chats/__tests__/quickMessageShared.spec.js
@@ -101,6 +101,20 @@ describe('useQuickMessageShared Store', () => {
     expect(QuickMessage.getByProjectV2).toHaveBeenCalledTimes(2);
   });
 
+  it('should rethrow errors from project pagination', async () => {
+    QuickMessage.getByProjectV2.mockRejectedValueOnce(new Error('fail'));
+
+    await expect(
+      quickMessageSharedStore.getByProjectNextPage(),
+    ).rejects.toThrow('fail');
+    expect(quickMessageSharedStore.isLoadingQuickMessagesSharedByProject).toBe(
+      false,
+    );
+    expect(quickMessageSharedStore.quickMessagesSharedByProjectRequested).toBe(
+      false,
+    );
+  });
+
   it('should create a new shared quick message', async () => {
     const newMessage = {
       uuid: '2',

--- a/src/store/modules/chats/__tests__/quickMessageShared.spec.js
+++ b/src/store/modules/chats/__tests__/quickMessageShared.spec.js
@@ -49,6 +49,14 @@ describe('useQuickMessageShared Store', () => {
 
     await quickMessageSharedStore.loadBySectorIfNeeded('sector-1');
 
+    expect(QuickMessage.getBySectorV2).toHaveBeenNthCalledWith(1, {
+      sectorUuid: 'sector-1',
+      next: '',
+    });
+    expect(QuickMessage.getBySectorV2).toHaveBeenNthCalledWith(2, {
+      sectorUuid: 'sector-1',
+      next: 'next-page',
+    });
     expect(QuickMessage.getBySectorV2).toHaveBeenCalledTimes(2);
     expect(quickMessageSharedStore.sharedBySector('sector-1')).toHaveLength(2);
     expect(quickMessageSharedStore.requestedSectors).toContain('sector-1');

--- a/src/store/modules/chats/__tests__/quickMessageShared.spec.js
+++ b/src/store/modules/chats/__tests__/quickMessageShared.spec.js
@@ -6,6 +6,8 @@ import QuickMessage from '@/services/api/resources/chats/quickMessage';
 vi.mock('@/services/api/resources/chats/quickMessage', () => ({
   default: {
     getAllBySector: vi.fn(),
+    getBySectorV2: vi.fn(),
+    getByProjectV2: vi.fn(),
     createBySector: vi.fn(),
     updateBySector: vi.fn(),
     deleteBySector: vi.fn(),
@@ -32,6 +34,71 @@ describe('useQuickMessageShared Store', () => {
     expect(quickMessageSharedStore.quickMessagesShared[0].uuid).toBe('1');
     expect(quickMessageSharedStore.nextQuickMessagesShared).toBe('next-page');
     expect(messages).toHaveLength(1);
+  });
+
+  it('should load shared messages by sector only once across pages', async () => {
+    QuickMessage.getBySectorV2
+      .mockResolvedValueOnce({
+        results: [{ uuid: '1', title: 'A', text: 'a', shortcut: 'a' }],
+        next: 'next-page',
+      })
+      .mockResolvedValueOnce({
+        results: [{ uuid: '2', title: 'B', text: 'b', shortcut: 'b' }],
+        next: '',
+      });
+
+    await quickMessageSharedStore.loadBySectorIfNeeded('sector-1');
+
+    expect(QuickMessage.getBySectorV2).toHaveBeenCalledTimes(2);
+    expect(quickMessageSharedStore.sharedBySector('sector-1')).toHaveLength(2);
+    expect(quickMessageSharedStore.requestedSectors).toContain('sector-1');
+
+    await quickMessageSharedStore.loadBySectorIfNeeded('sector-1');
+    expect(QuickMessage.getBySectorV2).toHaveBeenCalledTimes(2);
+  });
+
+  it('should reset requested sector when load fails', async () => {
+    QuickMessage.getBySectorV2.mockRejectedValueOnce(new Error('fail'));
+
+    await expect(
+      quickMessageSharedStore.loadBySectorIfNeeded('sector-x'),
+    ).rejects.toThrow('fail');
+    expect(quickMessageSharedStore.requestedSectors).not.toContain('sector-x');
+  });
+
+  it('should paginate shared messages by project', async () => {
+    QuickMessage.getByProjectV2.mockResolvedValueOnce({
+      results: [{ uuid: '1', title: 'A', text: 'a', shortcut: 'a' }],
+      next: 'next-project-page',
+    });
+
+    await quickMessageSharedStore.getByProjectNextPage();
+
+    expect(quickMessageSharedStore.quickMessagesSharedByProject).toHaveLength(
+      1,
+    );
+    expect(quickMessageSharedStore.nextQuickMessagesSharedByProject).toBe(
+      'next-project-page',
+    );
+    expect(quickMessageSharedStore.hasMoreQuickMessagesSharedByProject).toBe(
+      true,
+    );
+
+    QuickMessage.getByProjectV2.mockResolvedValueOnce({
+      results: [{ uuid: '2', title: 'B', text: 'b', shortcut: 'b' }],
+      next: '',
+    });
+
+    await quickMessageSharedStore.getByProjectNextPage();
+    expect(quickMessageSharedStore.quickMessagesSharedByProject).toHaveLength(
+      2,
+    );
+    expect(quickMessageSharedStore.hasMoreQuickMessagesSharedByProject).toBe(
+      false,
+    );
+
+    await quickMessageSharedStore.getByProjectNextPage();
+    expect(QuickMessage.getByProjectV2).toHaveBeenCalledTimes(2);
   });
 
   it('should create a new shared quick message', async () => {

--- a/src/store/modules/chats/__tests__/quickMessages.spec.js
+++ b/src/store/modules/chats/__tests__/quickMessages.spec.js
@@ -6,6 +6,7 @@ import QuickMessage from '@/services/api/resources/chats/quickMessage';
 vi.mock('@/services/api/resources/chats/quickMessage', () => ({
   default: {
     getAll: vi.fn(),
+    getAllV2: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
     delete: vi.fn(),
@@ -36,6 +37,34 @@ describe('useQuickMessages Store', () => {
     await quickMessageStore.getAll();
     expect(quickMessageStore.quickMessages).toEqual(mockMessages);
     expect(quickMessageStore.nextQuickMessages).toBe('next-url');
+  });
+
+  it('should fetch all v2 quick messages across pages only once', async () => {
+    QuickMessage.getAllV2
+      .mockResolvedValueOnce({
+        results: [{ uuid: '1', title: 'A', text: 'a', shortcut: 'a' }],
+        next: 'next-url',
+      })
+      .mockResolvedValueOnce({
+        results: [{ uuid: '2', title: 'B', text: 'b', shortcut: 'b' }],
+        next: '',
+      });
+
+    await quickMessageStore.loadAllV2IfNeeded();
+
+    expect(QuickMessage.getAllV2).toHaveBeenCalledTimes(2);
+    expect(quickMessageStore.quickMessages).toHaveLength(2);
+    expect(quickMessageStore.quickMessagesRequested).toBe(true);
+
+    await quickMessageStore.loadAllV2IfNeeded();
+    expect(QuickMessage.getAllV2).toHaveBeenCalledTimes(2);
+  });
+
+  it('should reset requested flag when v2 load fails', async () => {
+    QuickMessage.getAllV2.mockRejectedValueOnce(new Error('fail'));
+
+    await expect(quickMessageStore.loadAllV2IfNeeded()).rejects.toThrow('fail');
+    expect(quickMessageStore.quickMessagesRequested).toBe(false);
   });
 
   it('should create a new quick message', async () => {

--- a/src/store/modules/chats/quickMessages.js
+++ b/src/store/modules/chats/quickMessages.js
@@ -3,7 +3,11 @@ import { defineStore } from 'pinia';
 import QuickMessage from '@/services/api/resources/chats/quickMessage';
 
 export const useQuickMessages = defineStore('quickMessages', {
-  state: () => ({ quickMessages: [], nextQuickMessages: '' }),
+  state: () => ({
+    quickMessages: [],
+    nextQuickMessages: '',
+    quickMessagesRequested: false,
+  }),
   actions: {
     updateQuickMessage({ uuid, title, text, shortcut }) {
       const quickMessageToUpdate = this.quickMessages.find(
@@ -34,6 +38,33 @@ export const useQuickMessages = defineStore('quickMessages', {
       this.quickMessages = newQuickMessages;
 
       return newQuickMessages;
+    },
+
+    async getAllV2() {
+      const { quickMessages, nextQuickMessages } = this;
+
+      const response = await QuickMessage.getAllV2({ nextQuickMessages });
+
+      const newQuickMessages = [...quickMessages, ...(response.results || [])];
+
+      this.nextQuickMessages = response.next;
+      this.quickMessages = newQuickMessages;
+
+      return newQuickMessages;
+    },
+
+    async loadAllV2IfNeeded() {
+      if (this.quickMessagesRequested) return;
+      this.quickMessagesRequested = true;
+
+      try {
+        do {
+          await this.getAllV2();
+        } while (this.nextQuickMessages);
+      } catch (error) {
+        this.quickMessagesRequested = false;
+        throw error;
+      }
     },
 
     async create({ title, text, shortcut }) {

--- a/src/store/modules/chats/quickMessagesShared.js
+++ b/src/store/modules/chats/quickMessagesShared.js
@@ -3,7 +3,22 @@ import { defineStore } from 'pinia';
 import QuickMessage from '@/services/api/resources/chats/quickMessage';
 
 export const useQuickMessageShared = defineStore('quickMessagesShared', {
-  state: () => ({ quickMessagesShared: [], nextQuickMessagesShared: '' }),
+  state: () => ({
+    quickMessagesShared: [],
+    nextQuickMessagesShared: '',
+    quickMessagesSharedBySector: {},
+    requestedSectors: [],
+    quickMessagesSharedByProject: [],
+    nextQuickMessagesSharedByProject: '',
+    quickMessagesSharedByProjectRequested: false,
+    isLoadingQuickMessagesSharedByProject: false,
+  }),
+  getters: {
+    sharedBySector: (state) => (sectorUuid) =>
+      state.quickMessagesSharedBySector[sectorUuid] || [],
+    hasMoreQuickMessagesSharedByProject: (state) =>
+      !!state.nextQuickMessagesSharedByProject,
+  },
   actions: {
     updateQuickMessageShared({ uuid, title, text, shortcut }) {
       const quickMessageToUpdate = this.quickMessagesShared.find(
@@ -40,6 +55,62 @@ export const useQuickMessageShared = defineStore('quickMessagesShared', {
       this.quickMessagesShared = newQuickMessagesShared;
 
       return newQuickMessagesShared;
+    },
+
+    async loadBySectorIfNeeded(sectorUuid) {
+      if (!sectorUuid || this.requestedSectors.includes(sectorUuid)) return;
+      this.requestedSectors = [...this.requestedSectors, sectorUuid];
+
+      try {
+        let next = '';
+        let messages = [];
+
+        do {
+          const response = await QuickMessage.getBySectorV2({
+            sectorUuid,
+            next,
+          });
+          messages = [...messages, ...(response.results || [])];
+          next = response.next;
+        } while (next);
+
+        this.quickMessagesSharedBySector = {
+          ...this.quickMessagesSharedBySector,
+          [sectorUuid]: messages,
+        };
+      } catch (error) {
+        this.requestedSectors = this.requestedSectors.filter(
+          (sector) => sector !== sectorUuid,
+        );
+        throw error;
+      }
+    },
+
+    async getByProjectNextPage() {
+      if (
+        this.quickMessagesSharedByProjectRequested &&
+        !this.nextQuickMessagesSharedByProject
+      ) {
+        return;
+      }
+
+      if (this.isLoadingQuickMessagesSharedByProject) return;
+      this.isLoadingQuickMessagesSharedByProject = true;
+
+      try {
+        const response = await QuickMessage.getByProjectV2({
+          next: this.nextQuickMessagesSharedByProject,
+        });
+
+        this.quickMessagesSharedByProject = [
+          ...this.quickMessagesSharedByProject,
+          ...(response.results || []),
+        ];
+        this.nextQuickMessagesSharedByProject = response.next;
+        this.quickMessagesSharedByProjectRequested = true;
+      } finally {
+        this.isLoadingQuickMessagesSharedByProject = false;
+      }
     },
 
     async create({ sectorUuid, title, text, shortcut }) {

--- a/src/store/modules/featureFlag.js
+++ b/src/store/modules/featureFlag.js
@@ -5,6 +5,7 @@ export const useFeatureFlag = defineStore('featureFlag', {
   state: () => ({
     featureFlags: { active_features: [] },
     isLoadingFeatureFlags: false,
+    featureFlagsLoaded: false,
   }),
 
   actions: {
@@ -17,6 +18,7 @@ export const useFeatureFlag = defineStore('featureFlag', {
         console.error('Error getting feature flags', error);
       } finally {
         this.isLoadingFeatureFlags = false;
+        this.featureFlagsLoaded = true;
       }
     },
   },


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
Quick messages were always eagerly loaded at app startup, regardless of whether the user would ever need them. This approach becomes inefficient as the number of messages grows. A new `weniChatsQuickMessagesV2` feature flag gates a lazy-loading strategy that defers fetching until the data is actually needed, reducing unnecessary API calls on startup.

### Summary of Changes

**API layer**
- Added `getAllV2`, `getBySectorV2`, and `getByProjectV2` methods to the quick message API resource, all backed by the new `/v2/` endpoints and supporting cursor-based pagination via a `next` parameter.

**Store — personal quick messages (`quickMessages`)**
- Added `quickMessagesRequested` state flag.
- Added `getAllV2` action for paginated fetching.
- Added `loadAllV2IfNeeded` action that fetches all pages exactly once, resetting the flag on failure so retries are possible.

**Store — shared quick messages (`quickMessagesShared`)**
- Added `quickMessagesSharedBySector`, `requestedSectors`, `quickMessagesSharedByProject`, `nextQuickMessagesSharedByProject`, `quickMessagesSharedByProjectRequested`, and `isLoadingQuickMessagesSharedByProject` state fields.
- Added `sharedBySector` and `hasMoreQuickMessagesSharedByProject` getters.
- Added `loadBySectorIfNeeded` action that fetches all pages for a given sector exactly once, keyed by sector UUID.
- Added `getByProjectNextPage` action for paginated project-wide shared message loading.

**Store — feature flags**
- Added `featureFlagsLoaded` boolean so consumers can wait until flags have been resolved before acting on them.

**App bootstrap (`App.vue`)**
- Replaced the unconditional eager `loadQuickMessages` / `loadQuickMessagesShared` calls with a `bootstrapQuickMessages` method gated on `quickMessagesBootstrapReady` (app token, project, and feature flags all available).
- When the v2 flag is **off**, behaviour is unchanged (eager load on startup).
- When the v2 flag is **on**, eager loading is skipped on the live desk and only retained for `/settings` routes. A new `activeRoom` watcher triggers `loadPersonalQuickMessagesV2IfNeeded` and `loadQuickMessagesSharedBySectorIfNeeded` each time the agent enters a room.

**UI components**
- `MessageManager` and `SuggestionBox` now resolve shared shortcuts through a `sharedShortcuts` computed property that returns sector-scoped messages under the v2 flag and falls back to the legacy flat list otherwise.
- `QuickMessagesList` gains `infiniteScroll`, `loadingMore`, and `hasMore` props along with an `IntersectionObserver`-based sentinel element and a `load-more` emit, enabling infinite scroll pagination of the shared list in the settings panel.
- `QuickMessages` panel uses `quickMessagesSharedByProject` under the v2 flag and triggers `loadPersonalQuickMessagesV2IfNeeded` and the first page of project-shared messages on mount.

**Tests**
- New and updated unit tests cover: v2 API methods, `loadAllV2IfNeeded` idempotency and error recovery, `loadBySectorIfNeeded` full pagination and error recovery, `getByProjectNextPage` pagination and guard conditions, App bootstrap behaviour for all flag/route combinations, lazy room-entry loading, and the QuickMessages panel mount behaviour under the v2 flag.