### PR TITLE
Added translations for strings added in fix/modal-chat-takeover

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -529,15 +529,15 @@
     "chat_take_over": {
       "by_another_representative": {
         "title": "Chat taken over by another representative",
-        "description": "Your chat with {contact} has been taken over by {representative}."
+        "description": "Your chat with {contact} has been taken over by {representative}"
       },
       "transfer_to_another_representative": {
         "title": "Chat transferred to another representative",
-        "description": "Your chat with {contact} was transferred by a moderator to {representative}."
+        "description": "Your chat with {contact} was transferred by a moderator to {representative}"
       },
       "transfer_to_queue": {
         "title": "Chat transferred to queue",
-        "description": "Your chat with {contact} was transferred by a moderator to the {queue} queue."
+        "description": "Your chat with {contact} was transferred by a moderator to the {queue} queue"
       }
     },
     "your_chat_assumed": "Chat taken over by another representative",
@@ -570,7 +570,7 @@
       "close": "End visualization",
       "assume_chat": "Take over only this chat",
       "assume_chat_question": "Take over chat with {contact}?",
-      "assume_chat_question_description": "Are you sure you want to take over chat with {contact}?<br><br>When confirming you will remove the chat from representative and will be responsible for chat."
+      "assume_chat_question_description": "Are you sure you want to take over chat with {contact}?<br><br>If you confirm, you will remove the chat from the current representative and you will be responsible for it."
     }
   },
   "select": "Select",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -532,20 +532,20 @@
     "you_got_chat": "Tienes el chat",
     "chat_take_over": {
       "by_another_representative": {
-        "title": "Chat asumido por otro representante",
-        "description": "Tu chat con {contact} ha sido asumido por {representative}."
+        "title": "Chat asignado a otro representante",
+        "description": "Tu chat con {contact} se ha asignado a {representative}"
       },
       "transfer_to_another_representative": {
         "title": "Chat transferido a otro representante",
-        "description": "Tu chat con {contact} fue transferido por un moderador a {representative}."
+        "description": "Tu chat con {contact} fue transferido por un moderador a {representative}"
       },
       "transfer_to_queue": {
-        "title": "Chat transferido a cola",
-        "description": "Tu chat con {contact} fue transferido por un moderador a la cola {queue}."
+        "title": "Chat transferido a la cola",
+        "description": "Tu chat con {contact} fue transferido por un moderador a la cola {queue}"
       }
     },
-    "your_chat_assumed": "Chat asumido por otro representante",
-    "your_chat_assumed_description": "Tu chat con {contact} ha sido asumido por {representative}",
+    "your_chat_assumed": "Chat asignado a otro representante",
+    "your_chat_assumed_description": "Tu chat con {contact} se ha asignado a {representative}",
     "closed_chats": {
       "contact_history": "Historial del contacto",
       "general_history": "Historial general",
@@ -573,8 +573,8 @@
       "title": "Modo de vista en vivo del agente {viewedAgent}",
       "close": "Visualización final",
       "assume_chat": "Asumir solo este chat",
-      "assume_chat_question": "¿Asumir el chat con {contact}?",
-      "assume_chat_question_description": "¿Seguro de que deseas asumir el chat con {contact}?<br><br>Al confirmar, quitarás el chat del representante y serás responsable del chat."
+      "assume_chat_question": "¿Asignarse el chat con {contact}?",
+      "assume_chat_question_description": "¿Seguro de que deseas asignarte el chat con {contact}?<br><br>Al confirmar, el chat se removerá del representante actual y quedará bajo tu responsabilidad."
     }
   },
   "select": "Seleccionar",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -533,15 +533,15 @@
     "chat_take_over": {
       "by_another_representative": {
         "title": "Chat assumido por outro atendente",
-        "description": "Seu chat com {contact} foi assumido por {representative}."
+        "description": "Seu chat com {contact} foi assumido por {representative}"
       },
       "transfer_to_another_representative": {
         "title": "Chat transferido para outro atendente",
-        "description": "Seu chat com {contact} foi transferido por um moderador para {representative}."
+        "description": "Seu chat com {contact} foi transferido por um moderador para {representative}"
       },
       "transfer_to_queue": {
-        "title": "Chat transferido para fila",
-        "description": "Seu chat com {contact} foi transferido por um moderador para a fila {queue}."
+        "title": "Chat transferido para a fila",
+        "description": "Seu chat com {contact} foi transferido por um moderador para a fila {queue}"
       }
     },
     "your_chat_assumed": "Chat assumido por outro atendente",
