### PR TITLE
refactor: Update audio download visibility logic in ChatMessageAudio component

### DIFF
--- a/src/components/chats/chat/ChatMessages/ChatMessageAudio/ChatMessageAudio.vue
+++ b/src/components/chats/chat/ChatMessages/ChatMessageAudio/ChatMessageAudio.vue
@@ -101,7 +101,7 @@
     </UnnnicAudioRecorder>
 
     <section
-      v-if="isContactMessage"
+      v-if="canShowAudioDownloadAction"
       class="chat-message-audio__download"
     >
       <UnnnicToolTip
@@ -175,6 +175,17 @@ const messageMedia = computed(() => {
 
 const isContactMessage = computed(() => {
   return !!props.message.contact;
+});
+
+const canShowAudioDownloadAction = computed(() => {
+  if (
+    !featureFlags.value.active_features?.includes(
+      'weniChatsDownloadAudioMessage',
+    )
+  ) {
+    return false;
+  }
+  return isContactMessage.value;
 });
 
 const handleDownload = async () => {

--- a/src/components/chats/chat/ChatMessages/ChatMessageAudio/__tests__/ChatMessageAudio.spec.js
+++ b/src/components/chats/chat/ChatMessages/ChatMessageAudio/__tests__/ChatMessageAudio.spec.js
@@ -110,6 +110,7 @@ describe('ChatMessageAudio', () => {
     roomMessagesStore = useRoomMessages();
     useFeatureFlag().featureFlags.active_features = [
       'weniChatsTranscriptAudioMessage',
+      'weniChatsDownloadAudioMessage',
     ];
     vi.spyOn(roomMessagesStore, 'updateMessage').mockImplementation(() => {});
   });
@@ -333,6 +334,18 @@ describe('ChatMessageAudio', () => {
     it('does not render download button when message has no contact', () => {
       wrapper = mountComponent({
         message: createMessage({ contact: null }),
+      });
+      expect(wrapper.find('[data-testid="download-button"]').exists()).toBe(
+        false,
+      );
+    });
+
+    it('does not render download button when feature flag is disabled', () => {
+      useFeatureFlag().featureFlags.active_features = [
+        'weniChatsTranscriptAudioMessage',
+      ];
+      wrapper = mountComponent({
+        message: createMessage({ contact: { uuid: 'c1' } }),
       });
       expect(wrapper.find('[data-testid="download-button"]').exists()).toBe(
         false,


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
The audio message download button should only be available when explicitly enabled, allowing controlled rollout of this functionality through a feature flag.

### Summary of Changes
- Introduced a `canShowAudioDownloadAction` computed property that gates the audio download button behind the `weniChatsDownloadAudioMessage` feature flag, in addition to requiring the message to be from a contact.
- Replaced the `isContactMessage` condition on the download section with `canShowAudioDownloadAction`.
- Added a test case to verify the download button is not rendered when the `weniChatsDownloadAudioMessage` feature flag is absent, and updated existing tests to include the flag where the download button is expected to be present.