### PR TITLE
[ENGAGE-8661] feat: Increase maxLength for AI transfer textarea from 1000 to 2000

### DIFF
--- a/src/views/Settings/SettingsProjectOptions/AiTransferModal.vue
+++ b/src/views/Settings/SettingsProjectOptions/AiTransferModal.vue
@@ -18,7 +18,7 @@
           :placeholder="
             $t('config_chats.project_configs.ai_transfer.textarea_placeholder')
           "
-          :maxLength="1000"
+          :maxLength="2000"
           data-testid="ai-transfer-criteria-textarea"
         />
       </section>

--- a/src/views/Settings/SettingsProjectOptions/__tests__/SettingsProjectOptions.spec.js
+++ b/src/views/Settings/SettingsProjectOptions/__tests__/SettingsProjectOptions.spec.js
@@ -211,7 +211,7 @@ describe('SettingsProjectOptions.vue', () => {
         (item) => item.key === 'ai_transfer',
       );
       expect(aiItem.prompt).toBeDefined();
-      expect(aiItem.prompt.maxLength).toBe(1000);
+      expect(aiItem.prompt.maxLength).toBe(2000);
       expect(aiItem.onToggle).toBeTypeOf('function');
       expect(aiItem.onEdit).toBeTypeOf('function');
     });

--- a/src/views/Settings/SettingsProjectOptions/index.vue
+++ b/src/views/Settings/SettingsProjectOptions/index.vue
@@ -211,7 +211,7 @@ export default {
             placeholder: this.$t(
               'config_chats.project_configs.ai_transfer.textarea_placeholder',
             ),
-            maxLength: 1000,
+            maxLength: 2000,
           },
           onToggle: this.handleAiTransferToggle,
           onEdit: this.openAiTransferModal,


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [x] Other

### Summary of Changes
<!--- Describe your changes in detail -->
- Updated the maxLength property in the AI transfer configuration to allow for longer input.
- Adjusted corresponding unit test to reflect the new maxLength value.