@@ -574,7 +574,7 @@
       "close": "Encerrar visualização",
       "assume_chat": "Assumir apenas este chat",
       "assume_chat_question": "Assumir o chat com {contact}?",
-      "assume_chat_question_description": "Tem certeza de que deseja assumir o chat com {contact}?<br><br>Ao confirmar, você remove o chat do representante e fica responsável pelo chat."
+      "assume_chat_question_description": "Tem certeza de que deseja assumir o chat com {contact}?<br><br>Ao confirmar, você removerá o chat do atendente atual e será responsável pelo chat."
     }
   },
   "select": "Selecionar",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -14,6 +14,22 @@
     "back_to_original_tooltip": "Revenire la versiunea originală (Ctrl+Z)"
   },
   "chats": {
+    "chat_take_over": {
+      "by_another_representative": {
+        "title": "Chat assumido por outro atendente",
+        "description": "Seu chat com {contact} foi assumido por {representative}"
+      },
+      "transfer_to_another_representative": {
+        "title": "Chat transferido para outro atendente",
+        "description": "Seu chat com {contact} foi transferido por um moderador para {representative}"
+      },
+      "transfer_to_queue": {
+        "title": "Chat transferido para a fila",
+        "description": "Seu chat com {contact} foi transferido por um moderador para a fila {queue}"
+      }
+    },
+    "your_chat_assumed": "Chatul a fost preluat de un alt reprezentant",
+    "your_chat_assumed_description": "Chatul cu {contact} a fost preluat de {representative}",
     "assigned_queues": "Cozi atribuite",
     "define_the_queues": "Definește cozile",
     "error_update_queues": "Nu s-au putut actualiza cozile de serviciu",
@@ -28,6 +44,12 @@
     "select_services_queues": "Setează cozile pentru a primi chat-uri",
     "select_your_queues": "Selectează cozile tale",
     "success_update_queues": "Cozile tale de serviciu au fost actualizate"
+  },
+  "dashboard": {
+    "view-mode": {
+      "assume_chat_question": "Preiei chatul cu {contact}?",
+      "assume_chat_question_description": "Sigur dorești să preiei chatul cu {contact}?<br><br>Dacă confirmi, vei elimina chatul de la reprezentantul actual și vei fi responsabil pentru acesta."
+    }
   },
   "room_card": {
     "new_chat_received": {
@@ -51,7 +73,7 @@
     "queue_success": "Coada a fost ștearsă cu succes",
     "queue_error": "Nu s-a putut șterge coada",
     "transfer_error_sector": "Nu s-au putut transfera chaturile. Ștergerea departamentului a fost anulată.",
-    "transfer_error_queue": "Nu s-au putut transfera conversațiile. Ștergerea cozii a fost anulată.",
+    "transfer_error_queue": "Nu s-au putut transfera conversațiile. Ștergerea cozii a fost anulată."
   },
   "export_conversation": {
     "accept_terms": "Accept termenii și înțeleg limitările exportului.",


### PR DESCRIPTION
## Description

### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [X] Other

### Motivation and Context
Add Romanian translation for string added in [PR#885](https://github.com/weni-ai/chats-webapp/pull/885/). Tracked in [LOC-25410](https://vtex-dev.atlassian.net/browse/LOC-25410).