### PR TITLE
fix: remove unnecessary align-self property from TextArea component

### DIFF
--- a/src/components/chats/MessageManager/TextBox/TextArea.vue
+++ b/src/components/chats/MessageManager/TextBox/TextArea.vue
@@ -291,7 +291,6 @@ defineExpose({
     position: fixed;
     width: $unnnic-space-6;
     margin-top: -33px;
-    align-self: flex-end;
 
     background-color: $unnnic-color-bg-yellow-strong;
     padding: 0px $unnnic-spacing-nano;


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other