### PR TITLE
feat: Add audio download functionality and improve layout for audio messages

### DIFF
--- a/src/components/chats/chat/ChatMessages/ChatMessageAudio/ChatMessageAudio.vue
+++ b/src/components/chats/chat/ChatMessages/ChatMessageAudio/ChatMessageAudio.vue
@@ -100,21 +100,24 @@
       </template>
     </UnnnicAudioRecorder>
 
-    <UnnnicToolTip
+    <section
       v-if="isContactMessage"
-      enabled
-      :text="$t('chats.audio_download.tooltip')"
-      side="top"
-      class="audio-player__download"
+      class="chat-message-audio__download"
     >
-      <UnnnicButton
-        iconCenter="download"
-        type="tertiary"
-        size="small"
-        data-testid="download-button"
-        @click="handleDownload"
-      />
-    </UnnnicToolTip>
+      <UnnnicToolTip
+        enabled
+        :text="$t('chats.audio_download.tooltip')"
+        side="top"
+      >
+        <UnnnicButton
+          iconCenter="download"
+          type="tertiary"
+          size="small"
+          data-testid="download-button"
+          @click="handleDownload"
+        />
+      </UnnnicToolTip>
+    </section>
 
     <TranscriptionFeedbackModal
       v-if="showFeedbackModal"
@@ -362,6 +365,14 @@ const handleCloseFeedbackModal = ({ reset } = {}) => {
   :deep(.audio-player__transcription) {
     background-color: $unnnic-color-bg-muted;
   }
+
+  &__download {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    align-self: flex-start;
+    margin-top: $unnnic-space-1;
+  }
 }
 
 .audio-player {
@@ -389,10 +400,6 @@ const handleCloseFeedbackModal = ({ reset } = {}) => {
         color: $unnnic-color-fg-emphasized;
       }
     }
-  }
-
-  &__download {
-    margin-top: $unnnic-space-1;
   }
 }
 </style>

--- a/src/components/chats/chat/ChatMessages/ChatMessageAudio/ChatMessageAudio.vue
+++ b/src/components/chats/chat/ChatMessages/ChatMessageAudio/ChatMessageAudio.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="chat-message-audio">
     <UnnnicAudioRecorder
       ref="audio-recorder"
       class="audio-player"
@@ -99,6 +99,23 @@
         </section>
       </template>
     </UnnnicAudioRecorder>
+
+    <UnnnicToolTip
+      v-if="isContactMessage"
+      enabled
+      :text="$t('chats.audio_download.tooltip')"
+      side="top"
+      class="audio-player__download"
+    >
+      <UnnnicButton
+        iconCenter="download"
+        type="tertiary"
+        size="small"
+        data-testid="download-button"
+        @click="handleDownload"
+      />
+    </UnnnicToolTip>
+
     <TranscriptionFeedbackModal
       v-if="showFeedbackModal"
       v-model="showFeedbackModal"
@@ -121,6 +138,7 @@ import { useFeatureFlag } from '@/store/modules/featureFlag';
 import TranscriptionFeedbackModal from './FeedbackModal.vue';
 
 import audioTranscriptionService from '@/services/api/resources/chats/audioTranscription';
+import Media from '@/services/api/resources/chats/media';
 
 import i18n from '@/plugins/i18n';
 
@@ -151,6 +169,27 @@ const dashboardStore = useDashboard();
 const messageMedia = computed(() => {
   return props.message.media[0];
 });
+
+const isContactMessage = computed(() => {
+  return !!props.message.contact;
+});
+
+const handleDownload = async () => {
+  try {
+    const url = messageMedia.value.url || messageMedia.value.preview;
+    const filename = url?.split('/').at(-1) || 'audio';
+    await Media.download({ media: url, name: filename });
+  } catch (error) {
+    console.error('Error downloading audio', error);
+    UnnnicCallAlert({
+      props: {
+        text: i18n.global.t('chats.audio_download.error'),
+        type: 'error',
+      },
+      seconds: 5,
+    });
+  }
+};
 
 const isLoadingTranscription = ref(false);
 const showTranscriptionText = ref(false);
