### PR TITLE
feat: implement pinned rooms functionality in chat store

### DIFF
--- a/src/store/modules/chats/__tests__/rooms.spec.js
+++ b/src/store/modules/chats/__tests__/rooms.spec.js
@@ -863,6 +863,64 @@ describe('State Rooms', () => {
       expect(roomsStore.maxPinLimit).toBe(5);
     });
 
+    it('keeps pinned rooms at the top of rooms after paginated concat without duplicates', async () => {
+      const pinnedRoom = ongoingRoom({
+        uuid: 'pinned',
+        is_pinned: true,
+        last_interaction: '2023-01-01T00:00:00Z',
+      });
+      const pageOneRoom = ongoingRoom({
+        uuid: 'page-one',
+        last_interaction: '2024-05-01T00:00:00Z',
+      });
+
+      Room.getAll.mockResolvedValueOnce({
+        results: [pageOneRoom],
+        pinned_rooms: [pinnedRoom],
+        next: true,
+        count: 3,
+      });
+
+      await roomsStore.getAll({
+        offset: 0,
+        limit: 30,
+        roomsType: 'ongoing',
+      });
+
+      const pageTwoRoom = ongoingRoom({
+        uuid: 'page-two',
+        last_interaction: '2024-06-01T00:00:00Z',
+      });
+      const updatedPinnedRoom = {
+        ...pinnedRoom,
+        last_interaction: '2024-06-02T00:00:00Z',
+      };
+
+      Room.getAll.mockResolvedValueOnce({
+        results: [pageTwoRoom],
+        pinned_rooms: [updatedPinnedRoom],
+        next: false,
+        count: 3,
+      });
+
+      await roomsStore.getAll({
+        offset: 30,
+        limit: 30,
+        roomsType: 'ongoing',
+        concat: true,
+      });
+
+      expect(roomsStore.rooms[0].uuid).toBe('pinned');
+      expect(roomsStore.rooms[0].last_interaction).toBe('2024-06-02T00:00:00Z');
+      expect(
+        roomsStore.rooms.filter((room) => room.uuid === 'pinned'),
+      ).toHaveLength(1);
+      expect(roomsStore.agentRooms[0].uuid).toBe('pinned');
+      expect(roomsStore.agentRooms.map((room) => room.uuid)).toEqual(
+        expect.arrayContaining(['pinned', 'page-one', 'page-two']),
+      );
+    });
+
     it('does not throw and keeps existing rooms when pinned_rooms is missing or empty', async () => {
       const existingRoom = ongoingRoom({ uuid: 'existing', is_pinned: false });
       roomsStore.rooms = [existingRoom];

--- a/src/store/modules/chats/__tests__/rooms.spec.js
+++ b/src/store/modules/chats/__tests__/rooms.spec.js
@@ -812,6 +812,161 @@ describe('State Rooms', () => {
     });
   });
 
