### PR TITLE
[ENGAGE-8557] fix: Improve URL regex in formatMessageText function and enhance text sanitization

### DIFF
--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -16,7 +16,7 @@ export const normalizeText = (text) => {
  */
 export const formatMessageText = (text) => {
   function treatTextUrl(text) {
-    const urlRegex = /(https?:\/\/[^\s]+)/g;
+    const urlRegex = /(https?:\/\/[^\s<]+)/g;
     return text.replace(urlRegex, '<a href="$1" target="_blank">$1</a>');
   }
 
@@ -64,9 +64,8 @@ export const formatMessageText = (text) => {
     );
   }
 
-  const formattedText = treatTextUrl(
-    removeHtmlDangerousContent(text).trim()?.replace(/\n/g, '<br/>'),
-  );
+  const sanitizedText = removeHtmlDangerousContent(text).trim();
+  const formattedText = treatTextUrl(sanitizedText)?.replace(/\n/g, '<br/>');
 
   return typeof text === 'string' ? formattedText : '';
 };


### PR DESCRIPTION
## Description

### Type of Change

- [x]  Bugfix
- [ ]  Feature
- [ ]  Code style update (formatting, local variables)
- [ ]  Refactoring (no functional changes, no api changes)
- [ ]  Tests
- [ ]  Other

### Motivation and Context

The URL regex used in `formatMessageText` was incorrectly matching HTML characters (such as `<`) as part of URLs. This caused malformed anchor tags to be generated when URLs appeared near HTML content, leading to broken or invalid links in rendered messages.

Additionally, newline replacement (`\n` → `<br/>`) was being applied before URL detection, which could interfere with proper URL matching and transformation.

### Summary of Changes

- Updated the URL regex from `/(https?:\/\/[^\s]+)/g` to `/(https?:\/\/[^\s<]+)/g` to prevent `<` characters from being included in matched URLs, avoiding malformed anchor tags.
- Reordered the text processing steps so that URL replacement (`treatTextUrl`) is applied to the sanitized text first, and newline replacement (`\n` → `<br/>`) is applied afterward, ensuring URLs are matched correctly before any HTML line break tags are introduced.