### PR TITLE
feat: Implement room summary polling with attempt limit and cleanup logic

### DIFF
--- a/src/components/chats/chat/RoomMessages.vue
+++ b/src/components/chats/chat/RoomMessages.vue
@@ -51,6 +51,9 @@ import RoomNotes from '@/services/api/resources/chats/roomNotes';
 import { SEE_ALL_INTERNAL_NOTES_CHIP_CONTENT } from '@/utils/chats';
 import i18n from '@/plugins/i18n';
 
+const TERMINAL_SUMMARY_STATUSES = new Set(['DONE', 'UNAVAILABLE']);
+const MAX_SUMMARY_POLL_ATTEMPTS = 12;
+
 export default {
   name: 'RoomMessages',
 
@@ -73,6 +76,7 @@ export default {
       silentLoadingMessages: false,
       isLoadingSummary: false,
       getRoomSummaryInterval: null,
+      summaryPollAttempts: 0,
       skipSummaryAnimation: false,
     };
   },
@@ -131,7 +135,8 @@ export default {
     'room.uuid': {
       immediate: true,
       async handler(roomUuid) {
-        clearInterval(this.getRoomSummaryInterval);
+        this.stopRoomSummaryPolling();
+        this.summaryPollAttempts = 0;
         if (roomUuid) {
           this.resetRoomMessages();
           this.page = 0;
@@ -165,6 +170,10 @@ export default {
     },
   },
 
+  beforeUnmount() {
+    this.stopRoomSummaryPolling();
+  },
+
   methods: {
     ...mapActions(useRoomMessages, {
       roomResendMessages: 'resendRoomMessages',
@@ -184,6 +193,11 @@ export default {
       }
     },
 
+    stopRoomSummaryPolling() {
+      clearInterval(this.getRoomSummaryInterval);
+      this.getRoomSummaryInterval = null;
+    },
+
     setRoomSummary(text, feedback, status = '') {
       this.isLoadingActiveRoomSummary = false;
       if (this.room) {
@@ -193,24 +207,35 @@ export default {
           status,
         };
       }
-      clearInterval(this.getRoomSummaryInterval);
+      this.stopRoomSummaryPolling();
+      this.summaryPollAttempts = 0;
     },
 
     async getRoomSummary() {
       if (!this.room) return;
       const roomUuid = this.room.uuid;
+      this.summaryPollAttempts += 1;
       try {
         const { status, summary, feedback } = await RoomService.getSummary({
           roomUuid,
         });
         if (this.room?.uuid !== roomUuid) return;
-        if (['DONE', 'UNAVAILABLE'].includes(status)) {
+        if (TERMINAL_SUMMARY_STATUSES.has(status)) {
           const unavailableText = this.$t('chats.summary.unavailable');
           this.setRoomSummary(
             status === 'UNAVAILABLE' ? unavailableText : summary,
             feedback,
             status,
           );
+          return;
+        }
+        if (this.summaryPollAttempts >= MAX_SUMMARY_POLL_ATTEMPTS) {
+          if (summary) {
+            this.setRoomSummary(summary, feedback, 'ERROR');
+          } else {
+            const errorText = i18n.global.t('chats.summary.error');
+            this.setRoomSummary(errorText, { liked: null }, 'ERROR');
+          }
         }
       } catch (error) {
         if (this.room?.uuid !== roomUuid) return;

--- a/src/components/chats/chat/RoomMessages.vue
+++ b/src/components/chats/chat/RoomMessages.vue
@@ -236,6 +236,7 @@ export default {
             const errorText = i18n.global.t('chats.summary.error');
             this.setRoomSummary(errorText, { liked: null }, 'ERROR');
           }
+          return;
         }
       } catch (error) {
         if (this.room?.uuid !== roomUuid) return;

--- a/src/components/chats/chat/__tests__/RoomMessages.spec.js
+++ b/src/components/chats/chat/__tests__/RoomMessages.spec.js
@@ -390,6 +390,36 @@ describe('RoomMessages.vue', () => {
       });
       expect(roomsStore.isLoadingActiveRoomSummary).toBe(false);
     });
+
+    it('stops the polling interval and resets attempts counter', async () => {
+      vi.useFakeTimers();
+      RoomNotes.getInternalNotes.mockResolvedValue({ results: [] });
+      RoomService.getSummary.mockResolvedValue({
+        status: 'IN_PROGRESS',
+        summary: '',
+        feedback: null,
+      });
+
+      const wrapper = createWrapper(
+        {},
+        {
+          rooms: { roomsSummary: {} },
+          config: { project: { config: { has_chats_summary: true } } },
+        },
+      );
+      await flushPromises();
+
+      wrapper.vm.handlingGetRoomSummary();
+      wrapper.vm.summaryPollAttempts = 5;
+      expect(wrapper.vm.getRoomSummaryInterval).not.toBe(null);
+
+      wrapper.vm.setRoomSummary('text', null, 'DONE');
+
+      expect(wrapper.vm.getRoomSummaryInterval).toBe(null);
+      expect(wrapper.vm.summaryPollAttempts).toBe(0);
+
+      vi.useRealTimers();
+    });
   });
 
   describe('getRoomSummary', () => {
@@ -472,6 +502,117 @@ describe('RoomMessages.vue', () => {
 
       expect(RoomService.getSummary).not.toHaveBeenCalled();
     });
+
+    it('does not call setRoomSummary when status is not terminal and cap is not reached', async () => {
+      vi.useFakeTimers();
+      RoomNotes.getInternalNotes.mockResolvedValue({ results: [] });
+      RoomService.getSummary.mockResolvedValue({
+        status: 'IN_PROGRESS',
+        summary: '',
+        feedback: null,
+      });
+
+      const wrapper = createWrapper(
+        {},
+        {
+          rooms: { roomsSummary: {} },
+          config: { project: { config: { has_chats_summary: true } } },
+        },
+      );
+      await flushPromises();
+
+      wrapper.vm.handlingGetRoomSummary();
+      await flushPromises();
+      expect(wrapper.vm.getRoomSummaryInterval).not.toBe(null);
+
+      const setRoomSummarySpy = vi.spyOn(wrapper.vm, 'setRoomSummary');
+      wrapper.vm.summaryPollAttempts = 0;
+
+      await wrapper.vm.getRoomSummary();
+
+      expect(setRoomSummarySpy).not.toHaveBeenCalled();
+      expect(wrapper.vm.getRoomSummaryInterval).not.toBe(null);
+
+      vi.useRealTimers();
+    });
+
+    it('falls back to error text when MAX_SUMMARY_POLL_ATTEMPTS is reached and summary is empty', async () => {
+      RoomNotes.getInternalNotes.mockResolvedValue({ results: [] });
+      RoomService.getSummary.mockResolvedValue({
+        status: 'IN_PROGRESS',
+        summary: '',
+        feedback: null,
+      });
+
+      const wrapper = createWrapper();
+      await flushPromises();
+
+      vi.spyOn(wrapper.vm, 'setRoomSummary');
+      wrapper.vm.summaryPollAttempts = 11;
+
+      await wrapper.vm.getRoomSummary();
+
+      const errorText = i18n.global.t('chats.summary.error');
+      expect(wrapper.vm.setRoomSummary).toHaveBeenCalledWith(
+        errorText,
+        { liked: null },
+        'ERROR',
+      );
+    });
+
+    it('preserves the partial summary text when MAX_SUMMARY_POLL_ATTEMPTS is reached with a populated summary', async () => {
+      RoomNotes.getInternalNotes.mockResolvedValue({ results: [] });
+      RoomService.getSummary.mockResolvedValue({
+        status: 'IN_PROGRESS',
+        summary: 'Partial summary content',
+        feedback: { liked: true },
+      });
+
+      const wrapper = createWrapper();
+      await flushPromises();
+
+      vi.spyOn(wrapper.vm, 'setRoomSummary');
+      wrapper.vm.summaryPollAttempts = 11;
+
+      await wrapper.vm.getRoomSummary();
+
+      expect(wrapper.vm.setRoomSummary).toHaveBeenCalledWith(
+        'Partial summary content',
+        { liked: true },
+        'ERROR',
+      );
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('calls stopRoomSummaryPolling on beforeUnmount to avoid ghost intervals', async () => {
+      vi.useFakeTimers();
+      RoomNotes.getInternalNotes.mockResolvedValue({ results: [] });
+      RoomService.getSummary.mockResolvedValue({
+        status: 'IN_PROGRESS',
+        summary: '',
+        feedback: null,
+      });
+
+      const wrapper = createWrapper(
+        {},
+        {
+          rooms: { roomsSummary: {} },
+          config: { project: { config: { has_chats_summary: true } } },
+        },
+      );
+      await flushPromises();
+
+      wrapper.vm.handlingGetRoomSummary();
+      expect(wrapper.vm.getRoomSummaryInterval).not.toBe(null);
+
+      const stopSpy = vi.spyOn(wrapper.vm, 'stopRoomSummaryPolling');
+      wrapper.unmount();
+
+      expect(stopSpy).toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
   });
 
   describe('getRoomInternalNotes', () => {
@@ -545,8 +686,8 @@ describe('RoomMessages.vue', () => {
       vi.useFakeTimers();
       RoomNotes.getInternalNotes.mockResolvedValue({ results: [] });
       RoomService.getSummary.mockResolvedValue({
-        status: 'DONE',
-        summary: 'S',
+        status: 'IN_PROGRESS',
+        summary: '',
         feedback: null,
       });
 


### PR DESCRIPTION
## Description
### Type of Change
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
The room summary polling had no upper bound on the number of attempts, meaning it could run indefinitely if the backend never returned a terminal status (`DONE` or `UNAVAILABLE`). Additionally, the polling interval was not being cleared when the component was unmounted, which could lead to ghost intervals continuing to fire after the component was destroyed.

### Summary of Changes
- Introduced `MAX_SUMMARY_POLL_ATTEMPTS` (12) to cap the number of polling attempts for the room summary. When the limit is reached, the component either displays any partial summary text already returned or falls back to a localized error message, both with an `ERROR` status.
- Extracted interval cleanup into a dedicated `stopRoomSummaryPolling` method that clears the interval and sets it to `null`, replacing all direct `clearInterval` calls.
- Added a `beforeUnmount` lifecycle hook that calls `stopRoomSummaryPolling` to prevent intervals from running after the component is destroyed.
- Added a `summaryPollAttempts` counter that is reset to `0` whenever polling stops or the active room changes.
- Added tests covering: polling stopping and counter resetting on `setRoomSummary`, the cap-not-reached path not triggering `setRoomSummary`, the error fallback when the cap is reached with an empty summary, the partial summary preservation when the cap is reached with content, and the `beforeUnmount` cleanup preventing ghost intervals.