@@ -216,8 +255,7 @@ const canShowTranscriptionAudioAction = computed(() => {
   ) {
     return false;
   }
-  const isContactMessage = !!props.message.contact;
-  return isContactMessage;
+  return isContactMessage.value;
 });
 
 const canGenerateTranscriptionAudio = computed(() => {
@@ -311,9 +349,25 @@ const handleCloseFeedbackModal = ({ reset } = {}) => {
 </script>
 
 <style lang="scss" scoped>
+.chat-message-audio {
+  display: flex;
+  align-items: flex-start;
+
+  :deep(.unnnic-audio-recorder) {
+    flex: 1;
+    min-width: 0;
+    width: auto;
+  }
+
+  :deep(.audio-player__transcription) {
+    background-color: $unnnic-color-bg-muted;
+  }
+}
+
 .audio-player {
-  padding: $unnnic-spacing-xs;
-  margin: $unnnic-spacing-nano 0;
+  padding: $unnnic-space-2;
+  margin: $unnnic-space-1 0;
+
   &__transcription {
     &-feedback {
       display: flex;
@@ -335,6 +389,10 @@ const handleCloseFeedbackModal = ({ reset } = {}) => {
         color: $unnnic-color-fg-emphasized;
       }
     }
+  }
+
+  &__download {
+    margin-top: $unnnic-space-1;
   }
 }
 </style>

--- a/src/components/chats/chat/ChatMessages/ChatMessageAudio/__tests__/ChatMessageAudio.spec.js
+++ b/src/components/chats/chat/ChatMessages/ChatMessageAudio/__tests__/ChatMessageAudio.spec.js
@@ -14,6 +14,7 @@ import { useRoomMessages } from '@/store/modules/chats/roomMessages';
 import { useFeatureFlag } from '@/store/modules/featureFlag';
 import audioTranscriptionService from '@/services/api/resources/chats/audioTranscription';
 import { UnnnicCallAlert, UnnnicAudioRecorder } from '@weni/unnnic-system';
+import Media from '@/services/api/resources/chats/media';
 import i18n from '@/plugins/i18n';
 
 beforeAll(() => {
@@ -33,6 +34,12 @@ vi.mock('@/services/api/resources/chats/audioTranscription', () => ({
   default: {
     generateAudioTranscription: vi.fn(),
     sendAudioTranscriptionFeedback: vi.fn(),
+  },
+}));
+
+vi.mock('@/services/api/resources/chats/media', () => ({
+  default: {
+    download: vi.fn(),
   },
 }));
 
@@ -310,6 +317,82 @@ describe('ChatMessageAudio', () => {
       wrapper = mountComponent({ isClosedChat: true });
       const recorder = wrapper.findComponent(UnnnicAudioRecorder);
       expect(recorder.props('enableGenerateTranscription')).toBeDefined();
+    });
+  });
+
+  describe('download button', () => {
+    it('renders download button when message has contact', () => {
+      wrapper = mountComponent({
+        message: createMessage({ contact: { uuid: 'c1' } }),
+      });
+      expect(wrapper.find('[data-testid="download-button"]').exists()).toBe(
+        true,
+      );
+    });
+
+    it('does not render download button when message has no contact', () => {
+      wrapper = mountComponent({
+        message: createMessage({ contact: null }),
+      });
+      expect(wrapper.find('[data-testid="download-button"]').exists()).toBe(
+        false,
+      );
+    });
+
+    it('calls Media.download with correct params on click', async () => {
+      Media.download.mockResolvedValue();
+      const message = createMessage({
+        media: [
+          {
+            url: 'https://example.com/audio-file.mp3',
+            preview: null,
+            transcription: null,
+          },
+        ],
+      });
+      wrapper = mountComponent({ message });
+      await wrapper.find('[data-testid="download-button"]').trigger('click');
+      await flushPromises();
+      expect(Media.download).toHaveBeenCalledWith({
+        media: 'https://example.com/audio-file.mp3',
+        name: 'audio-file.mp3',
+      });
+    });
+
+    it('uses preview as fallback when url is not available', async () => {
+      Media.download.mockResolvedValue();
+      const message = createMessage({
+        media: [
+          {
+            url: null,
+            preview: 'https://example.com/audio-preview.mp3',
+            transcription: null,
+          },
+        ],
+      });
+      wrapper = mountComponent({ message });
+      await wrapper.find('[data-testid="download-button"]').trigger('click');
+      await flushPromises();
+      expect(Media.download).toHaveBeenCalledWith({
+        media: 'https://example.com/audio-preview.mp3',
+        name: 'audio-preview.mp3',
+      });
+    });
+
+    it('shows error alert when download fails', async () => {
+      Media.download.mockRejectedValue(new Error('Download failed'));
+      const consoleSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      wrapper = mountComponent();
+      await wrapper.find('[data-testid="download-button"]').trigger('click');
+      await flushPromises();
+      expect(UnnnicCallAlert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          props: expect.objectContaining({ type: 'error' }),
+        }),
+      );
+      consoleSpy.mockRestore();
     });
   });
 });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -415,6 +415,10 @@
         }
       }
     },
+    "audio_download": {
+      "tooltip": "Export",
+      "error": "Audio couldn't be exported due to a technical issue"
+    },
     "search_messages": {
       "title": "Search in conversation",
       "input_placeholder": "Enter a word or phrase to search",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -418,6 +418,10 @@
         }
       }
     },
+    "audio_download": {
+      "tooltip": "Exportar",
+      "error": "No se pudo exportar el audio debido a un problema técnico"
+    },
     "search_messages": {
       "title": "Buscar en la conversación",
       "input_placeholder": "Ingrese una palabra o frase para buscar",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -418,6 +418,10 @@
         }
       }
     },
+    "audio_download": {
+      "tooltip": "Exportar",
+      "error": "Não foi possível exportar o áudio devido a um problema técnico"
+    },
     "search_messages": {
       "title": "Pesquisar na conversa",
       "input_placeholder": "Digite uma palavra ou frase para pesquisar",


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
Contact audio messages lacked a way for agents to export/download the audio file directly from the chat interface. This feature enables agents to save audio messages sent by contacts for external use or record-keeping.

### Summary of Changes
- Added a download button to `ChatMessageAudio` that appears exclusively on contact messages (i.e., when `message.contact` is present)
- The button uses `Media.download` to fetch and save the audio file, deriving the filename from the media URL and falling back to the `preview` URL if `url` is unavailable
- An error alert is displayed if the download fails
- The `isContactMessage` logic was extracted into a computed property and reused in both the download button visibility and the transcription action check
- Added localized strings for the download tooltip ("Export") and error message in English, Spanish, and Portuguese
- Added unit tests covering: button visibility based on contact presence, correct download parameters, preview URL fallback, and error alert on failure

## Preview and examples

<img width="589" height="231" alt="image" src="https://github.com/user-attachments/assets/86980236-de64-49a6-a17f-065816745c50" />
<img width="412" height="120" alt="image" src="https://github.com/user-attachments/assets/eab932b6-47b3-487e-898c-73132f02b263" />
