### PR TITLE
style: update icon scheme in QuickMessageCard component

### DIFF
--- a/src/components/chats/QuickMessages/QuickMessageCard.vue
+++ b/src/components/chats/QuickMessages/QuickMessageCard.vue
@@ -31,7 +31,7 @@
             <UnnnicIconSvg
               icon="more_vert"
               size="sm"
-              scheme="neutral-darkest"
+              scheme="fg-base"
               @click="togglePopover"
             />
           </UnnnicPopoverTrigger>


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Code style update (formatting, local variables)
* * [ ] Feature
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The icon color scheme in the `QuickMessageCard` component was using an outdated token (`neutral-darkest`), which needed to be updated to align with the current design system token standards.

### Summary of Changes
The color scheme of the `more_vert` icon in `QuickMessageCard.vue` was updated from `neutral-darkest` to `fg-base` to reflect the correct design token.