### PR TITLE
[ENGAGE-8349] feat: Add floating action buttons for message input actions

### DIFF
--- a/src/components/chats/MessageManagerV2/TextBox/FloatingActions.vue
+++ b/src/components/chats/MessageManagerV2/TextBox/FloatingActions.vue
@@ -87,7 +87,7 @@ const handleClearInputs = () => {
 
   border-radius: $unnnic-radius-2;
   border: 1px solid $unnnic-color-border-base;
-  background: $unnnic-color-bg-base-soft;
+  background: $unnnic-color-bg-base;
   box-shadow: $unnnic-shadow-1;
 
   position: absolute;

--- a/src/components/chats/MessageManagerV2/TextBox/FloatingActions.vue
+++ b/src/components/chats/MessageManagerV2/TextBox/FloatingActions.vue
@@ -1,0 +1,122 @@
+<template>
+  <Transition name="floating-actions">
+    <section
+      v-if="visible"
+      class="floating-actions"
+    >
+      <UnnnicToolTip
+        enabled
+        side="top"
+        :text="$t('chats.message_input_floating_actions.copy')"
+      >
+        <UnnnicIconSvg
+          icon="content_copy"
+          size="ant"
+          scheme="fg-base"
+          clickable
+          data-testid="floating-actions-copy"
+          @click="handleCopyInputMessageToClipboard"
+        />
+      </UnnnicToolTip>
+      <UnnnicToolTip
+        enabled
+        side="top"
+        :text="$t('chats.message_input_floating_actions.clear')"
+      >
+        <UnnnicIconSvg
+          icon="close"
+          size="ant"
+          scheme="fg-critical"
+          clickable
+          data-testid="floating-actions-clear"
+          @click="handleClearInputs"
+        />
+      </UnnnicToolTip>
+    </section>
+  </Transition>
+</template>
+
+<script setup lang="ts">
+import { useMessageManager } from '@/store/modules/chats/messageManager';
+import { UnnnicCallAlert } from '@weni/unnnic-system';
+
+import i18n from '@/plugins/i18n';
+
+const { t } = i18n.global;
+
+defineOptions({
+  name: 'MessageManagerTextBoxFloatingActions',
+});
+
+defineProps({
+  visible: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const { clearInputs, copyInputMessageToClipboard } = useMessageManager();
+
+const handleCopyInputMessageToClipboard = () => {
+  copyInputMessageToClipboard();
+  UnnnicCallAlert({
+    props: {
+      text: t('chats.message_input_floating_actions.copy_alert_success'),
+      type: 'success',
+    },
+  });
+};
+
+const handleClearInputs = () => {
+  clearInputs();
+  UnnnicCallAlert({
+    props: {
+      type: 'success',
+      text: t('chats.message_input_floating_actions.clear_alert_success'),
+    },
+  });
+};
+</script>
+
+<style scoped lang="scss">
+.floating-actions {
+  display: flex;
+  align-items: center;
+  gap: $unnnic-space-4;
+  padding: $unnnic-space-2 $unnnic-space-4;
+
+  border-radius: $unnnic-radius-2;
+  border: 1px solid $unnnic-color-border-base;
+  background: $unnnic-color-bg-base-soft;
+  box-shadow: $unnnic-shadow-1;
+
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + $unnnic-space-2);
+  z-index: 1;
+}
+
+.floating-actions-enter-active {
+  transition:
+    transform 0.25s cubic-bezier(0, 0, 0.2, 1),
+    opacity 0.25s cubic-bezier(0, 0, 0.2, 1);
+}
+
+.floating-actions-leave-active {
+  transition:
+    transform 0.22s cubic-bezier(0.4, 0, 1, 1),
+    opacity 0.18s cubic-bezier(0.4, 0, 1, 1);
+  pointer-events: none;
+  will-change: transform, opacity;
+}
+
+.floating-actions-enter-from {
+  opacity: 0;
+  transform: translateY($unnnic-space-2);
+}
+
+.floating-actions-leave-to {
+  opacity: 0;
+  transform: translateY($unnnic-space-3);
+}
+</style>

--- a/src/components/chats/MessageManagerV2/TextBox/TextArea.vue
+++ b/src/components/chats/MessageManagerV2/TextBox/TextArea.vue
@@ -86,6 +86,7 @@ const {
   inputMessageFocused,
   isDisabledInput,
 } = storeToRefs(messageManager);
+
 const { addMediaUploadFiles, clearInputs } = messageManager;
 
 const aiTextImprovementStore = useAiTextImprovement();
@@ -216,83 +217,68 @@ defineExpose({
 </script>
 
 <style scoped lang="scss">
-.text-box__input-block {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: $unnnic-space-2;
-}
+.text-box {
+  &__input-block {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-2;
+  }
+  &__textarea-container {
+    width: 100%;
+    display: flex;
+    gap: $unnnic-space-1;
+  }
+  &__internal-note-medias {
+    width: 100%;
+  }
+  &__textarea {
+    flex: 1;
+    border: none;
+    resize: none;
+    overflow-y: hidden;
+    outline: none;
+    font: $unnnic-font-body;
+    max-height: 104px;
 
-.text-box__textarea-container {
-  width: 100%;
-  display: flex;
-  gap: $unnnic-space-1;
-}
+    background-color: transparent;
+    color: $unnnic-color-fg-emphasized;
+    caret-color: $unnnic-color-fg-emphasized;
 
-.text-box__internal-note-medias {
-  width: 100%;
-}
+    &::placeholder {
+      color: $unnnic-color-fg-muted;
+    }
 
-.text-box__textarea {
-  flex: 1;
-  border: none;
-  resize: none;
-  overflow-y: hidden;
-  outline: none;
-  font: $unnnic-font-body;
-  max-height: 104px;
-
-  background-color: transparent;
-  color: $unnnic-color-fg-emphasized;
-  caret-color: $unnnic-color-fg-emphasized;
-
-  &::placeholder {
+    &.internal-note {
+      color: $unnnic-color-fg-base;
+      caret-color: $unnnic-color-fg-base;
+    }
+  }
+  &__ai-loading-text {
+    font: $unnnic-font-body;
     color: $unnnic-color-fg-muted;
   }
-
-  &.internal-note {
-    color: $unnnic-color-fg-base;
-    caret-color: $unnnic-color-fg-base;
+  &__ai-loading-dots {
+    display: inline-flex;
+    align-items: flex-end;
+    gap: 3px;
+    margin-left: $unnnic-space-1;
+    padding-bottom: $unnnic-space-1;
   }
-}
+  &__ai-loading-dot {
+    display: inline-block;
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background-color: $unnnic-color-fg-muted;
+    animation: dot-jump 1.4s ease-in-out infinite;
 
-.text-box__ai-loading-text {
-  font: $unnnic-font-body;
-  color: $unnnic-color-fg-muted;
-}
-
-.text-box__ai-loading-dots {
-  display: inline-flex;
-  align-items: flex-end;
-  gap: 3px;
-  margin-left: $unnnic-space-1;
-  padding-bottom: $unnnic-space-1;
-}
-
-.text-box__ai-loading-dot {
-  display: inline-block;
-  width: 5px;
-  height: 5px;
-  border-radius: 50%;
-  background-color: $unnnic-color-fg-muted;
-  animation: dot-jump 1.4s ease-in-out infinite;
-
-  &:nth-child(2) {
-    animation-delay: 0.16s;
-  }
-  &:nth-child(3) {
-    animation-delay: 0.32s;
-  }
-}
-
-@keyframes dot-jump {
-  0%,
-  60%,
-  100% {
-    transform: translateY(0);
-  }
-  30% {
-    transform: translateY(-6px);
+    &:nth-child(2) {
+      animation-delay: 0.16s;
+    }
+    &:nth-child(3) {
+      animation-delay: 0.32s;
+    }
   }
 }
 
@@ -316,6 +302,17 @@ defineExpose({
     margin-right: $unnnic-spacing-ant;
     justify-self: end;
     padding: $unnnic-space-05 $unnnic-spacing-nano;
+  }
+}
+
+@keyframes dot-jump {
+  0%,
+  60%,
+  100% {
+    transform: translateY(0);
+  }
+  30% {
+    transform: translateY(-6px);
   }
 }
 </style>

--- a/src/components/chats/MessageManagerV2/TextBox/__tests__/TextBox.spec.js
+++ b/src/components/chats/MessageManagerV2/TextBox/__tests__/TextBox.spec.js
@@ -183,17 +183,21 @@ describe('TextBox (index.vue)', () => {
       );
     });
 
-    it('should show textarea-row wrapper when BackToOriginal is visible', () => {
+    it('should show textarea wrapper with back modifier when BackToOriginal is visible', () => {
       const wrapper = createWrapper({
         improvedText: 'improved',
         originalText: 'original',
       });
-      expect(wrapper.find('.text-box__textarea-row').exists()).toBe(true);
+      expect(
+        wrapper.find('.text-box__textarea-wrapper--with-back').exists(),
+      ).toBe(true);
     });
 
-    it('should not show textarea-row wrapper when BackToOriginal is hidden', () => {
+    it('should not show textarea wrapper with back modifier when BackToOriginal is hidden', () => {
       const wrapper = createWrapper({ improvedText: '' });
-      expect(wrapper.find('.text-box__textarea-row').exists()).toBe(false);
+      expect(
+        wrapper.find('.text-box__textarea-wrapper--with-back').exists(),
+      ).toBe(false);
     });
   });
 

--- a/src/components/chats/MessageManagerV2/TextBox/index.vue
+++ b/src/components/chats/MessageManagerV2/TextBox/index.vue
@@ -11,20 +11,20 @@
     ]"
   >
     <section
-      v-if="showBackToOriginal"
-      class="text-box__textarea-row"
+      :class="[
+        'text-box__textarea-wrapper',
+        { 'text-box__textarea-wrapper--with-back': showBackToOriginal },
+      ]"
     >
       <MessageManagerTextBoxTextArea
         ref="textArea"
         @keydown="handleKeyDown"
       />
-      <BackToOriginal @reverted="focus" />
+      <BackToOriginal
+        v-if="showBackToOriginal"
+        @reverted="focus"
+      />
     </section>
-    <MessageManagerTextBoxTextArea
-      v-else
-      ref="textArea"
-      @keydown="handleKeyDown"
-    />
     <MessageManagerTextBoxUploadField ref="uploadField" />
     <MessageManagerTextBoxAudioRecorder ref="audioRecorder" />
     <MessageManagerTextBoxMedias
@@ -194,11 +194,20 @@ defineExpose({
     background-color: $unnnic-color-bg-warning;
     border-color: $unnnic-color-border-warning;
   }
-  &__textarea-row {
-    display: flex;
-    align-items: stretch;
-    gap: $unnnic-space-2;
+
+  &__textarea-wrapper {
     width: 100%;
+
+    &--with-back {
+      display: flex;
+      align-items: stretch;
+      gap: $unnnic-space-2;
+
+      > :first-child {
+        flex: 1;
+        min-width: 0;
+      }
+    }
   }
 
   &__divider {

--- a/src/components/chats/MessageManagerV2/index.vue
+++ b/src/components/chats/MessageManagerV2/index.vue
@@ -7,11 +7,16 @@
       type="informational"
     />
     <MessageManagerLoading v-if="isLoading" />
-    <MessageManagerTextBox
+    <section
       v-else
-      ref="messageManagerTextBox"
-      @keydown="onKeyDown"
-    />
+      class="message-manager-v2__input-area"
+    >
+      <FloatingActions :visible="showFloatingActions" />
+      <MessageManagerTextBox
+        ref="messageManagerTextBox"
+        @keydown="onKeyDown"
+      />
+    </section>
     <SuggestionBox
       v-if="!activeDiscussion?.uuid"
       :search="inputMessage"
@@ -30,11 +35,12 @@
 </template>
 
 <script setup lang="ts">
-import { nextTick, onMounted, ref, useTemplateRef, watch } from 'vue';
+import { computed, nextTick, onMounted, ref, useTemplateRef, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 
 import MessageManagerLoading from './MessageManagerLoading.vue';
 import MessageManagerTextBox from './TextBox/index.vue';
+import FloatingActions from './TextBox/FloatingActions.vue';
 import SuggestionBox from './SuggestionBox/index.vue';
 import CoPilot from './CoPilot.vue';
 
@@ -78,6 +84,12 @@ const {
 
 const keyboardEvent = ref<KeyboardEvent | null>(null);
 const messageManagerTextBoxRef = useTemplateRef('messageManagerTextBox');
+
+const showFloatingActions = computed(() => {
+  const validInput =
+    inputMessage.value.trim() !== '' && !inputMessage.value.startsWith('/');
+  return !isInternalNote.value && validInput && !isDisabledInput.value;
+});
 
 const suggestionBoxIgnoreClickOutside = [messageManagerTextBoxRef];
 
@@ -161,5 +173,10 @@ onMounted(() => {
   gap: $unnnic-space-2;
   margin-right: $unnnic-space-2;
   align-items: end;
+
+  &__input-area {
+    position: relative;
+    width: 100%;
+  }
 }
 </style>

--- a/src/components/chats/chat/ChatMessages/index.vue
+++ b/src/components/chats/chat/ChatMessages/index.vue
@@ -394,7 +394,7 @@ export default {
     }),
     ...mapState(useDashboard, ['viewedAgent']),
     ...mapState(useRoomMessages, ['roomMessagesNext']),
-    ...mapWritableState(useMessageManager, ['replyMessage']),
+    ...mapWritableState(useMessageManager, ['replyMessage', 'inputMessage']),
     ...mapWritableState(useRoomMessages, [
       'toScrollNote',
       'toScrollMessage',
@@ -416,6 +416,11 @@ export default {
     unreadMessages() {
       if (!this.room) return 0;
       return this.newMessagesByRoom[this.room.uuid]?.messages?.length || 0;
+    },
+    scrollToBottomButtonPosition() {
+      return this.inputMessage.length > 0
+        ? '64px' // unnnic-space-16
+        : '24px'; // unnnic-space-6
     },
   },
 
@@ -878,9 +883,11 @@ export default {
 .chat-messages__scroll-button {
   &-container {
     position: absolute;
-    bottom: $unnnic-space-6;
-    right: $unnnic-space-4;
+    bottom: v-bind(scrollToBottomButtonPosition);
+    right: $unnnic-space-2;
     z-index: 9;
+    box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.25); // token don't exist
+    border-radius: $unnnic-radius-2;
   }
   &-chip {
     padding: 0 $unnnic-space-2;

--- a/src/components/chats/chat/ChatMessages/index.vue
+++ b/src/components/chats/chat/ChatMessages/index.vue
@@ -888,6 +888,7 @@ export default {
     z-index: 9;
     box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.25); // token don't exist
     border-radius: $unnnic-radius-2;
+    background-color: $unnnic-color-bg-base;
   }
   &-chip {
     padding: 0 $unnnic-space-2;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -503,6 +503,12 @@
     },
     "message_input_placeholder": "Type your message or / to activate quick messages",
     "message_input_disabled_description": "Change your status to online to continue this conversation",
+    "message_input_floating_actions": {
+      "copy": "Copy typed content",
+      "copy_alert_success": "Content copied!",
+      "clear": "Clear typed content",
+      "clear_alert_success": "Typed content removed!"
+    },
     "search_contact": "Search contact",
     "search_contact_placeholder": "Search contact (name, phone or ticket ID)",
     "tags": "Chat tags",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -506,6 +506,12 @@
     },
     "message_input_placeholder": "Escribe tu mensaje o / para activar mensajes rápidos",
     "message_input_disabled_description": "Cambia tu status a online para continuar esta conversación",
+    "message_input_floating_actions": {
+      "copy": "Copiar contenido escrito",
+      "copy_alert_success": "Contenido copiado!",
+      "clear": "Limpiar contenido escrito",
+      "clear_alert_success": "Contenido eliminado!"
+    },
     "search_contact": "Buscar contacto",
     "search_contact_placeholder": "Buscar contacto (nombre, teléfono o ticket ID)",
     "tags": "Etiquetas de chat",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -506,6 +506,12 @@
     },
     "message_input_placeholder": "Digite sua mensagem aqui ou / para ativar mensagens rápidas",
     "message_input_disabled_description": "Altere seu status para online para continuar esta conversa",
+    "message_input_floating_actions": {
+      "copy": "Copiar conteúdo digitado",
+      "copy_alert_success": "Conteúdo copiado!",
+      "clear": "Limpar conteúdo digitado",
+      "clear_alert_success": "Conteúdo removido!"
+    },
     "search_contact": "Pesquisar contato",
     "search_contact_placeholder": "Pesquisar contato (nome, telefone ou protocolo)",
     "tags": "Tags do chat",

--- a/src/store/modules/chats/messageManager.ts
+++ b/src/store/modules/chats/messageManager.ts
@@ -53,6 +53,11 @@ export const useMessageManager = defineStore('messageManager', () => {
     },
   );
 
+  function copyInputMessageToClipboard() {
+    if (!inputMessage.value) return;
+    navigator.clipboard.writeText(inputMessage.value);
+  }
+
   function clearInputs() {
     inputMessage.value = '';
     audioMessage.value = null;
@@ -236,5 +241,6 @@ export const useMessageManager = defineStore('messageManager', () => {
     sendMediasMessage,
     addMediaUploadFiles,
     clearInputs,
+    copyInputMessageToClipboard,
   };
 });


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Summary of Changes
<!--- Describe your changes in detail -->
- Introduced a new FloatingActions component to provide options for copying and clearing typed content.
- Updated MessageManagerV2 to include the FloatingActions component, which appears based on input validity.
- Enhanced localization files to support new floating action messages in English, Spanish, and Portuguese.
- Refactored related components and styles for improved layout and functionality.

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File 1](https://www.figma.com/design/IAXGYmgDyjLzHavOtX0ram/Live-Desk----General-improvements--2026-?node-id=1669-14303&m=dev)

### Demonstration <!--- (If not appropriate, remove this topic) -->
<!--- Include a screenshot or video showcasing a feature or fix implemented in this pull request. -->
<img width="785" height="185" alt="image" src="https://github.com/user-attachments/assets/5bf69864-2cda-4383-a4b8-04c970debb89" />
