### PR TITLE
refactor: Simplify settings page logic and conditionally render CustomBreaks component

### DIFF
--- a/src/store/modules/__tests__/config.spec.js
+++ b/src/store/modules/__tests__/config.spec.js
@@ -140,4 +140,36 @@ describe('useConfig Store', () => {
 
     expect(config.copilot.customRules).toBe('rule-1');
   });
+
+  describe('groups mode getters', () => {
+    it('should return false for enableGroupsMode when its_principal is absent', () => {
+      const config = useConfig();
+      config.project = { config: {} };
+
+      expect(config.enableGroupsMode).toBe(false);
+      expect(config.isPrimaryProject).toBe(false);
+      expect(config.isSecondaryProject).toBe(false);
+      expect(config.isMainGroupsProject).toBe(false);
+    });
+
+    it('should identify main groups project when its_principal is true', () => {
+      const config = useConfig();
+      config.project = { config: { its_principal: true } };
+
+      expect(config.enableGroupsMode).toBe(true);
+      expect(config.isPrimaryProject).toBe(true);
+      expect(config.isSecondaryProject).toBe(false);
+      expect(config.isMainGroupsProject).toBe(true);
+    });
+
+    it('should identify secondary groups project when its_principal is false', () => {
+      const config = useConfig();
+      config.project = { config: { its_principal: false } };
+
+      expect(config.enableGroupsMode).toBe(true);
+      expect(config.isPrimaryProject).toBe(false);
+      expect(config.isSecondaryProject).toBe(true);
+      expect(config.isMainGroupsProject).toBe(false);
+    });
+  });
 });

--- a/src/store/modules/config.js
+++ b/src/store/modules/config.js
@@ -98,8 +98,11 @@ export const useConfig = defineStore('config', {
     isPrimaryProject: ({ project }) => {
       return !!project.config?.its_principal;
     },
-    isSecondaryProject: ({ project }) => {
-      return !!project.config?.its_principal === false;
+    isSecondaryProject() {
+      return this.enableGroupsMode && !this.isPrimaryProject;
+    },
+    isMainGroupsProject() {
+      return this.enableGroupsMode && this.isPrimaryProject;
     },
   },
 });

--- a/src/views/Settings/SettingsProjectOptions/__tests__/SettingsProjectOptions.spec.js
+++ b/src/views/Settings/SettingsProjectOptions/__tests__/SettingsProjectOptions.spec.js
@@ -217,6 +217,80 @@ describe('SettingsProjectOptions.vue', () => {
     });
   });
 