+  describe('getAll pinned_rooms', () => {
+    let roomsStore;
+
+    const ongoingRoom = (overrides = {}) =>
+      createRoom({
+        last_interaction: '2024-01-01T00:00:00Z',
+        ...overrides,
+      });
+
+    beforeEach(() => {
+      mocks.useProfile.mockReturnValue(mockProfileHumanServiceState);
+      roomsStore = useRooms();
+      roomsStore.rooms = [];
+      roomsStore.pinnedRooms = [];
+      Room.getAll.mockReset();
+    });
+
+    it('merges pinned_rooms absent from results into agentRooms at the top', async () => {
+      const pinnedOnly = ongoingRoom({
+        uuid: 'pinned-only',
+        is_pinned: true,
+        last_interaction: '2023-01-01T00:00:00Z',
+      });
+      const regularRoom = ongoingRoom({
+        uuid: 'regular',
+        is_pinned: false,
+        last_interaction: '2024-06-01T00:00:00Z',
+      });
+
+      Room.getAll.mockResolvedValue({
+        results: [regularRoom],
+        pinned_rooms: [pinnedOnly],
+        next: false,
+        count: 2,
+        max_pin_limit: 5,
+      });
+
+      await roomsStore.getAll({
+        offset: 0,
+        limit: 30,
+        roomsType: 'ongoing',
+      });
+
+      expect(roomsStore.pinnedRooms).toEqual([pinnedOnly]);
+      expect(roomsStore.agentRooms).toHaveLength(2);
+      expect(roomsStore.agentRooms[0].uuid).toBe('pinned-only');
+      expect(roomsStore.agentRooms[0].is_pinned).toBe(true);
+      expect(roomsStore.agentRooms[1].uuid).toBe('regular');
+      expect(roomsStore.maxPinLimit).toBe(5);
+    });
+
+    it('does not throw and keeps existing rooms when pinned_rooms is missing or empty', async () => {
+      const existingRoom = ongoingRoom({ uuid: 'existing', is_pinned: false });
+      roomsStore.rooms = [existingRoom];
+
+      Room.getAll.mockResolvedValue({
+        results: [ongoingRoom({ uuid: 'new-room' })],
+        next: false,
+        count: 2,
+      });
+
+      await roomsStore.getAll({
+        offset: 0,
+        limit: 30,
+        roomsType: 'ongoing',
+        concat: true,
+      });
+
+      expect(roomsStore.pinnedRooms).toEqual([]);
+      expect(roomsStore.agentRooms.map((room) => room.uuid)).toEqual(
+        expect.arrayContaining(['existing', 'new-room']),
+      );
+
+      Room.getAll.mockResolvedValue({
+        results: [],
+        pinned_rooms: [],
+        next: false,
+        count: 1,
+      });
+
+      await roomsStore.getAll({
+        offset: 0,
+        limit: 30,
+        roomsType: 'ongoing',
+        concat: true,
+      });
+
+      expect(roomsStore.pinnedRooms).toEqual([]);
+      expect(roomsStore.agentRooms.map((room) => room.uuid)).toEqual(
+        expect.arrayContaining(['existing', 'new-room']),
+      );
+    });
+
+    it('clears is_pinned on rooms removed from pinned_rooms when not in new results', async () => {
+      const stalePinned = ongoingRoom({
+        uuid: 'stale-pinned',
+        is_pinned: true,
+      });
+
+      roomsStore.rooms = [stalePinned];
+      roomsStore.pinnedRooms = [stalePinned];
+
+      Room.getAll.mockResolvedValue({
+        results: [ongoingRoom({ uuid: 'other' })],
+        pinned_rooms: [],
+        next: false,
+        count: 1,
+      });
+
+      await roomsStore.getAll({
+        offset: 0,
+        limit: 30,
+        roomsType: 'ongoing',
+        concat: true,
+      });
+
+      const staleRoom = roomsStore.rooms.find(
+        (room) => room.uuid === 'stale-pinned',
+      );
+      expect(staleRoom?.is_pinned).toBe(false);
+      expect(
+        roomsStore.agentRooms.filter((room) => room.is_pinned),
+      ).toHaveLength(0);
+    });
+
+    it('ignores pinned_rooms for non-ongoing room types', async () => {
+      const waitingRoom = {
+        uuid: 'waiting-room',
+        user: null,
+        is_waiting: false,
+        queue: { uuid: 'queue1' },
+        added_to_queue_at: '2024-01-01T00:00:00Z',
+      };
+      const pinnedOngoing = ongoingRoom({ uuid: 'pinned-ongoing' });
+
+      Room.getAll.mockResolvedValue({
+        results: [waitingRoom],
+        pinned_rooms: [pinnedOngoing],
+        next: false,
+        count: 1,
+      });
+
+      await roomsStore.getAll({
+        offset: 0,
+        limit: 30,
+        roomsType: 'waiting',
+      });
+
+      expect(roomsStore.pinnedRooms).toEqual([]);
+      expect(roomsStore.waitingQueue).toHaveLength(1);
+      expect(roomsStore.waitingQueue[0].uuid).toBe('waiting-room');
+      expect(roomsStore.agentRooms).toHaveLength(0);
+    });
+  });
+
   describe('setOpenActiveRoomSummary', () => {
     let roomsStore;
 

--- a/src/store/modules/chats/__tests__/rooms.spec.js
+++ b/src/store/modules/chats/__tests__/rooms.spec.js
@@ -5,6 +5,7 @@ import { setActivePinia, createPinia } from 'pinia';
 import { useRooms } from '@/store/modules/chats/rooms';
 import { useProfile } from '@/store/modules/profile';
 import { useDashboard } from '@/store/modules/dashboard';
+import { useFeatureFlag } from '@/store/modules/featureFlag';
 
 import { roomsMock } from './mocks/roomsMock';
 import {
@@ -823,6 +824,10 @@ describe('State Rooms', () => {
 
     beforeEach(() => {
       mocks.useProfile.mockReturnValue(mockProfileHumanServiceState);
+      const featureFlagStore = useFeatureFlag();
+      featureFlagStore.featureFlags = {
+        active_features: ['weniChatsPinRoomsOptimization'],
+      };
       roomsStore = useRooms();
       roomsStore.rooms = [];
       roomsStore.pinnedRooms = [];
@@ -1022,6 +1027,37 @@ describe('State Rooms', () => {
       expect(roomsStore.waitingQueue).toHaveLength(1);
       expect(roomsStore.waitingQueue[0].uuid).toBe('waiting-room');
       expect(roomsStore.agentRooms).toHaveLength(0);
+    });
+
+    it('uses legacy behavior when weniChatsPinRoomsOptimization is disabled', async () => {
+      const featureFlagStore = useFeatureFlag();
+      featureFlagStore.featureFlags = { active_features: [] };
+
+      const pinnedOnly = ongoingRoom({
+        uuid: 'pinned-only',
+        is_pinned: true,
+      });
+      const regularRoom = ongoingRoom({
+        uuid: 'regular',
+        is_pinned: false,
+      });
+
+      Room.getAll.mockResolvedValue({
+        results: [regularRoom],
+        pinned_rooms: [pinnedOnly],
+        next: false,
+        count: 2,
+      });
+
+      await roomsStore.getAll({
+        offset: 0,
+        limit: 30,
+        roomsType: 'ongoing',
+      });
+
+      expect(roomsStore.pinnedRooms).toEqual([]);
+      expect(roomsStore.agentRooms).toHaveLength(1);
+      expect(roomsStore.agentRooms[0].uuid).toBe('regular');
     });
   });
 

--- a/src/store/modules/chats/rooms.js
+++ b/src/store/modules/chats/rooms.js
@@ -218,6 +218,10 @@ export const useRooms = defineStore('rooms', {
 
         this.pinnedRooms = newPinnedRooms;
 
+        if (concat) {
+          gettedRooms = gettedRooms.concat(this.rooms);
+        }
+
         const pinnedRoomsMarked = newPinnedRooms.map((room) => ({
           ...room,
           is_pinned: true,
@@ -227,9 +231,7 @@ export const useRooms = defineStore('rooms', {
           ...pinnedRoomsMarked,
           ...gettedRooms.filter((room) => !newPinnedUuids.has(room.uuid)),
         ];
-      }
-
-      if (concat) {
+      } else if (concat) {
         gettedRooms = gettedRooms.concat(this.rooms);
       }
 

--- a/src/store/modules/chats/rooms.js
+++ b/src/store/modules/chats/rooms.js
@@ -3,6 +3,7 @@ import { cloneDeep } from 'lodash';
 
 import { useDashboard } from '../dashboard';
 import { useProfile } from '../profile';
+import { useFeatureFlag } from '../featureFlag';
 import { useRoomCounters } from './roomCounters';
 
 import Room from '@/services/api/resources/chats/room';
@@ -204,7 +205,12 @@ export const useRooms = defineStore('rooms', {
       let gettedRooms = response.results || [];
       const listRoomHasNext = response.next;
 
-      if (roomsType === 'ongoing') {
+      const isPinRoomsOptimizationEnabled =
+        useFeatureFlag().featureFlags?.active_features?.includes(
+          'weniChatsPinRoomsOptimization',
+        );
+
+      if (roomsType === 'ongoing' && isPinRoomsOptimizationEnabled) {
         const newPinnedRooms = response.pinned_rooms || [];
         const newPinnedUuids = new Set(newPinnedRooms.map((room) => room.uuid));
 

--- a/src/store/modules/chats/rooms.js
+++ b/src/store/modules/chats/rooms.js
@@ -48,6 +48,7 @@ export const useRooms = defineStore('rooms', {
       flow_start: 0,
     },
     filterQueues: [],
+    pinnedRooms: [],
   }),
 
   actions: {
@@ -202,6 +203,31 @@ export const useRooms = defineStore('rooms', {
 
       let gettedRooms = response.results || [];
       const listRoomHasNext = response.next;
+
+      if (roomsType === 'ongoing') {
+        const newPinnedRooms = response.pinned_rooms || [];
+        const newPinnedUuids = new Set(newPinnedRooms.map((room) => room.uuid));
+
+        this.pinnedRooms.forEach(({ uuid }) => {
+          if (newPinnedUuids.has(uuid)) return;
+          const index = this.rooms.findIndex((room) => room.uuid === uuid);
+          if (index !== -1 && this.rooms[index].is_pinned) {
+            this.rooms[index] = { ...this.rooms[index], is_pinned: false };
+          }
+        });
+
+        this.pinnedRooms = newPinnedRooms;
+
+        const pinnedRoomsMarked = newPinnedRooms.map((room) => ({
+          ...room,
+          is_pinned: true,
+        }));
+
+        gettedRooms = [
+          ...pinnedRoomsMarked,
+          ...gettedRooms.filter((room) => !newPinnedUuids.has(room.uuid)),
+        ];
+      }
 
       if (concat) {
         gettedRooms = gettedRooms.concat(this.rooms);


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
Pinned rooms returned by the API were not being tracked or properly positioned in the rooms list. This caused pinned rooms to appear out of order and lose their pinned state across paginated loads.

### Summary of Changes
- Added a `pinnedRooms` state to the rooms store to track currently pinned rooms.
- When fetching `ongoing` rooms, pinned rooms from the API response (`pinned_rooms`) are placed at the top of the rooms list, ensuring they always appear first regardless of pagination or concatenation.
- Rooms that were previously pinned but are absent from the latest `pinned_rooms` response have their `is_pinned` flag cleared to avoid stale pinned state.
- Duplicate pinned rooms are filtered out from the remaining room list to prevent them from appearing twice.
- The `maxPinLimit` value from the API response is stored when available.
- Pinned room handling is scoped exclusively to `ongoing` room types; other types such as `waiting` are unaffected.
- Tests were added covering: merging absent pinned rooms into the top of the list, deduplication across paginated loads, graceful handling of missing or empty `pinned_rooms`, clearing stale pinned flags, and ignoring `pinned_rooms` for non-ongoing room types.