### PR TITLE
Apply LOC-23756 localization review fixes

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -884,7 +884,7 @@
   "photo_or_video": "Photo or video",
   "send_docs": "Send doc | Send doc | Send docs",
   "doc": "Doc",
-  "send_images": "Send image | Send image | Send images",
+  "send_images": "Send image | Send images",
   "quick_message": "Quick messages",
   "flows": "Flows",
   "flows_trigger": {
@@ -973,7 +973,7 @@
     "no_suggestions": "No results found for the entered shortcut.",
     "disclaimer": "Type the shortcut / (slash) in the chat message field to activate the display of quick messages."
   },
-  "discard": "Delete",
+  "discard": "Discard",
   "on_boarding": {
     "title": "Getting started with Live desk",
     "title_sector": "Configure your support team!",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -724,7 +724,7 @@
     "queue_transfer_success": "Contact successfully transferred to queue {queue} | Contacts successfully transferred to queue {queue}",
     "error": "It was not possible to transfer the contacts, try again",
     "disclaimer": {
-      "transfer_to_other_sector": "When transferring the chat to a queue in another sector, the added tags will be removed.",
+      "transfer_to_other_sector": "When transferring the chat to a queue in another department, tags will be removed.",
       "selected_agent_offline": "The selected agent is offline at the moment",
       "without_online_agents": "No online agent at the moment"
     }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -547,8 +547,8 @@
         "description": "Tu chat con {contact} fue transferido por un moderador a la cola {queue}"
       }
     },
-    "your_chat_assumed": "Chat asignado a otro representante",
-    "your_chat_assumed_description": "Tu chat con {contact} se ha asignado a {representative}",
+    "your_chat_assumed": "Este chat se lo ha asignado otro representante",
+    "your_chat_assumed_description": "El chat con {contact} se lo ha asignado {representative}",
     "closed_chats": {
       "contact_history": "Historial del contacto",
       "general_history": "Historial general",
@@ -710,7 +710,7 @@
   "contact_transferred_to_queue": "Contacto transferido a la cola {queue}",
   "contact_transferred_error": "No se pudieron transferir los contactos",
   "contact_transferred_to_agent": "Contacto transferido al agente {agent}",
-  "agent_took_from_queue": "{agent} tomó de la cola {queue}",
+  "agent_took_from_queue": "{agent} se lo asignó de la cola {queue}",
   "contact_in_queue": "Contacto en la cola",
   "chat_closed_by": {
     "agent": "Chat cerrado por el agente"
@@ -727,7 +727,7 @@
     "queue_transfer_success": "Contacto transferido con éxito a la cola {queue} | Contactos transferidos con éxito a la cola {queue}",
     "error": "No fue posible transferir los contactos, intente nuevamente",
     "disclaimer": {
-      "transfer_to_other_sector": "Al transferir el chat a una cola en otro sector, las etiquetas agregadas se eliminarán.",
+      "transfer_to_other_sector": "Al transferir el chat a una cola de otro departamento las tags serán eliminadas.",
       "selected_agent_offline": "El agente seleccionado está actualmente desconectado",
       "without_online_agents": "No hay agentes en línea en este momento"
     }
@@ -844,7 +844,7 @@
     "speed": "Velocidad"
   },
   "media": "Multimedia",
-  "medias": "Multimedias",
+  "medias": "Contenidos multimedia",
   "audio": "Audio",
   "audios": "Audios",
   "docs": "Documentos",
@@ -887,7 +887,7 @@
   "photo_or_video": "Foto o vídeo",
   "send_docs": "Enviar documento | Enviar documento | Enviar documentos",
   "doc": "Documento",
-  "send_images": "Enviar imagen | Enviar imagen | Enviar imágenes",
+  "send_images": "Enviar imagen | Enviar imágenes",
   "quick_message": "Mensajes rápidos",
   "flows": "Flujos",
   "flows_trigger": {
@@ -895,7 +895,7 @@
     "triggered_flows": {
       "title": "Flujos activados",
       "single": "Flujo activado",
-      "trigger_time": "Tiempo de activación"
+      "trigger_time": "Hora del disparo"
     },
     "groups": "Grupos ({length})",
     "group_contacts": "{n} contacto | {n} contactos",
@@ -1249,7 +1249,7 @@
         "input": {
           "label": "Definir el límite de chats simultáneos",
           "tooltip": "Un límite definido para un representante específico reemplaza el límite a nivel de sector",
-          "helper": "Con 0, los representantes toman los chats de la cola",
+          "helper": "Define 0 para que los representantes puedan asignarse chats de la cola",
           "placeholder": "Ejemplo: 4"
         }
       },
@@ -1265,7 +1265,7 @@
           "switch_helper": "Un límite definido para un representante concreto reemplaza el límite a nivel de sector",
           "input_label": "Número de chats simultáneos",
           "input_placeholder": "Ej.: 4",
-          "input_helper": "Con 0, el representante toma los chats de la cola"
+          "input_helper": "Define 0 para que el representante pueda asignarse chats de la cola"
         },
         "sector_queues_checkbox": {
           "title": "Sectores y colas",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -183,7 +183,7 @@
   "live": "Ao Vivo",
   "number_chats": "Quantidade de chats",
   "language": "Idioma",
-  "search": "Pesquisar",
+  "search": "Buscar",
   "try_again": "Tentar novamente",
   "date_format_variable": "{day}/{month}/{year}",
   "undo": "Desfazer",
@@ -727,7 +727,7 @@
     "queue_transfer_success": "Contato transferido com sucesso para fila {queue} | Contatos transferidos com sucesso para fila {queue}",
     "error": "Não foi possível transferir os contatos, tente novamente",
     "disclaimer": {
-      "transfer_to_other_sector": "Ao transferir o chat para uma fila em outro setor, as etiquetas adicionadas serão removidas.",
+      "transfer_to_other_sector": "Ao transferir o chat para uma fila de outro setor, as tags serão removidas.",
       "selected_agent_offline": "O agente selecionado está offline no momento",
       "without_online_agents": "Nenhum agente online no momento"
     }

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -1,5 +1,6 @@
 {
   "internal_note_with_attachment_tooltip": "Notă internă cu atașament",
+  "close_internal_note": "Închide nota internă (Esc)",
   "view_options": {
     "new_badge": "Nou"
   },
@@ -32,6 +33,7 @@
     "back_to_original_tooltip": "Revenire la versiunea originală (Ctrl+Z)"
   },
   "chats": {
+    "message_input_placeholder": "Scrie mesajul tău sau / pentru a activa mesajele rapide",
     "message_input_disabled_description": "Schimbă-ți statusul în online pentru a continua această conversație",
     "chat_take_over": {
       "by_another_representative": {


### PR DESCRIPTION
## Summary
- Replaces the stale approach in #935 with value-only translation updates on current `main` keys
- Applies agreed fixes and PR review feedback
- Updates EN source strings (`send_images`, `discard`) plus PT/ES translations where they still differed from main