+  describe('Groups mode (main vs secondary project)', () => {
+    const otherKeys = [
+      'restrict_offline_agents',
+      'can_use_bulk_transfer',
+      'filter_offline_agents',
+      'can_use_bulk_close',
+      'can_close_chats_in_queue',
+      'can_use_queue_prioritization',
+      'can_see_waiting_rooms_count',
+      'can_use_name_sector_in_rooms',
+    ];
+
+    it('should hide ai_transfer item on main groups project but keep other items', async () => {
+      wrapper = createWrapper({
+        projectConfig: { its_principal: true },
+      });
+      await flushPromises();
+
+      const aiItem = wrapper.vm.optionsItems.find(
+        (item) => item.key === 'ai_transfer',
+      );
+      expect(aiItem).toBeUndefined();
+
+      otherKeys.forEach((key) => {
+        const item = wrapper.vm.optionsItems.find((i) => i.key === key);
+        expect(item).toBeTruthy();
+      });
+    });
+
+    it('should keep only ai_transfer item on secondary project', async () => {
+      wrapper = createWrapper({
+        projectConfig: { its_principal: false },
+      });
+      await flushPromises();
+
+      expect(wrapper.vm.optionsItems).toHaveLength(1);
+      expect(wrapper.vm.optionsItems[0].key).toBe('ai_transfer');
+
+      otherKeys.forEach((key) => {
+        const item = wrapper.vm.optionsItems.find((i) => i.key === key);
+        expect(item).toBeUndefined();
+      });
+    });
+
+    it('should hide ai_transfer on secondary project when hasAgentBuilder is false', async () => {
+      agentBuilder.getAiTransferConfig.mockRejectedValueOnce(
+        new Error('Not found'),
+      );
+
+      wrapper = createWrapper({
+        projectConfig: { its_principal: false },
+      });
+      await flushPromises();
+
+      expect(wrapper.vm.optionsItems).toHaveLength(0);
+    });
+
+    it('should not hide items on regular projects without groups mode', async () => {
+      wrapper = createWrapper();
+      await flushPromises();
+
+      const aiItem = wrapper.vm.optionsItems.find(
+        (item) => item.key === 'ai_transfer',
+      );
+      expect(aiItem).toBeTruthy();
+
+      otherKeys.forEach((key) => {
+        if (key === 'can_use_bulk_take') return;
+        const item = wrapper.vm.optionsItems.find((i) => i.key === key);
+        expect(item).toBeTruthy();
+      });
+    });
+  });
+
   describe('Agent Builder / AI Transfer', () => {
     it('should call agentBuilder.getAiTransferConfig on mount', async () => {
       await flushPromises();

--- a/src/views/Settings/SettingsProjectOptions/index.vue
+++ b/src/views/Settings/SettingsProjectOptions/index.vue
@@ -120,17 +120,13 @@ export default {
   },
 
   computed: {
-    ...mapState(useConfig, ['project', 'enableGroupsMode', 'isPrimaryProject']),
+    ...mapState(useConfig, [
+      'project',
+      'isSecondaryProject',
+      'isMainGroupsProject',
+    ]),
     ...mapState(useProfile, ['me']),
     ...mapState(useFeatureFlag, ['featureFlags']),
-
-    isSecondaryProject() {
-      return this.enableGroupsMode && !this.isPrimaryProject;
-    },
-
-    isMainGroupsProject() {
-      return this.enableGroupsMode && this.isPrimaryProject;
-    },
 
     isBulkCloseFeatureEnabled() {
       return this.featureFlags.active_features?.includes('weniChatsBulkClose');

--- a/src/views/Settings/SettingsProjectOptions/index.vue
+++ b/src/views/Settings/SettingsProjectOptions/index.vue
@@ -120,9 +120,17 @@ export default {
   },
 
   computed: {
-    ...mapState(useConfig, ['project']),
+    ...mapState(useConfig, ['project', 'enableGroupsMode', 'isPrimaryProject']),
     ...mapState(useProfile, ['me']),
     ...mapState(useFeatureFlag, ['featureFlags']),
+
+    isSecondaryProject() {
+      return this.enableGroupsMode && !this.isPrimaryProject;
+    },
+
+    isMainGroupsProject() {
+      return this.enableGroupsMode && this.isPrimaryProject;
+    },
 
     isBulkCloseFeatureEnabled() {
       return this.featureFlags.active_features?.includes('weniChatsBulkClose');
@@ -199,7 +207,7 @@ export default {
         {
           key: 'ai_transfer',
           type: 'flag-prompt',
-          visible: this.hasAgentBuilder,
+          visible: this.hasAgentBuilder && !this.isMainGroupsProject,
           flag: this.aiTransferConfig.enabled,
           name: this.configAiTransferTranslation,
           prompt: {
@@ -218,7 +226,7 @@ export default {
         {
           key: 'restrict_offline_agents',
           type: 'flag',
-          visible: true,
+          visible: !this.isSecondaryProject,
           name: this.$t(
             'config_chats.project_configs.restrict_offline_agents.switch_label',
           ),
@@ -229,37 +237,37 @@ export default {
         {
           key: 'can_use_bulk_transfer',
           type: 'flag',
-          visible: true,
+          visible: !this.isSecondaryProject,
           name: this.configBulkTransferTranslation,
         },
         {
           key: 'filter_offline_agents',
           type: 'flag',
-          visible: true,
+          visible: !this.isSecondaryProject,
           name: this.configBlockTransferToOffAgentsTranslation,
         },
         {
           key: 'can_use_bulk_close',
           type: 'flag',
-          visible: this.isBulkCloseFeatureEnabled,
+          visible: this.isBulkCloseFeatureEnabled && !this.isSecondaryProject,
           name: this.configBulkCloseTranslation,
         },
         {
           key: 'can_close_chats_in_queue',
           type: 'flag',
-          visible: true,
+          visible: !this.isSecondaryProject,
           name: this.configBlockCloseChatsInQueueTranslation,
         },
         {
           key: 'can_use_bulk_take',
           type: 'flag',
-          visible: this.isBulkTakeFeatureEnabled,
+          visible: this.isBulkTakeFeatureEnabled && !this.isSecondaryProject,
           name: this.configBulkTakeTranslation,
         },
         {
           key: 'can_use_queue_prioritization',
           type: 'flag',
-          visible: true,
+          visible: !this.isSecondaryProject,
           name: this.$t(
             'config_chats.project_configs.queue_prioritization.switch_label',
           ),
@@ -270,7 +278,7 @@ export default {
         {
           key: 'can_see_waiting_rooms_count',
           type: 'flag',
-          visible: true,
+          visible: !this.isSecondaryProject,
           name: this.$t(
             'config_chats.project_configs.show_waiting_rooms_count.switch_label',
           ),
@@ -278,7 +286,7 @@ export default {
         {
           key: 'can_use_name_sector_in_rooms',
           type: 'flag',
-          visible: true,
+          visible: !this.isSecondaryProject,
           name: this.$t(
             'config_chats.project_configs.use_name_sector_in_rooms.switch_label',
           ),

--- a/src/views/Settings/__tests__/SettingsPage.spec.js
+++ b/src/views/Settings/__tests__/SettingsPage.spec.js
@@ -1,0 +1,142 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { createTestingPinia } from '@pinia/testing';
+import { createMemoryHistory, createRouter } from 'vue-router';
+
+import SettingsPage from '@/views/Settings/index.vue';
+
+import { useCompositionI18nInThisSpecFile } from '@/utils/test/compositionI18nVitest';
+
+const routes = [{ path: '/settings', name: 'settings' }];
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes,
+});
+
+router.push = vi.fn();
+router.replace = vi.fn();
+
+const SettingsProjectOptionsStub = {
+  name: 'SettingsProjectOptions',
+  template: '<section data-testid="settings-project-options" />',
+};
+const CustomBreaksStub = {
+  name: 'CustomBreaks',
+  template: '<section data-testid="custom-breaks" />',
+};
+
+const createWrapper = ({ projectConfig = {} } = {}) => {
+  return mount(SettingsPage, {
+    global: {
+      plugins: [
+        router,
+        createTestingPinia({
+          initialState: {
+            config: {
+              project: {
+                uuid: 'test-uuid',
+                name: 'Test Project',
+                config: { ...projectConfig },
+              },
+            },
+            featureFlag: {
+              featureFlags: { active_features: [] },
+            },
+            settings: {
+              sectors: [],
+              groups: [],
+            },
+          },
+        }),
+      ],
+      stubs: {
+        SettingsProjectOptions: SettingsProjectOptionsStub,
+        CustomBreaks: CustomBreaksStub,
+        SectorsList: true,
+        GroupsList: true,
+        RepresentativesSettings: true,
+        NewSectorDrawer: true,
+        NewGroupDrawer: true,
+      },
+    },
+  });
+};
+
+describe('Settings/index.vue (SettingsPage)', () => {
+  useCompositionI18nInThisSpecFile();
+
+  let wrapper;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Regular project (not in groups mode)', () => {
+    beforeEach(() => {
+      wrapper = createWrapper();
+    });
+
+    it('renders the settings page', () => {
+      expect(wrapper.find('.settings-page').exists()).toBe(true);
+    });
+
+    it('renders SettingsProjectOptions and CustomBreaks on the general tab', () => {
+      expect(
+        wrapper.find('[data-testid="settings-project-options"]').exists(),
+      ).toBe(true);
+      expect(wrapper.find('[data-testid="custom-breaks"]').exists()).toBe(true);
+    });
+
+    it('exposes general and sectors tabs at minimum', () => {
+      const tabValues = wrapper.vm.settingsTabs.map((tab) => tab.value);
+      expect(tabValues).toContain('general');
+      expect(tabValues).toContain('sectors');
+    });
+  });
+
+  describe('Main groups project (its_principal: true)', () => {
+    beforeEach(() => {
+      wrapper = createWrapper({ projectConfig: { its_principal: true } });
+    });
+
+    it('renders the settings page', () => {
+      expect(wrapper.find('.settings-page').exists()).toBe(true);
+    });
+
+    it('still renders CustomBreaks', () => {
+      expect(wrapper.find('[data-testid="custom-breaks"]').exists()).toBe(true);
+    });
+
+    it('exposes general, sectors and groups tabs', () => {
+      const tabValues = wrapper.vm.settingsTabs.map((tab) => tab.value);
+      expect(tabValues).toEqual(
+        expect.arrayContaining(['general', 'sectors', 'groups']),
+      );
+    });
+  });
+
+  describe('Secondary groups project (its_principal: false)', () => {
+    beforeEach(() => {
+      wrapper = createWrapper({ projectConfig: { its_principal: false } });
+    });
+
+    it('still renders the settings page', () => {
+      expect(wrapper.find('.settings-page').exists()).toBe(true);
+    });
+
+    it('renders SettingsProjectOptions but hides CustomBreaks', () => {
+      expect(
+        wrapper.find('[data-testid="settings-project-options"]').exists(),
+      ).toBe(true);
+      expect(wrapper.find('[data-testid="custom-breaks"]').exists()).toBe(
+        false,
+      );
+    });
+
+    it('exposes only the general tab', () => {
+      expect(wrapper.vm.settingsTabs).toHaveLength(1);
+      expect(wrapper.vm.settingsTabs[0].value).toBe('general');
+    });
+  });
+});

--- a/src/views/Settings/index.vue
+++ b/src/views/Settings/index.vue
@@ -102,11 +102,7 @@ const router = useRouter();
 const route = useRoute();
 
 const configStore = useConfig();
-const { isPrimaryProject, enableGroupsMode } = storeToRefs(configStore);
-
-const isSecondaryProject = computed(() => {
-  return enableGroupsMode.value && !isPrimaryProject.value;
-});
+const { isSecondaryProject, enableGroupsMode } = storeToRefs(configStore);
 
 const settingsStore = useSettings();
 const { sectors, groups } = storeToRefs(settingsStore);

--- a/src/views/Settings/index.vue
+++ b/src/views/Settings/index.vue
@@ -1,8 +1,5 @@
 <template>
-  <section
-    v-if="showSettings"
-    class="settings-page"
-  >
+  <section class="settings-page">
     <UnnnicPageHeader :title="$t('config_chats.title')">
       <template #actions>
         <UnnnicButton
@@ -39,7 +36,7 @@
           <UnnnicTabsContent value="general">
             <section class="settings-page__content">
               <SettingsProjectOptions />
-              <CustomBreaks />
+              <CustomBreaks v-if="!isSecondaryProject" />
             </section>
           </UnnnicTabsContent>
           <UnnnicTabsContent value="sectors">
@@ -107,6 +104,10 @@ const route = useRoute();
 const configStore = useConfig();
 const { isPrimaryProject, enableGroupsMode } = storeToRefs(configStore);
 
+const isSecondaryProject = computed(() => {
+  return enableGroupsMode.value && !isPrimaryProject.value;
+});
+
 const settingsStore = useSettings();
 const { sectors, groups } = storeToRefs(settingsStore);
 
@@ -119,12 +120,12 @@ const enableRepresentativesManagement = computed(() => {
   );
 });
 
-const showSettings = computed(() => {
-  return !enableGroupsMode.value || isPrimaryProject.value;
-});
-
 const activeTab = ref('');
 const settingsTabs = computed(() => {
+  if (isSecondaryProject.value) {
+    return [{ label: t('config_chats.tabs.general'), value: 'general' }];
+  }
+
   const tabs = [
     { label: t('config_chats.tabs.general'), value: 'general' },
     { label: t('config_chats.tabs.sectors'), value: 'sectors' },


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
Projects operating in groups mode have distinct roles — a main (primary) project and secondary projects. Each role requires a different subset of settings to be available. Previously, secondary projects were entirely hidden from the settings page, and no distinction was made in which options were shown based on the project's role within a group.

### Summary of Changes
- Secondary projects in groups mode now have access to the settings page, but only see the **general** tab with a limited set of options.
- The `ai_transfer` option is hidden on the main groups project and is the **only** option shown on secondary projects (when Agent Builder is available).
- All other project options (e.g., `restrict_offline_agents`, `can_use_bulk_transfer`, `filter_offline_agents`, etc.) are hidden for secondary projects.
- `CustomBreaks` is hidden for secondary projects.
- The `showSettings` computed guard that previously blocked secondary projects from seeing the settings page entirely has been removed, replaced by a more granular `isSecondaryProject` computed property used to conditionally render individual sections and tabs.
- `isSecondaryProject` and `isMainGroupsProject` computed properties were introduced in `SettingsProjectOptions` to drive per-item visibility logic.
- Tests were added to cover groups mode behavior for both the settings page and the project options component, including main project, secondary project, and regular (non-groups) project scenarios.