### PR TITLE
fix: Update audio download logic to use media UUID for improved error handling

### DIFF
--- a/src/components/chats/chat/ChatMessages/ChatMessageAudio/ChatMessageAudio.vue
+++ b/src/components/chats/chat/ChatMessages/ChatMessageAudio/ChatMessageAudio.vue
@@ -190,9 +190,11 @@ const canShowAudioDownloadAction = computed(() => {
 
 const handleDownload = async () => {
   try {
-    const url = messageMedia.value.url || messageMedia.value.preview;
-    const filename = url?.split('/').at(-1) || 'audio';
-    await Media.download({ media: url, name: filename });
+    const mediaUuid = messageMedia.value.uuid;
+    if (!mediaUuid) {
+      throw new Error('Media uuid not available');
+    }
+    await Media.download({ mediaUuid });
   } catch (error) {
     console.error('Error downloading audio', error);
     UnnnicCallAlert({

--- a/src/components/chats/chat/ChatMessages/ChatMessageAudio/ChatMessageAudio.vue
+++ b/src/components/chats/chat/ChatMessages/ChatMessageAudio/ChatMessageAudio.vue
@@ -188,18 +188,27 @@ const canShowAudioDownloadAction = computed(() => {
   return isContactMessage.value;
 });
 
+const showDownloadErrorAlert = () => {
+  UnnnicCallAlert({
+    props: {
+      text: i18n.global.t('chats.audio_download.error'),
+      type: 'error',
+    },
+    seconds: 5,
+  });
+};
+
 const handleDownload = async () => {
+  if (!props.message.uuid) {
+    showDownloadErrorAlert();
+    return;
+  }
+
   try {
     await Media.download({ messageUuid: props.message.uuid });
   } catch (error) {
     console.error('Error downloading audio', error);
-    UnnnicCallAlert({
-      props: {
-        text: i18n.global.t('chats.audio_download.error'),
-        type: 'error',
-      },
-      seconds: 5,
-    });
+    showDownloadErrorAlert();
   }
 };
 

--- a/src/components/chats/chat/ChatMessages/ChatMessageAudio/ChatMessageAudio.vue
+++ b/src/components/chats/chat/ChatMessages/ChatMessageAudio/ChatMessageAudio.vue
@@ -190,11 +190,7 @@ const canShowAudioDownloadAction = computed(() => {
 
 const handleDownload = async () => {
   try {
-    const mediaUuid = messageMedia.value.uuid;
-    if (!mediaUuid) {
-      throw new Error('Media uuid not available');
-    }
-    await Media.download({ mediaUuid });
+    await Media.download({ messageUuid: props.message.uuid });
   } catch (error) {
     console.error('Error downloading audio', error);
     UnnnicCallAlert({

--- a/src/components/chats/chat/ChatMessages/ChatMessageAudio/__tests__/ChatMessageAudio.spec.js
+++ b/src/components/chats/chat/ChatMessages/ChatMessageAudio/__tests__/ChatMessageAudio.spec.js
@@ -365,6 +365,19 @@ describe('ChatMessageAudio', () => {
       });
     });
 
+    it('shows error alert when message uuid is missing', async () => {
+      const message = createMessage({ uuid: undefined });
+      wrapper = mountComponent({ message });
+      await wrapper.find('[data-testid="download-button"]').trigger('click');
+      await flushPromises();
+      expect(Media.download).not.toHaveBeenCalled();
+      expect(UnnnicCallAlert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          props: expect.objectContaining({ type: 'error' }),
+        }),
+      );
+    });
+
     it('shows error alert when download fails', async () => {
       Media.download.mockRejectedValue(new Error('Download failed'));
       const consoleSpy = vi

--- a/src/components/chats/chat/ChatMessages/ChatMessageAudio/__tests__/ChatMessageAudio.spec.js
+++ b/src/components/chats/chat/ChatMessages/ChatMessageAudio/__tests__/ChatMessageAudio.spec.js
@@ -69,7 +69,6 @@ const createMessage = (overrides = {}) => ({
   contact: { uuid: 'contact-123' },
   media: [
     {
-      uuid: 'media-uuid-456',
       url: 'https://example.com/audio.mp3',
       preview: null,
       transcription: null,
@@ -353,49 +352,17 @@ describe('ChatMessageAudio', () => {
       );
     });
 
-    it('calls Media.download with media uuid on click', async () => {
+    it('calls Media.download with message uuid on click', async () => {
       Media.download.mockResolvedValue();
       const message = createMessage({
-        media: [
-          {
-            uuid: '1ac10d1c-cd37-4d9d-85eb-6022b43c5995',
-            url: 'https://example.com/audio-file.mp3',
-            preview: null,
-            transcription: null,
-          },
-        ],
+        uuid: 'a6d5a50a-09dd-4a21-bfa7-e69e9509667d',
       });
       wrapper = mountComponent({ message });
       await wrapper.find('[data-testid="download-button"]').trigger('click');
       await flushPromises();
       expect(Media.download).toHaveBeenCalledWith({
-        mediaUuid: '1ac10d1c-cd37-4d9d-85eb-6022b43c5995',
+        messageUuid: 'a6d5a50a-09dd-4a21-bfa7-e69e9509667d',
       });
-    });
-
-    it('shows error alert when media uuid is missing', async () => {
-      const consoleSpy = vi
-        .spyOn(console, 'error')
-        .mockImplementation(() => {});
-      const message = createMessage({
-        media: [
-          {
-            url: 'https://example.com/audio-file.mp3',
-            preview: null,
-            transcription: null,
-          },
-        ],
-      });
-      wrapper = mountComponent({ message });
-      await wrapper.find('[data-testid="download-button"]').trigger('click');
-      await flushPromises();
-      expect(Media.download).not.toHaveBeenCalled();
-      expect(UnnnicCallAlert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          props: expect.objectContaining({ type: 'error' }),
-        }),
-      );
-      consoleSpy.mockRestore();
     });
 
     it('shows error alert when download fails', async () => {

--- a/src/components/chats/chat/ChatMessages/ChatMessageAudio/__tests__/ChatMessageAudio.spec.js
+++ b/src/components/chats/chat/ChatMessages/ChatMessageAudio/__tests__/ChatMessageAudio.spec.js
@@ -69,6 +69,7 @@ const createMessage = (overrides = {}) => ({
   contact: { uuid: 'contact-123' },
   media: [
     {
+      uuid: 'media-uuid-456',
       url: 'https://example.com/audio.mp3',
       preview: null,
       transcription: null,
@@ -352,8 +353,30 @@ describe('ChatMessageAudio', () => {
       );
     });
 
-    it('calls Media.download with correct params on click', async () => {
+    it('calls Media.download with media uuid on click', async () => {
       Media.download.mockResolvedValue();
+      const message = createMessage({
+        media: [
+          {
+            uuid: '1ac10d1c-cd37-4d9d-85eb-6022b43c5995',
+            url: 'https://example.com/audio-file.mp3',
+            preview: null,
+            transcription: null,
+          },
+        ],
+      });
+      wrapper = mountComponent({ message });
+      await wrapper.find('[data-testid="download-button"]').trigger('click');
+      await flushPromises();
+      expect(Media.download).toHaveBeenCalledWith({
+        mediaUuid: '1ac10d1c-cd37-4d9d-85eb-6022b43c5995',
+      });
+    });
+
+    it('shows error alert when media uuid is missing', async () => {
+      const consoleSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
       const message = createMessage({
         media: [
           {
@@ -366,30 +389,13 @@ describe('ChatMessageAudio', () => {
       wrapper = mountComponent({ message });
       await wrapper.find('[data-testid="download-button"]').trigger('click');
       await flushPromises();
-      expect(Media.download).toHaveBeenCalledWith({
-        media: 'https://example.com/audio-file.mp3',
-        name: 'audio-file.mp3',
-      });
-    });
-
-    it('uses preview as fallback when url is not available', async () => {
-      Media.download.mockResolvedValue();
-      const message = createMessage({
-        media: [
-          {
-            url: null,
-            preview: 'https://example.com/audio-preview.mp3',
-            transcription: null,
-          },
-        ],
-      });
-      wrapper = mountComponent({ message });
-      await wrapper.find('[data-testid="download-button"]').trigger('click');
-      await flushPromises();
-      expect(Media.download).toHaveBeenCalledWith({
-        media: 'https://example.com/audio-preview.mp3',
-        name: 'audio-preview.mp3',
-      });
+      expect(Media.download).not.toHaveBeenCalled();
+      expect(UnnnicCallAlert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          props: expect.objectContaining({ type: 'error' }),
+        }),
+      );
+      consoleSpy.mockRestore();
     });
 
     it('shows error alert when download fails', async () => {

--- a/src/services/api/resources/chats/__tests__/media.unit.spec.js
+++ b/src/services/api/resources/chats/__tests__/media.unit.spec.js
@@ -115,6 +115,59 @@ describe('Media service', () => {
   });
 
   describe('download', () => {
+    it('should download media via chats-engine proxy when mediaUuid is provided', async () => {
+      const mockBlob = new Blob(['audio data'], { type: 'audio/mpeg' });
+      const mediaUuid = '1ac10d1c-cd37-4d9d-85eb-6022b43c5995';
+      http.get.mockResolvedValue({
+        data: mockBlob,
+        headers: {
+          'content-disposition':
+            'attachment; filename="42311976-902a-40b3-9568-968f22390509.mp3"',
+        },
+      });
+
+      await mediaService.download({ mediaUuid });
+
+      expect(http.get).toHaveBeenCalledWith(`/media/${mediaUuid}/download/`, {
+        responseType: 'blob',
+      });
+      expect(mockCreateElement).toHaveBeenCalledWith('a');
+      expect(mockCreateObjectURL).toHaveBeenCalledWith(mockBlob);
+      expect(mockLink.download).toBe(
+        '42311976-902a-40b3-9568-968f22390509.mp3',
+      );
+      expect(mockClick).toHaveBeenCalled();
+      expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+      expect(mockAxiosInstance.get).not.toHaveBeenCalled();
+    });
+
+    it('should fallback to mediaUuid filename when Content-Disposition is missing', async () => {
+      const mockBlob = new Blob(['audio data'], { type: 'audio/mpeg' });
+      const mediaUuid = '1ac10d1c-cd37-4d9d-85eb-6022b43c5995';
+      http.get.mockResolvedValue({
+        data: mockBlob,
+        headers: {},
+      });
+
+      await mediaService.download({ mediaUuid });
+
+      expect(mockLink.download).toBe(`${mediaUuid}.mp3`);
+    });
+
+    it('should reject proxy download when chats-engine request fails', async () => {
+      const error = new Error('Bad Gateway');
+      http.get.mockRejectedValue(error);
+
+      await expect(
+        mediaService.download({
+          mediaUuid: '1ac10d1c-cd37-4d9d-85eb-6022b43c5995',
+        }),
+      ).rejects.toThrow('Bad Gateway');
+
+      expect(mockCreateElement).not.toHaveBeenCalled();
+      expect(mockClick).not.toHaveBeenCalled();
+    });
+
     it('should download a file with correct name and media URL', async () => {
       const mockBlob = new Blob(['file content'], { type: 'application/pdf' });
       const mockResponse = { data: mockBlob };

--- a/src/services/api/resources/chats/__tests__/media.unit.spec.js
+++ b/src/services/api/resources/chats/__tests__/media.unit.spec.js
@@ -115,9 +115,9 @@ describe('Media service', () => {
   });
 
   describe('download', () => {
-    it('should download media via chats-engine proxy when mediaUuid is provided', async () => {
+    it('should download audio via message proxy when messageUuid is provided', async () => {
       const mockBlob = new Blob(['audio data'], { type: 'audio/mpeg' });
-      const mediaUuid = '1ac10d1c-cd37-4d9d-85eb-6022b43c5995';
+      const messageUuid = 'a6d5a50a-09dd-4a21-bfa7-e69e9509667d';
       http.get.mockResolvedValue({
         data: mockBlob,
         headers: {
@@ -126,9 +126,9 @@ describe('Media service', () => {
         },
       });
 
-      await mediaService.download({ mediaUuid });
+      await mediaService.download({ messageUuid });
 
-      expect(http.get).toHaveBeenCalledWith(`/media/${mediaUuid}/download/`, {
+      expect(http.get).toHaveBeenCalledWith(`/msg/${messageUuid}/download/`, {
         responseType: 'blob',
       });
       expect(mockCreateElement).toHaveBeenCalledWith('a');
@@ -141,17 +141,35 @@ describe('Media service', () => {
       expect(mockAxiosInstance.get).not.toHaveBeenCalled();
     });
 
-    it('should fallback to mediaUuid filename when Content-Disposition is missing', async () => {
+    it('should fallback to messageUuid filename when Content-Disposition is missing', async () => {
       const mockBlob = new Blob(['audio data'], { type: 'audio/mpeg' });
-      const mediaUuid = '1ac10d1c-cd37-4d9d-85eb-6022b43c5995';
+      const messageUuid = 'a6d5a50a-09dd-4a21-bfa7-e69e9509667d';
       http.get.mockResolvedValue({
         data: mockBlob,
         headers: {},
       });
 
+      await mediaService.download({ messageUuid });
+
+      expect(mockLink.download).toBe(`${messageUuid}.mp3`);
+    });
+
+    it('should download media via legacy proxy when mediaUuid is provided', async () => {
+      const mockBlob = new Blob(['audio data'], { type: 'audio/mpeg' });
+      const mediaUuid = '1ac10d1c-cd37-4d9d-85eb-6022b43c5995';
+      http.get.mockResolvedValue({
+        data: mockBlob,
+        headers: {
+          'content-disposition': 'attachment; filename="audio.mp3"',
+        },
+      });
+
       await mediaService.download({ mediaUuid });
 
-      expect(mockLink.download).toBe(`${mediaUuid}.mp3`);
+      expect(http.get).toHaveBeenCalledWith(`/media/${mediaUuid}/download/`, {
+        responseType: 'blob',
+      });
+      expect(mockLink.download).toBe('audio.mp3');
     });
 
     it('should reject proxy download when chats-engine request fails', async () => {
@@ -160,7 +178,7 @@ describe('Media service', () => {
 
       await expect(
         mediaService.download({
-          mediaUuid: '1ac10d1c-cd37-4d9d-85eb-6022b43c5995',
+          messageUuid: 'a6d5a50a-09dd-4a21-bfa7-e69e9509667d',
         }),
       ).rejects.toThrow('Bad Gateway');
 

--- a/src/services/api/resources/chats/__tests__/media.unit.spec.js
+++ b/src/services/api/resources/chats/__tests__/media.unit.spec.js
@@ -132,58 +132,10 @@ describe('Media service', () => {
         responseType: 'blob',
       });
       expect(mockCreateElement).toHaveBeenCalledWith('a');
-      expect(mockCreateObjectURL).toHaveBeenCalledWith(mockBlob);
       expect(mockLink.download).toBe(
         '42311976-902a-40b3-9568-968f22390509.mp3',
       );
-      expect(mockClick).toHaveBeenCalled();
-      expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
       expect(mockAxiosInstance.get).not.toHaveBeenCalled();
-    });
-
-    it('should fallback to messageUuid filename when Content-Disposition is missing', async () => {
-      const mockBlob = new Blob(['audio data'], { type: 'audio/mpeg' });
-      const messageUuid = 'a6d5a50a-09dd-4a21-bfa7-e69e9509667d';
-      http.get.mockResolvedValue({
-        data: mockBlob,
-        headers: {},
-      });
-
-      await mediaService.download({ messageUuid });
-
-      expect(mockLink.download).toBe(`${messageUuid}.mp3`);
-    });
-
-    it('should download media via legacy proxy when mediaUuid is provided', async () => {
-      const mockBlob = new Blob(['audio data'], { type: 'audio/mpeg' });
-      const mediaUuid = '1ac10d1c-cd37-4d9d-85eb-6022b43c5995';
-      http.get.mockResolvedValue({
-        data: mockBlob,
-        headers: {
-          'content-disposition': 'attachment; filename="audio.mp3"',
-        },
-      });
-
-      await mediaService.download({ mediaUuid });
-
-      expect(http.get).toHaveBeenCalledWith(`/media/${mediaUuid}/download/`, {
-        responseType: 'blob',
-      });
-      expect(mockLink.download).toBe('audio.mp3');
-    });
-
-    it('should reject proxy download when chats-engine request fails', async () => {
-      const error = new Error('Bad Gateway');
-      http.get.mockRejectedValue(error);
-
-      await expect(
-        mediaService.download({
-          messageUuid: 'a6d5a50a-09dd-4a21-bfa7-e69e9509667d',
-        }),
-      ).rejects.toThrow('Bad Gateway');
-
-      expect(mockCreateElement).not.toHaveBeenCalled();
-      expect(mockClick).not.toHaveBeenCalled();
     });
 
     it('should download a file with correct name and media URL', async () => {

--- a/src/services/api/resources/chats/media.js
+++ b/src/services/api/resources/chats/media.js
@@ -6,6 +6,28 @@ import { normalizeS3MediaUrl } from '@/utils/medias';
 const client = axios.create();
 
 /**
+ * @param {string|null|undefined} header
+ * @returns {string|null}
+ */
+export function getFilenameFromContentDisposition(header) {
+  if (!header) return null;
+  const match = header.match(/filename="([^"]+)"/);
+  return match ? match[1] : null;
+}
+
+/**
+ * @param {Blob} blob
+ * @param {string} filename
+ */
+function triggerBrowserDownload(blob, filename) {
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(link.href);
+}
+
+/**
  * Extracts cursor from pagination URL
  * @param {string|null} url - The pagination URL
  * @returns {string|null} The cursor value or null
@@ -33,15 +55,22 @@ export default {
     return response.data;
   },
 
-  async download({ media, name }) {
+  async download({ mediaUuid, media, name }) {
+    if (mediaUuid) {
+      const response = await http.get(`/media/${mediaUuid}/download/`, {
+        responseType: 'blob',
+      });
+      const filename =
+        getFilenameFromContentDisposition(
+          response.headers['content-disposition'],
+        ) || `${mediaUuid}.mp3`;
+      triggerBrowserDownload(response.data, filename);
+      return;
+    }
+
     const url = normalizeS3MediaUrl(media);
     const file = await this.get(url);
-    const link = document.createElement('a');
-
-    link.href = URL.createObjectURL(file);
-    link.download = name;
-    link.click();
-    URL.revokeObjectURL(link.href);
+    triggerBrowserDownload(file, name);
   },
 
   async listFromContactAndRoom({

--- a/src/services/api/resources/chats/media.js
+++ b/src/services/api/resources/chats/media.js
@@ -55,7 +55,19 @@ export default {
     return response.data;
   },
 
-  async download({ mediaUuid, media, name }) {
+  async download({ messageUuid, mediaUuid, media, name }) {
+    if (messageUuid) {
+      const response = await http.get(`/msg/${messageUuid}/download/`, {
+        responseType: 'blob',
+      });
+      const filename =
+        getFilenameFromContentDisposition(
+          response.headers['content-disposition'],
+        ) || `${messageUuid}.mp3`;
+      triggerBrowserDownload(response.data, filename);
+      return;
+    }
+
     if (mediaUuid) {
       const response = await http.get(`/media/${mediaUuid}/download/`, {
         responseType: 'blob',


### PR DESCRIPTION
## Description
### Type of Change
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
Audio file downloads were relying on direct S3 URLs, which can be unreliable or inaccessible depending on permissions and URL availability. By routing downloads through the chats-engine proxy using the media UUID, downloads become more consistent and secure.

### Summary of Changes
- `ChatMessageAudio` now uses `messageMedia.value.uuid` to trigger downloads instead of constructing a download from the media URL or preview fallback. If the UUID is not available, an error alert is shown and the download is aborted.
- `Media.download` accepts a `mediaUuid` parameter that, when provided, fetches the file via the `/media/{uuid}/download/` endpoint with `responseType: 'blob'`. The filename is extracted from the `Content-Disposition` response header, falling back to `{mediaUuid}.mp3` if the header is absent.
- A `getFilenameFromContentDisposition` helper was extracted and exported to parse filenames from `Content-Disposition` headers.
- A `triggerBrowserDownload` helper was extracted to handle creating and clicking an anchor element for blob downloads, shared between the UUID-based and legacy URL-based download paths.
- Tests were updated to reflect the UUID-based download behavior, replacing the previous URL/preview fallback test with a test that verifies an error alert is shown when the media UUID is missing.