### PR TITLE
feat: Sync inactivity timeout default messages with locale changes

### DIFF
--- a/src/components/chats/MessageManagerV2/TextBox/AiTextImprovement.vue
+++ b/src/components/chats/MessageManagerV2/TextBox/AiTextImprovement.vue
@@ -129,13 +129,11 @@ function handleMouseEnter() {
 }
 
 function handleButtonClick() {
-
   if (isDisabled.value) {
     return;
   }
 
   isPopoverOpen.value = !isPopoverOpen.value;
-
 }
 
 async function selectOption(type: AiTextImprovementType) {

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -141,6 +141,18 @@
           "tooltip": "Alege între sondajul CSAT implicit și un flux personalizat deja configurat în modulul Fluxuri."
         }
       },
+      "inactivity_timeout": {
+        "close_room": {
+          "field": {
+            "default_close_room_message": "Această sesiune s-a încheiat din cauza inactivității. Poți începe un chat nou oricând."
+          }
+        },
+        "show": {
+          "field": {
+            "default_warning_message": "Mai ești acolo? Dacă nu există răspuns, această sesiune se va închide în curând."
+          }
+        }
+      },
       "additional_options": {
         "automated_message": {
           "switch_when_waiting_label": "Trimite mesaj automat contactelor care așteaptă",

--- a/src/plugins/i18n.js
+++ b/src/plugins/i18n.js
@@ -4,14 +4,17 @@ import { createI18n } from 'vue-i18n';
 import pt_br from '@/locales/pt_br.json';
 import en from '@/locales/en.json';
 import es from '@/locales/es.json';
+import ro from '@/locales/ro.json';
 
 import('moment/dist/locale/es.js');
 import('moment/dist/locale/pt-br.js');
+import('moment/dist/locale/ro.js');
 
 const messages = {
   'pt-br': pt_br,
   en,
   es,
+  ro,
 };
 
 const i18n = createI18n({
@@ -45,6 +48,17 @@ const i18n = createI18n({
       },
     },
     es: {
+      short: {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+      },
+      long: {
+        month: 'long',
+        day: '2-digit',
+      },
+    },
+    ro: {
       short: {
         year: 'numeric',
         month: '2-digit',

--- a/src/utils/test/compositionI18nVitest.js
+++ b/src/utils/test/compositionI18nVitest.js
@@ -8,6 +8,7 @@ import UnnnicSystemPlugin from '@/plugins/UnnnicSystem.js';
 import pt_br from '@/locales/pt_br.json';
 import en from '@/locales/en.json';
 import es from '@/locales/es.json';
+import ro from '@/locales/ro.json';
 
 /**
  * Legacy vue-i18n mixins break `<script setup>` in VTU (they assign `this.$t` in beforeCreate).
@@ -27,6 +28,7 @@ const compositionI18n = createI18n({
     'pt-br': pt_br,
     en,
     es,
+    ro,
   },
 });
 

--- a/src/views/Settings/Forms/ExtraOptions.vue
+++ b/src/views/Settings/Forms/ExtraOptions.vue
@@ -397,6 +397,9 @@ export default {
         'sector.additional_options.inactivity_timeout.close_room.field.default_close_room_message',
       );
     },
+    currentI18nLocale() {
+      return i18n.global.__composer.locale.value;
+    },
   },
   watch: {
     validForm: {
@@ -405,14 +408,9 @@ export default {
         this.$emit('changeIsValid', value);
       },
     },
-  },
-  created() {
-    this.$watch(
-      () => this.$i18n.locale,
-      () => {
-        this.syncInactivityTimeoutMessagesOnLocaleChange();
-      },
-    );
+    currentI18nLocale() {
+      this.syncInactivityTimeoutMessagesOnLocaleChange();
+    },
   },
   mounted() {
     if (this.isEditing) {

--- a/src/views/Settings/Forms/ExtraOptions.vue
+++ b/src/views/Settings/Forms/ExtraOptions.vue
@@ -288,7 +288,7 @@ import i18n from '@/plugins/i18n';
 
 import { parseSecondsToMinutes, parseMinutesToSeconds } from '@/utils/time';
 
-const INACTIVITY_TIMEOUT_LOCALES = ['en', 'pt-br', 'es', 'ro'];
+const INACTIVITY_TIMEOUT_LOCALES = ['en', 'pt-br', 'es'];
 
 export default {
   name: 'SectorExtraOptionsForm',

--- a/src/views/Settings/Forms/ExtraOptions.vue
+++ b/src/views/Settings/Forms/ExtraOptions.vue
@@ -288,7 +288,7 @@ import i18n from '@/plugins/i18n';
 
 import { parseSecondsToMinutes, parseMinutesToSeconds } from '@/utils/time';
 
-const INACTIVITY_TIMEOUT_LOCALES = ['en', 'pt-br', 'es'];
+const INACTIVITY_TIMEOUT_LOCALES = ['en', 'pt-br', 'es', 'ro'];
 
 export default {
   name: 'SectorExtraOptionsForm',

--- a/src/views/Settings/Forms/ExtraOptions.vue
+++ b/src/views/Settings/Forms/ExtraOptions.vue
@@ -281,13 +281,14 @@ import SatisfactionSurveySection from './SatisfactionSurveySection.vue';
 import TagGroup from '@/components/TagGroup.vue';
 
 import { useFeatureFlag } from '@/store/modules/featureFlag';
-import { useConfig } from '@/store/modules/config';
 
 import Sector from '@/services/api/resources/settings/sector';
 
 import i18n from '@/plugins/i18n';
 
 import { parseSecondsToMinutes, parseMinutesToSeconds } from '@/utils/time';
+
+const INACTIVITY_TIMEOUT_LOCALES = ['en', 'pt-br', 'es', 'ro'];
 
 export default {
   name: 'SectorExtraOptionsForm',
@@ -321,7 +322,6 @@ export default {
   },
   computed: {
     ...mapState(useFeatureFlag, ['featureFlags']),
-    ...mapState(useConfig, ['project']),
     sector: {
       get() {
         return this.modelValue;
@@ -388,24 +388,14 @@ export default {
       );
     },
     inactivityTimeoutDefaultMessage() {
-      const languageMap = {
-        'en-us': 'en',
-        'pt-br': 'pt-br',
-        es: 'es',
-      };
-      return i18n.global.messages[languageMap[this.project.language]].sector
-        .additional_options.inactivity_timeout.show.field
-        .default_warning_message;
+      return this.$t(
+        'sector.additional_options.inactivity_timeout.show.field.default_warning_message',
+      );
     },
     inactivityTimeoutDefaultCloseRoomMessage() {
-      const languageMap = {
-        'en-us': 'en',
-        'pt-br': 'pt-br',
-        es: 'es',
-      };
-      return i18n.global.messages[languageMap[this.project.language]].sector
-        .additional_options.inactivity_timeout.close_room.field
-        .default_close_room_message;
+      return this.$t(
+        'sector.additional_options.inactivity_timeout.close_room.field.default_close_room_message',
+      );
     },
   },
   watch: {
@@ -414,6 +404,9 @@ export default {
       handler(value) {
         this.$emit('changeIsValid', value);
       },
+    },
+    '$i18n.locale'() {
+      this.syncInactivityTimeoutMessagesOnLocaleChange();
     },
   },
   mounted() {
@@ -463,6 +456,47 @@ export default {
       } else {
         this.sector.inactivity_timeout.close_room_message_text = '';
         this.sector.inactivity_timeout.close_room_timeout_time = null;
+      }
+    },
+    getInactivityTimeoutDefaultMessages(messageType) {
+      const sectionKey = messageType === 'warning' ? 'show' : 'close_room';
+      const fieldKey =
+        messageType === 'warning'
+          ? 'default_warning_message'
+          : 'default_close_room_message';
+
+      return INACTIVITY_TIMEOUT_LOCALES.map(
+        (locale) =>
+          i18n.global.messages[locale].sector.additional_options
+            .inactivity_timeout[sectionKey].field[fieldKey],
+      );
+    },
+    isUntouchedInactivityMessage(text, messageType) {
+      if (!text) return false;
+
+      return this.getInactivityTimeoutDefaultMessages(messageType).includes(
+        text,
+      );
+    },
+    syncInactivityTimeoutMessagesOnLocaleChange() {
+      const { inactivity_timeout: timeout } = this.sector;
+
+      if (
+        timeout.is_message_timeout_enabled &&
+        this.isUntouchedInactivityMessage(timeout.message_timeout_text, 'warning')
+      ) {
+        timeout.message_timeout_text = this.inactivityTimeoutDefaultMessage;
+      }
+
+      if (
+        timeout.is_close_room_enabled &&
+        this.isUntouchedInactivityMessage(
+          timeout.close_room_message_text,
+          'close_room',
+        )
+      ) {
+        timeout.close_room_message_text =
+          this.inactivityTimeoutDefaultCloseRoomMessage;
       }
     },
     handleAutomaticMessageIsActive(value) {

--- a/src/views/Settings/Forms/ExtraOptions.vue
+++ b/src/views/Settings/Forms/ExtraOptions.vue
@@ -398,7 +398,7 @@ export default {
       );
     },
     currentI18nLocale() {
-      return i18n.global.__composer.locale.value;
+      return this.$i18n.locale;
     },
   },
   watch: {

--- a/src/views/Settings/Forms/ExtraOptions.vue
+++ b/src/views/Settings/Forms/ExtraOptions.vue
@@ -405,9 +405,14 @@ export default {
         this.$emit('changeIsValid', value);
       },
     },
-    '$i18n.locale'() {
-      this.syncInactivityTimeoutMessagesOnLocaleChange();
-    },
+  },
+  created() {
+    this.$watch(
+      () => this.$i18n.locale,
+      () => {
+        this.syncInactivityTimeoutMessagesOnLocaleChange();
+      },
+    );
   },
   mounted() {
     if (this.isEditing) {
@@ -467,9 +472,9 @@ export default {
 
       return INACTIVITY_TIMEOUT_LOCALES.map(
         (locale) =>
-          i18n.global.messages[locale].sector.additional_options
-            .inactivity_timeout[sectionKey].field[fieldKey],
-      );
+          i18n.global.messages[locale]?.sector?.additional_options
+            ?.inactivity_timeout?.[sectionKey]?.field?.[fieldKey],
+      ).filter(Boolean);
     },
     isUntouchedInactivityMessage(text, messageType) {
       if (!text) return false;
@@ -483,7 +488,10 @@ export default {
 
       if (
         timeout.is_message_timeout_enabled &&
-        this.isUntouchedInactivityMessage(timeout.message_timeout_text, 'warning')
+        this.isUntouchedInactivityMessage(
+          timeout.message_timeout_text,
+          'warning',
+        )
       ) {
         timeout.message_timeout_text = this.inactivityTimeoutDefaultMessage;
       }

--- a/src/views/Settings/Forms/__tests__/ExtraOptions.spec.js
+++ b/src/views/Settings/Forms/__tests__/ExtraOptions.spec.js
@@ -328,18 +328,6 @@ describe('SectorExtraOptions', () => {
         'Mensagem personalizada',
       );
     });
-
-    it('should use romanian default message when locale is ro', async () => {
-      wrapper.vm.$i18n.locale = 'ro';
-
-      wrapper.vm.handleInactivityTimeoutIsMessageTimeoutEnabled(true);
-
-      expect(wrapper.vm.sector.inactivity_timeout.message_timeout_text).toBe(
-        wrapper.vm.$t(
-          'sector.additional_options.inactivity_timeout.show.field.default_warning_message',
-        ),
-      );
-    });
   });
 
   it('Should match the snapshot', () => {

--- a/src/views/Settings/Forms/__tests__/ExtraOptions.spec.js
+++ b/src/views/Settings/Forms/__tests__/ExtraOptions.spec.js
@@ -8,6 +8,7 @@ import {
   afterAll,
 } from 'vitest';
 import { config, flushPromises, mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
 import { createTestingPinia } from '@pinia/testing';
 
 import { createMemoryHistory, createRouter } from 'vue-router';
@@ -334,54 +335,85 @@ describe('SectorExtraOptions', () => {
     });
 
     it('should sync default warning message when locale changes', async () => {
+      const localWrapper = createWrapper();
+      await flushPromises();
+
+      const syncSpy = vi.spyOn(
+        localWrapper.vm,
+        'syncInactivityTimeoutMessagesOnLocaleChange',
+      );
+
       i18n.global.locale = 'pt-br';
-      wrapper.vm.handleInactivityTimeoutIsMessageTimeoutEnabled(true);
+      await nextTick();
+      localWrapper.vm.handleInactivityTimeoutIsMessageTimeoutEnabled(true);
+      syncSpy.mockClear();
 
       i18n.global.locale = 'en';
-      wrapper.vm.syncInactivityTimeoutMessagesOnLocaleChange();
+      await nextTick();
 
-      expect(wrapper.vm.sector.inactivity_timeout.message_timeout_text).toBe(
+      expect(syncSpy).toHaveBeenCalled();
+      expect(
+        localWrapper.vm.sector.inactivity_timeout.message_timeout_text,
+      ).toBe(
         "Are you still there? If there's no response, this session will be closed soon.",
       );
     });
 
     it('should sync default close room message when locale changes', async () => {
+      const localWrapper = createWrapper();
+      await flushPromises();
+
       i18n.global.locale = 'pt-br';
-      wrapper.vm.handleInactivityTimeoutIsMessageTimeoutEnabled(true);
-      wrapper.vm.handleInactivityTimeoutIsCloseRoomEnabled(true);
+      await nextTick();
+      localWrapper.vm.handleInactivityTimeoutIsMessageTimeoutEnabled(true);
+      localWrapper.vm.handleInactivityTimeoutIsCloseRoomEnabled(true);
 
       i18n.global.locale = 'en';
-      wrapper.vm.syncInactivityTimeoutMessagesOnLocaleChange();
+      await nextTick();
 
-      expect(wrapper.vm.sector.inactivity_timeout.close_room_message_text).toBe(
+      expect(
+        localWrapper.vm.sector.inactivity_timeout.close_room_message_text,
+      ).toBe(
         'This session has ended due to inactivity. Feel free to start a new chat anytime!',
       );
     });
 
     it('should not sync warning message when locale changes after customization', async () => {
+      const localWrapper = createWrapper();
+      await flushPromises();
+
       i18n.global.locale = 'pt-br';
-      wrapper.vm.handleInactivityTimeoutIsMessageTimeoutEnabled(true);
-      wrapper.vm.sector.inactivity_timeout.message_timeout_text =
+      await nextTick();
+      localWrapper.vm.handleInactivityTimeoutIsMessageTimeoutEnabled(true);
+      localWrapper.vm.sector.inactivity_timeout.message_timeout_text =
         'Mensagem personalizada';
 
       i18n.global.locale = 'en';
-      wrapper.vm.syncInactivityTimeoutMessagesOnLocaleChange();
+      await nextTick();
 
-      expect(wrapper.vm.sector.inactivity_timeout.message_timeout_text).toBe(
-        'Mensagem personalizada',
-      );
+      expect(
+        localWrapper.vm.sector.inactivity_timeout.message_timeout_text,
+      ).toBe('Mensagem personalizada');
     });
 
     it('should use romanian default messages when locale is ro', async () => {
+      const localWrapper = createWrapper();
+      await flushPromises();
+
       i18n.global.locale = 'ro';
+      await nextTick();
 
-      wrapper.vm.handleInactivityTimeoutIsMessageTimeoutEnabled(true);
-      wrapper.vm.handleInactivityTimeoutIsCloseRoomEnabled(true);
+      localWrapper.vm.handleInactivityTimeoutIsMessageTimeoutEnabled(true);
+      localWrapper.vm.handleInactivityTimeoutIsCloseRoomEnabled(true);
 
-      expect(wrapper.vm.sector.inactivity_timeout.message_timeout_text).toBe(
+      expect(
+        localWrapper.vm.sector.inactivity_timeout.message_timeout_text,
+      ).toBe(
         'Mai ești acolo? Dacă nu există răspuns, această sesiune se va închide în curând.',
       );
-      expect(wrapper.vm.sector.inactivity_timeout.close_room_message_text).toBe(
+      expect(
+        localWrapper.vm.sector.inactivity_timeout.close_room_message_text,
+      ).toBe(
         'Această sesiune s-a încheiat din cauza inactivității. Poți începe un chat nou oricând.',
       );
     });

--- a/src/views/Settings/Forms/__tests__/ExtraOptions.spec.js
+++ b/src/views/Settings/Forms/__tests__/ExtraOptions.spec.js
@@ -276,6 +276,72 @@ describe('SectorExtraOptions', () => {
     );
   });
 
+  describe('inactivity timeout default messages', () => {
+    it('should use the current user locale for the warning message', async () => {
+      wrapper.vm.$i18n.locale = 'pt-br';
+
+      wrapper.vm.handleInactivityTimeoutIsMessageTimeoutEnabled(true);
+
+      expect(wrapper.vm.sector.inactivity_timeout.message_timeout_text).toBe(
+        wrapper.vm.$t(
+          'sector.additional_options.inactivity_timeout.show.field.default_warning_message',
+        ),
+      );
+    });
+
+    it('should use the current user locale for the close room message', async () => {
+      wrapper.vm.$i18n.locale = 'pt-br';
+
+      wrapper.vm.handleInactivityTimeoutIsCloseRoomEnabled(true);
+
+      expect(wrapper.vm.sector.inactivity_timeout.close_room_message_text).toBe(
+        wrapper.vm.$t(
+          'sector.additional_options.inactivity_timeout.close_room.field.default_close_room_message',
+        ),
+      );
+    });
+
+    it('should update default warning message when locale changes', async () => {
+      wrapper.vm.$i18n.locale = 'pt-br';
+      wrapper.vm.handleInactivityTimeoutIsMessageTimeoutEnabled(true);
+
+      wrapper.vm.$i18n.locale = 'en';
+      await flushPromises();
+
+      expect(wrapper.vm.sector.inactivity_timeout.message_timeout_text).toBe(
+        wrapper.vm.$t(
+          'sector.additional_options.inactivity_timeout.show.field.default_warning_message',
+        ),
+      );
+    });
+
+    it('should not update warning message when locale changes after customization', async () => {
+      wrapper.vm.$i18n.locale = 'pt-br';
+      wrapper.vm.handleInactivityTimeoutIsMessageTimeoutEnabled(true);
+      wrapper.vm.sector.inactivity_timeout.message_timeout_text =
+        'Mensagem personalizada';
+
+      wrapper.vm.$i18n.locale = 'en';
+      await flushPromises();
+
+      expect(wrapper.vm.sector.inactivity_timeout.message_timeout_text).toBe(
+        'Mensagem personalizada',
+      );
+    });
+
+    it('should use romanian default message when locale is ro', async () => {
+      wrapper.vm.$i18n.locale = 'ro';
+
+      wrapper.vm.handleInactivityTimeoutIsMessageTimeoutEnabled(true);
+
+      expect(wrapper.vm.sector.inactivity_timeout.message_timeout_text).toBe(
+        wrapper.vm.$t(
+          'sector.additional_options.inactivity_timeout.show.field.default_warning_message',
+        ),
+      );
+    });
+  });
+
   it('Should match the snapshot', () => {
     expect(wrapper.html()).toMatchSnapshot();
   });

--- a/src/views/Settings/Forms/__tests__/ExtraOptions.spec.js
+++ b/src/views/Settings/Forms/__tests__/ExtraOptions.spec.js
@@ -1,10 +1,18 @@
-import { expect, describe, it, vi, beforeEach } from 'vitest';
-import { flushPromises, mount } from '@vue/test-utils';
+import {
+  expect,
+  describe,
+  it,
+  vi,
+  beforeEach,
+  beforeAll,
+  afterAll,
+} from 'vitest';
+import { config, flushPromises, mount } from '@vue/test-utils';
 import { createTestingPinia } from '@pinia/testing';
 
 import { createMemoryHistory, createRouter } from 'vue-router';
 
-import { useCompositionI18nInThisSpecFile } from '@/utils/test/compositionI18nVitest';
+import i18n from '@/plugins/i18n';
 
 import FormSectorExtraOptions from '../ExtraOptions.vue';
 
@@ -74,11 +82,21 @@ function createWrapper(props = {}) {
 }
 
 describe('SectorExtraOptions', () => {
-  useCompositionI18nInThisSpecFile();
+  let savedTMock;
+
+  beforeAll(() => {
+    savedTMock = config.global.mocks.$t;
+    delete config.global.mocks.$t;
+  });
+
+  afterAll(() => {
+    config.global.mocks.$t = savedTMock;
+  });
 
   let wrapper;
 
   beforeEach(async () => {
+    i18n.global.locale = 'en';
     wrapper = createWrapper();
     await flushPromises();
   });
@@ -277,55 +295,94 @@ describe('SectorExtraOptions', () => {
   });
 
   describe('inactivity timeout default messages', () => {
+    beforeEach(async () => {
+      i18n.global.locale = 'en';
+      await wrapper.setProps({
+        modelValue: {
+          ...sectorExtraOptionsMock,
+          inactivity_timeout: {
+            is_message_timeout_enabled: false,
+            message_timeout_text: '',
+            message_timeout_time: null,
+            is_close_room_enabled: false,
+            close_room_message_text: '',
+            close_room_timeout_time: null,
+          },
+        },
+      });
+      await flushPromises();
+    });
+
     it('should use the current user locale for the warning message', async () => {
-      wrapper.vm.$i18n.locale = 'pt-br';
+      i18n.global.locale = 'pt-br';
 
       wrapper.vm.handleInactivityTimeoutIsMessageTimeoutEnabled(true);
 
       expect(wrapper.vm.sector.inactivity_timeout.message_timeout_text).toBe(
-        wrapper.vm.$t(
-          'sector.additional_options.inactivity_timeout.show.field.default_warning_message',
-        ),
+        'Você ainda está aí? Se não houver resposta, este atendimento será encerrado em breve.',
       );
     });
 
     it('should use the current user locale for the close room message', async () => {
-      wrapper.vm.$i18n.locale = 'pt-br';
+      i18n.global.locale = 'pt-br';
 
       wrapper.vm.handleInactivityTimeoutIsCloseRoomEnabled(true);
 
       expect(wrapper.vm.sector.inactivity_timeout.close_room_message_text).toBe(
-        wrapper.vm.$t(
-          'sector.additional_options.inactivity_timeout.close_room.field.default_close_room_message',
-        ),
+        'Este atendimento foi encerrado por inatividade. Inicie um novo chat quando quiser.',
       );
     });
 
-    it('should update default warning message when locale changes', async () => {
-      wrapper.vm.$i18n.locale = 'pt-br';
+    it('should sync default warning message when locale changes', async () => {
+      i18n.global.locale = 'pt-br';
       wrapper.vm.handleInactivityTimeoutIsMessageTimeoutEnabled(true);
 
-      wrapper.vm.$i18n.locale = 'en';
-      await flushPromises();
+      i18n.global.locale = 'en';
+      wrapper.vm.syncInactivityTimeoutMessagesOnLocaleChange();
 
       expect(wrapper.vm.sector.inactivity_timeout.message_timeout_text).toBe(
-        wrapper.vm.$t(
-          'sector.additional_options.inactivity_timeout.show.field.default_warning_message',
-        ),
+        "Are you still there? If there's no response, this session will be closed soon.",
       );
     });
 
-    it('should not update warning message when locale changes after customization', async () => {
-      wrapper.vm.$i18n.locale = 'pt-br';
+    it('should sync default close room message when locale changes', async () => {
+      i18n.global.locale = 'pt-br';
+      wrapper.vm.handleInactivityTimeoutIsMessageTimeoutEnabled(true);
+      wrapper.vm.handleInactivityTimeoutIsCloseRoomEnabled(true);
+
+      i18n.global.locale = 'en';
+      wrapper.vm.syncInactivityTimeoutMessagesOnLocaleChange();
+
+      expect(wrapper.vm.sector.inactivity_timeout.close_room_message_text).toBe(
+        'This session has ended due to inactivity. Feel free to start a new chat anytime!',
+      );
+    });
+
+    it('should not sync warning message when locale changes after customization', async () => {
+      i18n.global.locale = 'pt-br';
       wrapper.vm.handleInactivityTimeoutIsMessageTimeoutEnabled(true);
       wrapper.vm.sector.inactivity_timeout.message_timeout_text =
         'Mensagem personalizada';
 
-      wrapper.vm.$i18n.locale = 'en';
-      await flushPromises();
+      i18n.global.locale = 'en';
+      wrapper.vm.syncInactivityTimeoutMessagesOnLocaleChange();
 
       expect(wrapper.vm.sector.inactivity_timeout.message_timeout_text).toBe(
         'Mensagem personalizada',
+      );
+    });
+
+    it('should use romanian default messages when locale is ro', async () => {
+      i18n.global.locale = 'ro';
+
+      wrapper.vm.handleInactivityTimeoutIsMessageTimeoutEnabled(true);
+      wrapper.vm.handleInactivityTimeoutIsCloseRoomEnabled(true);
+
+      expect(wrapper.vm.sector.inactivity_timeout.message_timeout_text).toBe(
+        'Mai ești acolo? Dacă nu există răspuns, această sesiune se va închide în curând.',
+      );
+      expect(wrapper.vm.sector.inactivity_timeout.close_room_message_text).toBe(
+        'Această sesiune s-a încheiat din cauza inactivității. Poți începe un chat nou oricând.',
       );
     });
   });

--- a/src/views/Settings/Forms/__tests__/__snapshots__/ExtraOptions.spec.js.snap
+++ b/src/views/Settings/Forms/__tests__/__snapshots__/ExtraOptions.spec.js.snap
@@ -3,21 +3,21 @@
 exports[`SectorExtraOptions > Should match the snapshot 1`] = `
 "<section data-v-8e9664ba="" class="sector-extra-options-form">
   <section data-v-8e9664ba="" class="switchs">
-    <h2 data-v-8e9664ba="" class="switchs__title" data-testid="switchs-title">sector.additional_options.title</h2>
-    <unnnic-switch-stub data-v-8e9664ba="" size="small" label="" option="" helper="" textleft="" textright="sector.additional_options.template_message.switch_label" disabled="false" modelvalue="false" class="margin-y-space-1" data-testid="config-switch"></unnnic-switch-stub>
+    <h2 data-v-8e9664ba="" class="switchs__title" data-testid="switchs-title">Extra options</h2>
+    <unnnic-switch-stub data-v-8e9664ba="" size="small" label="" option="" helper="" textleft="" textright="Triggering message templates" disabled="false" modelvalue="false" class="margin-y-space-1" data-testid="config-switch"></unnnic-switch-stub>
     <section data-v-8e9664ba="" class="switchs__container">
-      <unnnic-switch-stub data-v-8e9664ba="" size="small" label="" option="" helper="sector.additional_options.agents_signature.hint" textleft="" textright="sector.additional_options.agents_signature.switch_label" disabled="false" modelvalue="false" class="margin-y-space-1" data-testid="config-switch"></unnnic-switch-stub>
+      <unnnic-switch-stub data-v-8e9664ba="" size="small" label="" option="" helper="Each message exchanged will have the name of the agent who is answering." textleft="" textright="Use signature" disabled="false" modelvalue="false" class="margin-y-space-1" data-testid="config-switch"></unnnic-switch-stub>
     </section>
-    <unnnic-switch-stub data-v-8e9664ba="" size="small" label="" option="" helper="sector.additional_options.edit_custom_fields.hint" textleft="" textright="sector.additional_options.edit_custom_fields.label" disabled="false" modelvalue="false" class="margin-y-space-1" data-testid="config-switch"></unnnic-switch-stub>
+    <unnnic-switch-stub data-v-8e9664ba="" size="small" label="" option="" helper="When active, it allows representatives to edit the custom fields of the contact in the &quot;All Information&quot; section." textleft="" textright="Allow representatives to edit custom contact information" disabled="false" modelvalue="false" class="margin-y-space-1" data-testid="config-switch"></unnnic-switch-stub>
   </section>
   <section data-v-8e9664ba="" class="switchs">
-    <h2 data-v-8e9664ba="" class="switchs__title">sector.additional_options.automated_message.title</h2>
+    <h2 data-v-8e9664ba="" class="switchs__title">Automated messages</h2>
     <!--v-if-->
   </section>
   <!--v-if-->
   <!--v-if-->
   <section data-v-8e9664ba="" class="tags">
-    <h2 data-v-8e9664ba="" class="tags__title" data-testid="tags-title">sector.tags <div data-v-03fa3548="" data-v-61269528="" class="unnnic-tooltip-trigger unnnic-tooltip" data-testid="tooltip-trigger" data-state="closed" data-grace-area-trigger=""><svg data-v-b593673c="" data-v-8e9664ba="" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 24 24" class="iconify iconify--ri unnnic-icon unnnic-icon-scheme--fg-base unnnic-icon-size--sm" data-testid="iconify-icon">
+    <h2 data-v-8e9664ba="" class="tags__title" data-testid="tags-title">Tags <div data-v-03fa3548="" data-v-61269528="" class="unnnic-tooltip-trigger unnnic-tooltip" data-testid="tooltip-trigger" data-state="closed" data-grace-area-trigger=""><svg data-v-b593673c="" data-v-8e9664ba="" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 24 24" class="iconify iconify--ri unnnic-icon unnnic-icon-scheme--fg-base unnnic-icon-size--sm" data-testid="iconify-icon">
           <path fill="currentColor" d="M12 22C6.477 22 2 17.523 2 12S6.477 2 12 2s10 4.477 10 10s-4.477 10-10 10m0-2a8 8 0 1 0 0-16a8 8 0 0 0 0 16m-1-5h2v2h-2zm2-1.645V14h-2v-1.5a1 1 0 0 1 1-1a1.5 1.5 0 1 0-1.471-1.794l-1.962-.393A3.501 3.501 0 1 1 13 13.355"></path>
         </svg></div>
       <div data-v-61269528="" disabled="false" defer="false" forcemount="false">
@@ -27,10 +27,10 @@ exports[`SectorExtraOptions > Should match the snapshot 1`] = `
     <section data-v-8e9664ba="" class="tags-form">
       <section data-v-a13fc64d="" data-v-2dd04313="" data-v-8e9664ba="" class="unnnic-form-element unnnic-form md tags-form__input" data-testid="tags-input-tag-name">
         <section data-v-b52fcb11="" data-v-a13fc64d="" class="unnnic-label unnnic-form-element__label">
-          <p data-v-b52fcb11="" class="unnnic-label__label">tags.add.label</p>
+          <p data-v-b52fcb11="" class="unnnic-label__label">Tag name</p>
           <!---->
         </section>
-        <div data-v-ff09e93b="" data-v-2dd04313="" class="text-input size--md tags-form__input unnnic-form-input" data-testid="tags-input-tag-name" hascloudycolor="false" mask=""><input data-v-043812be="" data-v-ff09e93b="" class="tags-form__input unnnic-form-input input-itself input size-md normal tags-form__input unnnic-form-input input-itself" data-testid="tags-input-tag-name" hascloudycolor="false" placeholder="tags.add.placeholder" iconleft="" iconright="" iconleftclickable="false" iconrightclickable="false" showclear="false" type="text" maxlength="120" value="">
+        <div data-v-ff09e93b="" data-v-2dd04313="" class="text-input size--md tags-form__input unnnic-form-input" data-testid="tags-input-tag-name" hascloudycolor="false" mask=""><input data-v-043812be="" data-v-ff09e93b="" class="tags-form__input unnnic-form-input input-itself input size-md normal tags-form__input unnnic-form-input input-itself" data-testid="tags-input-tag-name" hascloudycolor="false" placeholder="Enter the name of a tag to search or to add it" iconleft="" iconright="" iconleftclickable="false" iconrightclickable="false" showclear="false" type="text" maxlength="120" value="">
           <!---->
           <section data-v-ff09e93b="" class="icon-right-container">
             <!---->
@@ -41,13 +41,13 @@ exports[`SectorExtraOptions > Should match the snapshot 1`] = `
       </section><button data-v-d7396b6a="" data-v-8e9664ba="" data-testid="tags-add-tag-button" disabled="" class="unnnic-button unnnic-button--size-large unnnic-button--secondary">
         <!---->
         <!---->
-        <!----><span data-v-d7396b6a="" class="unnnic-button__label" style="visibility: visible;" data-testid="button-label"> add</span>
+        <!----><span data-v-d7396b6a="" class="unnnic-button__label" style="visibility: visible;" data-testid="button-label"> Add</span>
         <!---->
       </button>
     </section>
     <!--v-if-->
     <section data-v-8e9664ba="" class="switchs__container required-tags">
-      <unnnic-switch-stub data-v-8e9664ba="" size="small" label="" option="" helper="" textleft="" textright="sector.additional_options.required_tags.switch_label" disabled="true" modelvalue="false" class="margin-y-space-1" data-testid="config-switch"></unnnic-switch-stub>
+      <unnnic-switch-stub data-v-8e9664ba="" size="small" label="" option="" helper="" textleft="" textright="Require tags at the end of human support" disabled="true" modelvalue="false" class="margin-y-space-1" data-testid="config-switch"></unnnic-switch-stub>
     </section>
   </section>
 </section>"


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
The inactivity timeout default messages were previously resolved by directly accessing the i18n messages object using a hardcoded language map tied to the project's language setting. This approach was fragile and did not respond to locale changes at runtime. Additionally, Romanian (`ro`) locale was missing translations for the inactivity timeout messages.

### Summary of Changes
- Replaced direct `i18n.global.messages` access with `$t()` calls for `inactivityTimeoutDefaultMessage` and `inactivityTimeoutDefaultCloseRoomMessage` computed properties, so they now resolve based on the active user locale.
- Removed the dependency on `useConfig` store and the `project` state from `ExtraOptions.vue`, since the locale is now sourced directly from the i18n plugin.
- Added a watcher on `$i18n.locale` that automatically syncs the inactivity timeout messages when the locale changes, but only if the messages have not been customized by the user.
- Introduced `getInactivityTimeoutDefaultMessages` and `isUntouchedInactivityMessage` helper methods to detect whether a message is still one of the known default translations across supported locales (`en`, `pt-br`, `es`).
- Added Romanian (`ro`) translations for the inactivity timeout warning and close room default messages.
- Added tests covering locale-aware message resolution, automatic message sync on locale change, and preservation of user-customized messages when the locale changes.