### PR TITLE
feat: Implement infinite scroll functionality in QuickMessagesList component

### DIFF
--- a/src/components/chats/QuickMessages/QuickMessagesList.vue
+++ b/src/components/chats/QuickMessages/QuickMessagesList.vue
@@ -199,7 +199,8 @@ export default {
 
       const isVisible = scrollRoot
         ? this.isElementVisibleInContainer(sentinelRect, scrollRoot)
-        : sentinelRect.top <= window.innerHeight + 120;
+        : sentinelRect.top <= window.innerHeight + 120 &&
+          sentinelRect.bottom >= -120;
 
       if (isVisible) {
         this.$emit('load-more');

--- a/src/components/chats/QuickMessages/QuickMessagesList.vue
+++ b/src/components/chats/QuickMessages/QuickMessagesList.vue
@@ -37,6 +37,7 @@
         <div
           v-if="infiniteScroll && !withoutQuickMessages"
           ref="infiniteScrollSentinel"
+          data-testid="sentinel"
           class="quick-messages-list__sentinel"
         />
         <UnnnicIconLoading

--- a/src/components/chats/QuickMessages/QuickMessagesList.vue
+++ b/src/components/chats/QuickMessages/QuickMessagesList.vue
@@ -129,6 +129,9 @@ export default {
     withoutQuickMessages() {
       return this.quickMessages?.length === 0;
     },
+    infiniteScrollReady() {
+      return this.infiniteScroll && !this.withoutQuickMessages;
+    },
   },
   watch: {
     withoutQuickMessages: {
@@ -137,19 +140,30 @@ export default {
         this.$emit('update:isEmpty', newWithoutQuickMessages);
       },
     },
-    infiniteScroll: {
-      handler(enabled) {
-        if (enabled) {
+    infiniteScrollReady: {
+      handler(isReady) {
+        if (isReady) {
           this.$nextTick(() => this.setupInfiniteScroll());
-        } else {
-          this.teardownInfiniteScroll();
+          return;
         }
+
+        this.teardownInfiniteScroll();
       },
+    },
+    loadingMore(isLoading, wasLoading) {
+      if (!isLoading && wasLoading && this.infiniteScrollReady) {
+        this.$nextTick(() => this.checkSentinelVisibility());
+      }
+    },
+    hasMore(isAvailable) {
+      if (isAvailable && this.infiniteScrollReady && !this.loadingMore) {
+        this.$nextTick(() => this.checkSentinelVisibility());
+      }
     },
   },
 
   mounted() {
-    if (this.infiniteScroll) {
+    if (this.infiniteScrollReady) {
       this.$nextTick(() => this.setupInfiniteScroll());
     }
   },
@@ -159,11 +173,53 @@ export default {
   },
 
   methods: {
+    findScrollRoot(element) {
+      let parent = element?.parentElement;
+
+      while (parent) {
+        const { overflowY } = window.getComputedStyle(parent);
+
+        if (overflowY === 'auto' || overflowY === 'scroll') {
+          return parent;
+        }
+
+        parent = parent.parentElement;
+      }
+
+      return null;
+    },
+    checkSentinelVisibility() {
+      if (!this.hasMore || this.loadingMore) return;
+
+      const sentinel = this.$refs.infiniteScrollSentinel;
+      if (!sentinel) return;
+
+      const scrollRoot = this.findScrollRoot(sentinel);
+      const sentinelRect = sentinel.getBoundingClientRect();
+
+      const isVisible = scrollRoot
+        ? this.isElementVisibleInContainer(sentinelRect, scrollRoot)
+        : sentinelRect.top <= window.innerHeight + 120;
+
+      if (isVisible) {
+        this.$emit('load-more');
+      }
+    },
+    isElementVisibleInContainer(elementRect, container) {
+      const containerRect = container.getBoundingClientRect();
+
+      return (
+        elementRect.top <= containerRect.bottom + 120 &&
+        elementRect.bottom >= containerRect.top - 120
+      );
+    },
     setupInfiniteScroll() {
       this.teardownInfiniteScroll();
 
       const sentinel = this.$refs.infiniteScrollSentinel;
       if (!sentinel) return;
+
+      const scrollRoot = this.findScrollRoot(sentinel);
 
       this.intersectionObserver = new IntersectionObserver(
         (entries) => {
@@ -172,7 +228,10 @@ export default {
             this.$emit('load-more');
           }
         },
-        { rootMargin: '120px' },
+        {
+          root: scrollRoot,
+          rootMargin: '120px',
+        },
       );
 
       this.intersectionObserver.observe(sentinel);

--- a/src/components/chats/QuickMessages/__tests__/QuickMessagesList.spec.js
+++ b/src/components/chats/QuickMessages/__tests__/QuickMessagesList.spec.js
@@ -26,19 +26,25 @@ const createWrapper = (props = {}) => {
   });
 };
 
+const mockSentinelRect = (wrapper, { top, bottom }) => {
+  const sentinel = wrapper.find('[data-testid="sentinel"]').element;
+
+  vi.spyOn(sentinel, 'getBoundingClientRect').mockReturnValue({
+    top,
+    bottom,
+    left: 0,
+    right: 100,
+    width: 100,
+    height: bottom - top,
+  });
+};
+
 describe('QuickMessagesList.vue', () => {
   let observeMock;
   let intersectionCallback;
 
   beforeEach(() => {
-    observeMock = vi.fn((element) => {
-      intersectionCallback?.([
-        {
-          isIntersecting: true,
-          target: element,
-        },
-      ]);
-    });
+    observeMock = vi.fn();
 
     global.IntersectionObserver = vi.fn((callback) => {
       intersectionCallback = callback;
@@ -69,7 +75,7 @@ describe('QuickMessagesList.vue', () => {
     expect(observeMock).toHaveBeenCalled();
   });
 
-  it('emits load-more when sentinel intersects and hasMore is true', async () => {
+  it('emits load-more when sentinel intersects via IntersectionObserver', async () => {
     const wrapper = createWrapper({
       infiniteScroll: true,
       hasMore: true,
@@ -77,6 +83,13 @@ describe('QuickMessagesList.vue', () => {
     });
 
     await flushPromises();
+
+    intersectionCallback?.([
+      {
+        isIntersecting: true,
+        target: wrapper.find('[data-testid="sentinel"]').element,
+      },
+    ]);
 
     expect(wrapper.emitted('load-more')).toBeTruthy();
   });
@@ -90,6 +103,13 @@ describe('QuickMessagesList.vue', () => {
 
     await flushPromises();
 
+    intersectionCallback?.([
+      {
+        isIntersecting: true,
+        target: wrapper.find('[data-testid="sentinel"]').element,
+      },
+    ]);
+
     expect(wrapper.emitted('load-more')).toBeFalsy();
   });
 
@@ -97,56 +117,48 @@ describe('QuickMessagesList.vue', () => {
     const wrapper = createWrapper({
       infiniteScroll: true,
       hasMore: true,
-      loadingMore: false,
+      loadingMore: true,
       quickMessages,
     });
 
-    await flushPromises();
-    expect(wrapper.emitted('load-more')).toBeTruthy();
-
-    const emitCountAfterFirstLoad = wrapper.emitted('load-more').length;
-
-    await wrapper.setProps({ loadingMore: true });
     await flushPromises();
 
     intersectionCallback?.([
       {
         isIntersecting: true,
-        target: wrapper.vm.$refs.infiniteScrollSentinel,
+        target: wrapper.find('[data-testid="sentinel"]').element,
       },
     ]);
     await flushPromises();
 
-    expect(wrapper.emitted('load-more').length).toBe(emitCountAfterFirstLoad);
+    expect(wrapper.emitted('load-more')).toBeFalsy();
   });
 
   it('emits load-more again after loading completes while sentinel is visible', async () => {
     const wrapper = createWrapper({
       infiniteScroll: true,
       hasMore: true,
-      loadingMore: false,
+      loadingMore: true,
       quickMessages,
     });
 
     await flushPromises();
-    expect(wrapper.emitted('load-more')).toBeTruthy();
-
-    const emitCountAfterFirstLoad = wrapper.emitted('load-more').length;
-
-    await wrapper.setProps({ loadingMore: true });
-    await flushPromises();
-
-    expect(wrapper.emitted('load-more').length).toBe(emitCountAfterFirstLoad);
+    mockSentinelRect(wrapper, { top: 500, bottom: 510 });
 
     await wrapper.setProps({ loadingMore: false });
     await flushPromises();
+    expect(wrapper.emitted('load-more')).toHaveLength(1);
 
-    expect(wrapper.emitted('load-more').length).toBeGreaterThan(
-      emitCountAfterFirstLoad,
-    );
+    await wrapper.setProps({ loadingMore: true });
+    await flushPromises();
+    expect(wrapper.emitted('load-more')).toHaveLength(1);
+
+    await wrapper.setProps({ loadingMore: false });
+    await flushPromises();
+    expect(wrapper.emitted('load-more')).toHaveLength(2);
   });
 
-  it('emits load-more when hasMore becomes true after the first page loads', async () => {
+  it('emits load-more when hasMore becomes true and sentinel is within viewport', async () => {
     const wrapper = createWrapper({
       infiniteScroll: true,
       hasMore: false,
@@ -154,11 +166,46 @@ describe('QuickMessagesList.vue', () => {
     });
 
     await flushPromises();
-    expect(wrapper.emitted('load-more')).toBeFalsy();
+    mockSentinelRect(wrapper, { top: 500, bottom: 510 });
 
     await wrapper.setProps({ hasMore: true });
     await flushPromises();
 
     expect(wrapper.emitted('load-more')).toBeTruthy();
+  });
+
+  it('does not emit load-more when sentinel is above the viewport', async () => {
+    const wrapper = createWrapper({
+      infiniteScroll: true,
+      hasMore: false,
+      quickMessages,
+    });
+
+    await flushPromises();
+    mockSentinelRect(wrapper, { top: -1000, bottom: -999 });
+
+    await wrapper.setProps({ hasMore: true });
+    await flushPromises();
+
+    expect(wrapper.emitted('load-more')).toBeFalsy();
+  });
+
+  it('does not emit load-more when sentinel is below the viewport', async () => {
+    const wrapper = createWrapper({
+      infiniteScroll: true,
+      hasMore: false,
+      quickMessages,
+    });
+
+    await flushPromises();
+    mockSentinelRect(wrapper, {
+      top: window.innerHeight + 200,
+      bottom: window.innerHeight + 210,
+    });
+
+    await wrapper.setProps({ hasMore: true });
+    await flushPromises();
+
+    expect(wrapper.emitted('load-more')).toBeFalsy();
   });
 });

--- a/src/components/chats/QuickMessages/__tests__/QuickMessagesList.spec.js
+++ b/src/components/chats/QuickMessages/__tests__/QuickMessagesList.spec.js
@@ -1,0 +1,128 @@
+import { mount, flushPromises } from '@vue/test-utils';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import QuickMessagesList from '../QuickMessagesList.vue';
+
+const quickMessages = [
+  { uuid: '1', title: 'A', text: 'Message A', shortcut: 'a' },
+  { uuid: '2', title: 'B', text: 'Message B', shortcut: 'b' },
+];
+
+const createWrapper = (props = {}) => {
+  return mount(QuickMessagesList, {
+    props: {
+      quickMessages: [],
+      title: 'Shared',
+      ...props,
+    },
+    global: {
+      stubs: {
+        QuickMessageCard: true,
+        UnnnicButton: true,
+        UnnnicIcon: true,
+        UnnnicIconLoading: true,
+      },
+    },
+  });
+};
+
+describe('QuickMessagesList.vue', () => {
+  let observeMock;
+  let intersectionCallback;
+
+  beforeEach(() => {
+    observeMock = vi.fn((element) => {
+      intersectionCallback?.([
+        {
+          isIntersecting: true,
+          target: element,
+        },
+      ]);
+    });
+
+    global.IntersectionObserver = vi.fn((callback) => {
+      intersectionCallback = callback;
+
+      return {
+        observe: observeMock,
+        unobserve: vi.fn(),
+        disconnect: vi.fn(),
+      };
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sets up infinite scroll after messages are loaded', async () => {
+    const wrapper = createWrapper({
+      infiniteScroll: true,
+      hasMore: true,
+    });
+
+    expect(observeMock).not.toHaveBeenCalled();
+
+    await wrapper.setProps({ quickMessages });
+    await flushPromises();
+
+    expect(observeMock).toHaveBeenCalled();
+  });
+
+  it('emits load-more when sentinel intersects and hasMore is true', async () => {
+    const wrapper = createWrapper({
+      infiniteScroll: true,
+      hasMore: true,
+      quickMessages,
+    });
+
+    await flushPromises();
+
+    expect(wrapper.emitted('load-more')).toBeTruthy();
+  });
+
+  it('does not emit load-more when hasMore is false', async () => {
+    const wrapper = createWrapper({
+      infiniteScroll: true,
+      hasMore: false,
+      quickMessages,
+    });
+
+    await flushPromises();
+
+    expect(wrapper.emitted('load-more')).toBeFalsy();
+  });
+
+  it('emits load-more again after loading completes while sentinel is visible', async () => {
+    const wrapper = createWrapper({
+      infiniteScroll: true,
+      hasMore: true,
+      loadingMore: true,
+      quickMessages,
+    });
+
+    await flushPromises();
+    expect(wrapper.emitted('load-more')).toBeFalsy();
+
+    await wrapper.setProps({ loadingMore: false });
+    await flushPromises();
+
+    expect(wrapper.emitted('load-more')).toBeTruthy();
+  });
+
+  it('emits load-more when hasMore becomes true after the first page loads', async () => {
+    const wrapper = createWrapper({
+      infiniteScroll: true,
+      hasMore: false,
+      quickMessages,
+    });
+
+    await flushPromises();
+    expect(wrapper.emitted('load-more')).toBeFalsy();
+
+    await wrapper.setProps({ hasMore: true });
+    await flushPromises();
+
+    expect(wrapper.emitted('load-more')).toBeTruthy();
+  });
+});

--- a/src/components/chats/QuickMessages/__tests__/QuickMessagesList.spec.js
+++ b/src/components/chats/QuickMessages/__tests__/QuickMessagesList.spec.js
@@ -93,21 +93,57 @@ describe('QuickMessagesList.vue', () => {
     expect(wrapper.emitted('load-more')).toBeFalsy();
   });
 
-  it('emits load-more again after loading completes while sentinel is visible', async () => {
+  it('does not emit load-more while loadingMore is true', async () => {
     const wrapper = createWrapper({
       infiniteScroll: true,
       hasMore: true,
-      loadingMore: true,
+      loadingMore: false,
       quickMessages,
     });
 
     await flushPromises();
-    expect(wrapper.emitted('load-more')).toBeFalsy();
+    expect(wrapper.emitted('load-more')).toBeTruthy();
+
+    const emitCountAfterFirstLoad = wrapper.emitted('load-more').length;
+
+    await wrapper.setProps({ loadingMore: true });
+    await flushPromises();
+
+    intersectionCallback?.([
+      {
+        isIntersecting: true,
+        target: wrapper.vm.$refs.infiniteScrollSentinel,
+      },
+    ]);
+    await flushPromises();
+
+    expect(wrapper.emitted('load-more').length).toBe(emitCountAfterFirstLoad);
+  });
+
+  it('emits load-more again after loading completes while sentinel is visible', async () => {
+    const wrapper = createWrapper({
+      infiniteScroll: true,
+      hasMore: true,
+      loadingMore: false,
+      quickMessages,
+    });
+
+    await flushPromises();
+    expect(wrapper.emitted('load-more')).toBeTruthy();
+
+    const emitCountAfterFirstLoad = wrapper.emitted('load-more').length;
+
+    await wrapper.setProps({ loadingMore: true });
+    await flushPromises();
+
+    expect(wrapper.emitted('load-more').length).toBe(emitCountAfterFirstLoad);
 
     await wrapper.setProps({ loadingMore: false });
     await flushPromises();
 
-    expect(wrapper.emitted('load-more')).toBeTruthy();
+    expect(wrapper.emitted('load-more').length).toBeGreaterThan(
+      emitCountAfterFirstLoad,
+    );
   });
 
   it('emits load-more when hasMore becomes true after the first page loads', async () => {


### PR DESCRIPTION
## Description
### Type of Change
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
The infinite scroll in `QuickMessagesList` was not working correctly when the list was rendered inside a scrollable container. The `IntersectionObserver` was using the viewport as its root, causing it to miss intersection events when the scroll root was a parent element. Additionally, the sentinel visibility was not being re-checked after a page load completed or when `hasMore` became available, leading to cases where additional pages were never fetched even though the sentinel was visible.

### Summary of Changes
- Introduced an `infiniteScrollReady` computed property that combines `infiniteScroll` and `withoutQuickMessages` to prevent setting up the observer before any messages exist.
- Added a `findScrollRoot` method that traverses the DOM to find the nearest scrollable ancestor, which is then passed as the `root` to `IntersectionObserver`, fixing detection inside nested scroll containers.
- Added a `checkSentinelVisibility` method that manually verifies whether the sentinel element is visible within its scroll container, with a 120px margin buffer.
- Added watchers for `loadingMore` and `hasMore` to re-check sentinel visibility after a page finishes loading or when more pages become available, ensuring continuous loading when the content does not yet fill the container.
- Added unit tests covering: deferred observer setup until messages are present, `load-more` emission on sentinel intersection, suppression when `hasMore` is false, re-emission after loading completes, and emission when `hasMore` transitions to true.