### PR TITLE
[ENGAGE-8367] fix: update project config state after saving settings

### DIFF
--- a/src/views/Settings/SettingsProjectOptions/index.vue
+++ b/src/views/Settings/SettingsProjectOptions/index.vue
@@ -71,7 +71,7 @@
 </template>
 
 <script>
-import { mapState } from 'pinia';
+import { mapState, mapWritableState } from 'pinia';
 
 import { useConfig } from '@/store/modules/config';
 import { useProfile } from '@/store/modules/profile';
@@ -120,11 +120,8 @@ export default {
   },
 
   computed: {
-    ...mapState(useConfig, [
-      'project',
-      'isSecondaryProject',
-      'isMainGroupsProject',
-    ]),
+    ...mapWritableState(useConfig, ['project']),
+    ...mapState(useConfig, ['isSecondaryProject', 'isMainGroupsProject']),
     ...mapState(useProfile, ['me']),
     ...mapState(useFeatureFlag, ['featureFlags']),
 
@@ -394,7 +391,7 @@ export default {
         restrict_offline_agents,
       } = this.projectConfig;
 
-      Project.update({
+      await Project.update({
         can_use_bulk_transfer,
         filter_offline_agents,
         can_use_bulk_close,
@@ -406,6 +403,11 @@ export default {
         can_use_name_sector_in_rooms,
         restrict_offline_agents,
       });
+
+      this.project.config = {
+        ...this.project.config,
+        ...this.projectConfig,
+      };
     },
   },
 };


### PR DESCRIPTION
## Description

### Type of Change

<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->

- [x]  Bugfix
- [ ]  Feature
- [ ]  Code style update (formatting, local variables)
- [ ]  Refactoring (no functional changes, no api changes)
- [ ]  Tests
- [ ]  Other

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

General settings were not persistent when switching tabs on the configuration screen.

### Summary of Changes

<!--- Describe your changes in detail -->

- Replaced mapState with mapWritableState for the 'project' property in SettingsProjectOptions component.
- Improved project configuration update logic to merge new settings with existing configuration.