### PR TITLE
fix: Enhance AI text improvement tooltips with internal note handlig and localization updates

### DIFF
--- a/src/components/chats/MessageManager/TextBox/AiTextImprovement.vue
+++ b/src/components/chats/MessageManager/TextBox/AiTextImprovement.vue
@@ -101,11 +101,14 @@ const isDisabled = computed(
   () => !inputMessage.value.trim() || isInternalNote.value,
 );
 
-const tooltipText = computed(() =>
-  isDisabled.value
+const tooltipText = computed(() => {
+  if (isInternalNote.value) {
+    return t('ai_text_improvement.tooltip_internal_note');
+  }
+  return isDisabled.value
     ? t('ai_text_improvement.tooltip_disabled')
-    : t('ai_text_improvement.tooltip_enabled'),
-);
+    : t('ai_text_improvement.tooltip_enabled');
+});
 
 const improvementOptions = computed(() => [
   {

--- a/src/components/chats/MessageManager/TextBox/__tests__/AiTextImprovement.spec.js
+++ b/src/components/chats/MessageManager/TextBox/__tests__/AiTextImprovement.spec.js
@@ -12,6 +12,7 @@ import { createPinia, setActivePinia } from 'pinia';
 
 import { useAiTextImprovement } from '@/store/modules/chats/aiTextImprovement';
 import { useMessageManager } from '@/store/modules/chats/messageManager';
+import { useConfig } from '@/store/modules/config';
 import i18n from '@/plugins/i18n';
 
 vi.mock('@/services/api/resources/chats/aiTextImprovement', () => ({
@@ -97,6 +98,8 @@ const createWrapper = (options = {}) => {
     isInternalNote = false,
     isLoading = false,
     showNewTag = true,
+    restrictOfflineAgents = false,
+    agentStatus = 'ONLINE',
   } = options;
 
   const pinia = createPinia();
@@ -109,6 +112,14 @@ const createWrapper = (options = {}) => {
   const msgStore = useMessageManager();
   msgStore.inputMessage = inputMessage;
   msgStore.isInternalNote = isInternalNote;
+
+  const configStore = useConfig();
+  configStore.project = {
+    name: '',
+    config: { restrict_offline_agents: restrictOfflineAgents },
+    uuid: '',
+  };
+  configStore.status = agentStatus;
 
   return mount(AiTextImprovement, {
     global: {
@@ -162,11 +173,27 @@ describe('AiTextImprovement', () => {
       expect(button.attributes('data-disabled')).toBe('true');
     });
 
-    it('should show disabled tooltip when isInternalNote is true and has text', () => {
+    it('should show internal note tooltip when isInternalNote is true and has text', () => {
       const wrapper = createWrapper({
         inputMessage: 'hello',
         isInternalNote: true,
       });
+
+      expect(wrapper.vm.tooltipText).toBe(
+        'ai_text_improvement.tooltip_internal_note',
+      );
+    });
+
+    it('should show enabled tooltip when inputMessage has text', () => {
+      const wrapper = createWrapper({ inputMessage: 'hello' });
+
+      expect(wrapper.vm.tooltipText).toBe(
+        'ai_text_improvement.tooltip_enabled',
+      );
+    });
+
+    it('should show disabled tooltip when inputMessage is empty', () => {
+      const wrapper = createWrapper({ inputMessage: '' });
 
       expect(wrapper.vm.tooltipText).toBe(
         'ai_text_improvement.tooltip_disabled',

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -676,6 +676,7 @@
     "tooltip_disabled": "Write a response in the text field to enable improved responses with AI",
     "tooltip_enabled": "Improve response with AI",
     "tooltip_cancel": "Cancel AI response improvement",
+    "tooltip_internal_note": "This feature is not available for internal notes",
     "fix_grammar_and_spelling": "Fix spelling and grammar",
     "make_more_empathetic": "Make more empathetic",
     "rewrite_for_clarity": "Rewrite for clarity",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -679,6 +679,7 @@
     "tooltip_disabled": "Escribe una respuesta en el campo de texto para activar respuestas mejoradas con IA",
     "tooltip_enabled": "Mejorar respuesta con IA",
     "tooltip_cancel": "Cancelar respuestas mejoradas con IA",
+    "tooltip_internal_note": "Esta función no está disponible para notas internas",
     "fix_grammar_and_spelling": "Corregir gramática y ortografía",
     "make_more_empathetic": "Hacerla más empática",
     "rewrite_for_clarity": "Reescribir con claridad",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -679,6 +679,7 @@
     "tooltip_disabled": "Escreva uma resposta no campo de texto para habilitar respostas aprimoradas com IA",
     "tooltip_enabled": "Melhorar resposta com IA",
     "tooltip_cancel": "Cancelar resposta aprimorada com IA",
+    "tooltip_internal_note": "Esta função não está disponível para notas internas",
     "fix_grammar_and_spelling": "Corrigir gramática e ortografia",
     "make_more_empathetic": "Tornar mais empática",
     "rewrite_for_clarity": "Reescrever com clareza",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -194,6 +194,7 @@
     "tooltip_disabled": "Scrie un răspuns în câmpul de text pentru a activa răspunsuri îmbunătățite cu AI",
     "tooltip_enabled": "Îmbunătățește răspunsul cu AI",
     "tooltip_cancel": "Anulează îmbunătățirea răspunsului cu AI",
+    "tooltip_internal_note": "Această funcționalitate nu este disponibilă pentru note interne",
     "fix_grammar_and_spelling": "Corectează ortografia și gramatica",
     "make_more_empathetic": "Fă-l mai empatic",
     "rewrite_for_clarity": "Rescrie pentru claritate",


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Summary of Changes
<!--- Describe your changes in detail -->

- Updated tooltip logic in AiTextImprovement.vue to display a specific message when the feature is disabled for internal notes.
- Added new translation strings for the internal note tooltip in English, Spanish, Portuguese, and Romanian locale files.
