### PR TITLE
fix: Add and update locale keys for settings, automated messages, and quick messages

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -329,7 +329,8 @@
       },
       "template_message": {
         "switch_active": "Trigger message templates",
-        "switch_disabled": "Trigger message templates"
+        "switch_disabled": "Trigger message templates",
+        "switch_label": "Triggering message templates"
       },
       "edit_custom_fields": {
         "label": "Allow representatives to edit custom fields",
@@ -338,7 +339,9 @@
       "agents_signature": {
         "tooltip": "Each message will display the name of the representative who answered",
         "switch_active": "Display the representative name in messages",
-        "switch_disabled": "Display the representative name in messages"
+        "switch_disabled": "Display the representative name in messages",
+        "hint": "Each message exchanged will have the name of the agent who is answering.",
+        "switch_label": "Use signature"
       },
       "csat": {
         "custom": {
@@ -349,6 +352,13 @@
         "confirm_modal": {
           "content_1": "If an active flow in the Flows module is configured to trigger a survey after support ends, this setting may conflict with that flow and affect survey delivery.",
           "content_2": "Do you want to continue anyway?"
+        },
+        "section_title": "Satisfaction survey",
+        "type": {
+          "custom": "Custom flows",
+          "default": "Default CSAT survey (recommended)",
+          "label": "Survey type",
+          "tooltip": "Choose between the default CSAT survey and a custom flow already configured in the Flows module."
         }
       },
       "automatic_message": {
@@ -363,7 +373,19 @@
       "required_tags": {
         "switch_active": "Require tag at the end of the support chat",
         "switch_disabled": "Require tag at the end of the support chat",
-        "tooltip": "Add at least one tag to activate"
+        "tooltip": "Add at least one tag to activate",
+        "switch_label": "Require tags at the end of human support"
+      },
+      "automated_message": {
+        "title": "Automated messages",
+        "switch_when_waiting_label": "Send automatic message to waiting contacts",
+        "switch_when_start_label": "Send automatic message when support starts",
+        "hint_when_waiting": "Automatically send a message to contacts while they wait for human support in the queue.",
+        "hint_when_start": "Automatically send a message when a chat is assigned to a representative. The message will appear as if sent by the assigned representative.",
+        "field": {
+          "title": "Automatic message",
+          "placeholder": "Example: Hello! How can I help you today?"
+        }
       }
     }
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -232,7 +232,7 @@
   "without_chats": {
     "in_progress": "All set! You'll be notified when new chats are assigned, and they'll appear in this list.",
     "waiting": "Queue cleared! All contacts are now assigned to representatives.",
-        "filtered": "No chats {roomType} in the filtered queues. Remove the filter to see all chats."
+    "filtered": "No chats {roomType} in the filtered queues. Remove the filter to see all chats."
   },
   "other": "Other",
   "select_smart": {
@@ -331,7 +331,7 @@
         "switch_active": "Trigger message templates",
         "switch_disabled": "Trigger message templates"
       },
-            "edit_custom_fields": {
+      "edit_custom_fields": {
         "label": "Allow representatives to edit custom fields",
         "hint": "When active, it allows representatives to edit the custom fields of the contact in the \"All Information\" section."
       },
@@ -1011,7 +1011,8 @@
     "message_field_placeholder": "Example: Hello! How are you? I'll be assisting you today.",
     "successfully_added": "Quick message added",
     "successfully_updated": "Quick message updated",
-    "successfully_deleted": "Quick message deleted successfully!",    "error_deleting": "Unable to delete the quick message.",
+    "successfully_deleted": "Quick message deleted successfully!",
+    "error_deleting": "Unable to delete the quick message.",
     "error": "Error setting quick message",
     "no_suggestions": "No results found for the entered shortcut",
     "disclaimer": "Type / (slash) shortcut in the message field to view quick messages"
@@ -1136,9 +1137,7 @@
       },
       "queue_prioritization": {
         "tooltip": "This setting allows agents to choose which of the department's selected queues will receive contacts",
-        "switch_active": "Allow representatives to choose their queues within the department",
-        "switch_inactive": "Allow representatives to choose their queues within the department",
-        "switch_label": "Allows agents to choose which queues they receive chats from",
+        "switch_label": "Allow representatives to choose their queues within the department",
         "hint": "If active, the resource will be visible only to the representatives in the Live Desk module."
       },
       "show_agent_status_count_timer": {
@@ -1456,7 +1455,8 @@
     "content_3": {
       "text_1": "To make the information drawer more organized and easier to use, we've made some improvements. The information is now divided into <b>About the contact</b> and <b>About the service</b>.",
       "text_2": "In addition, <b>custom fields</b> can now be collapsed and expanded, so you can focus on what matters most without scrolling.",
-      "text_3": "To make the interface cleaner, we've updated the <b>Start discussion</b> button's appearance."    }
+      "text_3": "To make the interface cleaner, we've updated the <b>Start discussion</b> button's appearance."
+    }
   },
   "modal_confirm_delete": {
     "action_cannot_be_reversed": "This action cannot be reversed"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1142,8 +1142,8 @@
         "switch_inactive": "Transfer chats in bulk to another queue or representative"
       },
       "block_transfer_to_off_agents": {
-        "switch_active": "Block chat transfer to offline representatives",
-        "switch_inactive": "Block chat transfer to offline representatives"
+        "switch_active": "Block chats transfer to offline representatives",
+        "switch_inactive": "Block chats transfer to offline representatives"
       },
       "bulk_close": {
         "switch_active": "End chats in bulk",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1144,8 +1144,8 @@
         "switch_inactive": "Transferir chats en masa a otra cola o representante"
       },
       "block_transfer_to_off_agents": {
-        "switch_active": "Bloquear transferencia de chat a representantes offline",
-        "switch_inactive": "Bloquear transferencia de chat a representantes offline"
+        "switch_active": "Bloquear transferencia de chats a representantes offline",
+        "switch_inactive": "Bloquear transferencia de chats a representantes offline"
       },
       "bulk_close": {
         "switch_active": "Finalizar chats en masa",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -329,7 +329,8 @@
       },
       "template_message": {
         "switch_active": "Activar plantillas de mensajes",
-        "switch_disabled": "Activar plantillas de mensajes"
+        "switch_disabled": "Activar plantillas de mensajes",
+        "switch_label": "Envío de plantillas de mensajes"
       },
       "edit_custom_fields": {
         "label": "Permitir a los representantes editar campos personalizables",
@@ -338,7 +339,9 @@
       "agents_signature": {
         "tooltip": "Cada mensaje mostrará el nombre del representante que respondió",
         "switch_active": "Mostrar el nombre del representante en los mensajes",
-        "switch_disabled": "Mostrar el nombre del representante en los mensajes"
+        "switch_disabled": "Mostrar el nombre del representante en los mensajes",
+        "hint": "Cada mensaje intercambiado tendrá el nombre del agente que responde.",
+        "switch_label": "Usar firma"
       },
       "csat": {
         "custom": {
@@ -362,7 +365,12 @@
         "title": "Mensajes automatizados",
         "switch_when_waiting_label": "Enviar mensaje automático a los contactos en espera",
         "switch_when_start_label": "Enviar mensaje automático al iniciar el soporte",
-        "hint_when_waiting": "Se envía un mensaje automático a los contactos que están en la cola esperando soporte humano."
+        "hint_when_waiting": "Se envía un mensaje automático a los contactos que están en la cola esperando soporte humano.",
+        "hint_when_start": "Se envía un mensaje automático cuando un chat se asigna a un representante. En el chat, el mensaje aparece como enviado por el representante asignado.",
+        "field": {
+          "title": "Mensaje automático",
+          "placeholder": "Ejemplo: ¡Hola! ¿Cómo puedo ayudarte hoy?"
+        }
       },
       "automatic_message": {
         "switch_active": "Abrir mensajes automáticamente",
@@ -376,7 +384,8 @@
       "required_tags": {
         "switch_active": "Exigir tag al finalizar el chat de soporte",
         "switch_disabled": "Exigir tag al finalizar el chat de soporte",
-        "tooltip": "Agrega al menos una tag para activar"
+        "tooltip": "Agrega al menos una tag para activar",
+        "switch_label": "Exigir etiquetas al final del soporte humano"
       }
     }
   },
@@ -1027,7 +1036,10 @@
     "successfully_updated": "Mensaje rápido actualizado",
     "error": "Error al configurar mensaje rápido",
     "no_suggestions": "No se encontraron resultados para el atajo ingresado",
-    "disclaimer": "Escribe / (barra) en el campo de mensaje para ver los mensajes rápidos"
+    "disclaimer": "Escribe / (barra) en el campo de mensaje para ver los mensajes rápidos",
+    "description_new": "Mensaje rápido en el sector {sector}",
+    "error_deleting": "No se pudo eliminar el mensaje rápido.",
+    "successfully_deleted": "Mensaje rápido eliminado con éxito"
   },
   "discard": "Descartar",
   "on_boarding": {
@@ -1083,7 +1095,8 @@
       "settings": "Configuración",
       "groups": "Grupos de proyectos",
       "sectors": "Sectores",
-      "representatives": "Representantes"
+      "representatives": "Representantes",
+      "general": "General"
     },
     "custom_breaks": {
       "title": "Pausas personalizadas",
@@ -1501,5 +1514,6 @@
     "pending_response": {
       "tooltip": "No respondiste a este contacto"
     }
-  }
+  },
+  "select": "Seleccionar"
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -57,7 +57,8 @@
     "message": {
       "save": {
         "error": "Error al eliminar fechas no laborales. Vuelve a intentarlo.",
-        "success": "Fechas no laborables eliminadas con éxito"      }
+        "success": "Fechas no laborables eliminadas con éxito"
+      }
     }
   },
   "dark_mode_intro": {
@@ -1073,7 +1074,8 @@
   },
   "config_chats": {
     "title": "Configuración",
-    "section_sectors_title": "Departamentos en {project}",    "section_groups_title": "Gestión de grupos de proyectos",
+    "section_sectors_title": "Departamentos en {project}",
+    "section_groups_title": "Gestión de grupos de proyectos",
     "filter_by_sector_name": "Filtrar por nombre del sector",
     "filter_by_group_name": "Filtrar por nombre del grupo",
     "section_sectors_subtitle": "Agrega, consulta y gestiona departamentos, colas, managers y representantes dentro de tu organización.",
@@ -1146,8 +1148,8 @@
       },
       "queue_prioritization": {
         "tooltip": "Esta configuración permite a los agentes definir las colas del departamento que recibirán contactos",
-        "switch_active": "Permitir que los representantes elijan sus colas dentro del departamento",
-        "switch_inactive": "Permitir que los representantes elijan sus colas dentro del departamento"
+        "switch_label": "Permitir que los representantes elijan sus colas dentro del departamento",
+        "hint": "Si está activo, el recurso será visible solo para los representantes en el módulo Live Desk."
       },
       "show_agent_status_count_timer": {
         "switch_active": "Mostrar temporizador de status para pausas personalizadas",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -329,7 +329,8 @@
       },
       "template_message": {
         "switch_active": "Disparar templates de mensagens",
-        "switch_disabled": "Disparar templates de mensagens"
+        "switch_disabled": "Disparar templates de mensagens",
+        "switch_label": "Disparo de modelos de mensagens"
       },
       "edit_custom_fields": {
         "label": "Permitir que atendentes editem campos customizáveis",
@@ -338,7 +339,9 @@
       "agents_signature": {
         "tooltip": "Cada mensagem exibirá o nome do atendente que respondeu",
         "switch_active": "Exibir nome do atendente nas mensagens",
-        "switch_disabled": "Exibir nome do atendente nas mensagens"
+        "switch_disabled": "Exibir nome do atendente nas mensagens",
+        "hint": "Cada mensagem trocada terá o nome do agente que está respondendo.",
+        "switch_label": "Usar assinatura"
       },
       "csat": {
         "custom": {
@@ -370,7 +373,19 @@
       "required_tags": {
         "switch_active": "Exigir tag ao finalizar o suporte",
         "switch_disabled": "Exigir tag ao finalizar o suporte",
-        "tooltip": "Adicione pelo menos uma tag para ativar"
+        "tooltip": "Adicione pelo menos uma tag para ativar",
+        "switch_label": "Exigir tags ao final do atendimento humano"
+      },
+      "automated_message": {
+        "title": "Mensagens automatizadas",
+        "switch_when_waiting_label": "Enviar mensagem automática para contatos na fila de espera",
+        "switch_when_start_label": "Enviar mensagem automática quando o atendimento começar",
+        "hint_when_waiting": "Envia automaticamente uma mensagem para os contatos enquanto aguardam atendimento humano na fila.",
+        "hint_when_start": "Envia automaticamente uma mensagem quando um chat é atribuído a um atendente. A mensagem aparece como se tivesse sido enviada pelo atendente.",
+        "field": {
+          "title": "Mensagem automática",
+          "placeholder": "Exemplo: Olá! Como posso ajudar você hoje?"
+        }
       }
     }
   },
@@ -1083,7 +1098,8 @@
       "settings": "Configurações",
       "groups": "Grupos do projeto",
       "sectors": "Setores",
-      "representatives": "Atendentes"
+      "representatives": "Atendentes",
+      "general": "Geral"
     },
     "custom_breaks": {
       "title": "Pausas personalizadas",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -1148,8 +1148,8 @@
       },
       "queue_prioritization": {
         "tooltip": "Esta configuração permite que os atendentes escolham quais das filas selecionadas do setor receberão contatos",
-        "switch_active": "Permitir que atendentes escolham suas filas dentro do setor",
-        "switch_inactive": "Permitir que atendentes escolham suas filas dentro do setor"
+        "switch_label": "Permitir que atendentes escolham suas filas dentro do setor",
+        "hint": "Se ativado, o recurso será visível apenas para os atendentes no módulo Live Desk."
       },
       "show_agent_status_count_timer": {
         "switch_active": "Mostrar temporizador de status para intervalos personalizados",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -1143,12 +1143,12 @@
       },
       "bulk_transfer": {
         "tooltip": "Esta função permite que os atendentes transfiram diferentes contatos de uma só vez",
-        "switch_active": "Transferir chat em massa para outra fila ou atendente",
-        "switch_inactive": "Transferir chat em massa para outra fila ou atendente"
+        "switch_active": "Transferir chats em massa para outra fila ou atendente",
+        "switch_inactive": "Transferir chats em massa para outra fila ou atendente"
       },
       "block_transfer_to_off_agents": {
-        "switch_active": "Bloquear transferência de chat para atendentes offline",
-        "switch_inactive": "Bloquear transferência de chat para atendentes offline"
+        "switch_active": "Bloquear transferência de chats para atendentes offline",
+        "switch_inactive": "Bloquear transferência de chats para atendentes offline"
       },
       "bulk_close": {
         "switch_active": "Encerrar chats em massa",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -272,13 +272,16 @@
       "title": "Opțiuni suplimentare",
       "template_message": {
         "switch_active": "Declanșare șabloane mesaj",
-        "switch_disabled": "Declanșare șabloane mesaj"
+        "switch_disabled": "Declanșare șabloane mesaj",
+        "switch_label": "Declanșare șabloane de mesaje"
       },
       "edit_custom_fields": "Permite reprezentanților să editeze câmpurile personalizate",
       "agents_signature": {
         "tooltip": "Fiecare mesaj va afișa numele reprezentantului care a răspuns",
         "switch_active": "Afișează numele reprezentativ în mesaje",
-        "switch_disabled": "Afișează numele reprezentativ în mesaje"
+        "switch_disabled": "Afișează numele reprezentativ în mesaje",
+        "hint": "Fiecare mesaj schimbat va avea numele reprezentantului care răspunde.",
+        "switch_label": "Folosește semnătura"
       },
       "csat": {
         "custom": {
@@ -302,7 +305,12 @@
         "switch_when_waiting_label": "Trimite mesaj automat contactelor care așteaptă",
         "switch_when_start_label": "Trimite mesaj automat când începe asistența",
         "hint_when_waiting": "Trimite automat un mesaj contactelor în timp ce acestea așteaptă asistență umană în coadă.",
-        "hint_when_start": "Trimite automat un mesaj atunci când un chat este atribuit unui reprezentant. Mesajul va apărea ca și cum ar fi fost trimis de reprezentantul atribuit."
+        "hint_when_start": "Trimite automat un mesaj atunci când un chat este atribuit unui reprezentant. Mesajul va apărea ca și cum ar fi fost trimis de reprezentantul atribuit.",
+        "title": "Mesaje automate",
+        "field": {
+          "title": "Mesaj automat",
+          "placeholder": "Exemplu: Salut! Cum te pot ajuta astăzi?"
+        }
       },
       "automatic_message": {
         "switch_active": "Deschide automat mesajele",
@@ -316,7 +324,8 @@
       "required_tags": {
         "switch_active": "Solicită etichetă la sfârșitul chatului de asistență",
         "switch_disabled": "Solicită etichetă la sfârșitul chatului de asistență",
-        "tooltip": "Adaugă cel puțin o etichetă pentru a activa"
+        "tooltip": "Adaugă cel puțin o etichetă pentru a activa",
+        "switch_label": "Solicită etichete la sfârșitul asistenței umane"
       },
       "inactivity_timeout": {
         "show": {
@@ -935,7 +944,10 @@
     "successfully_updated": "Mesaj rapid actualizat",
     "error": "Eroare la setarea mesajului rapid",
     "no_suggestions": "Nu s-au găsit rezultate pentru comanda rapidă introdusă",
-    "disclaimer": "Tastează / (slash) în câmpul mesaj pentru a vedea mesajele rapide"
+    "disclaimer": "Tastează / (slash) în câmpul mesaj pentru a vedea mesajele rapide",
+    "description_new": "Mesaj rapid în sectorul {sector}",
+    "error_deleting": "Nu s-a putut șterge mesajul rapid.",
+    "successfully_deleted": "Mesaj rapid șters cu succes"
   },
   "discard": "Șterge",
   "on_boarding": {
@@ -1007,7 +1019,8 @@
     "tabs": {
       "settings": "Setări",
       "groups": "Grupuri de proiect",
-      "representatives": "Reprezentanți"
+      "representatives": "Reprezentanți",
+      "general": "General"
     },
     "custom_breaks": {
       "title": "Pauze personalizate",
@@ -1374,5 +1387,6 @@
     }
   },
   "representative": "Reprezentant",
-  "select_representative": "Selectează un reprezentant"
+  "select_representative": "Selectează un reprezentant",
+  "select": "Selectează"
 }

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -1056,8 +1056,8 @@
       },
       "queue_prioritization": {
         "tooltip": "Această setare permite agenților să aleagă care dintre cozile selectate ale departamentului vor primi contactele",
-        "switch_active": "Permite reprezentanților să aleagă cozile lor din cadrul departamentului",
-        "switch_inactive": "Permite reprezentanților să aleagă cozile lor din cadrul departamentului"
+        "switch_label": "Permite reprezentanților să aleagă cozile lor din cadrul departamentului",
+        "hint": "Dacă este activat, resursa va fi vizibilă doar pentru reprezentanții din modulul Live Desk."
       },
       "restrict_offline_agents": {
         "switch_label": "Permite interacțiuni doar pentru reprezentanții online",

--- a/src/views/Settings/Sectors/index.vue
+++ b/src/views/Settings/Sectors/index.vue
@@ -26,7 +26,7 @@
     class="settings-sectors"
   >
     <p class="settings-sectors__title">
-      {{ $t('config_chats.section_sectors_title') }}
+      {{ $t('config_chats.section_sectors_title', { project: project.name }) }}
     </p>
     <section class="settings-sectors__container">
       <section class="settings-sectors__filters">
@@ -91,7 +91,7 @@ import SectorCard from './SectorCard.vue';
 
 import Rooms from '@/services/api/resources/settings/rooms';
 import { useSettings } from '@/store/modules/settings';
-
+import { useConfig } from '@/store/modules/config';
 import { handleConnectOverlay } from '@/utils/overlay';
 import { UnnnicCallAlert } from '@weni/unnnic-system';
 
@@ -107,6 +107,9 @@ const router = useRouter();
 const emit = defineEmits<{
   'open-new-sector-modal': [void];
 }>();
+
+const configStore = useConfig();
+const { project } = storeToRefs(configStore);
 
 const showDeleteSectorModal = ref(false);
 const sectorNameFilter = ref('');


### PR DESCRIPTION
## Description

### Type of Change

    - [x] Bugfix
    - [ ] Feature
    - [ ] Code style update (formatting, local variables)
    - [ ] Refactoring (no functional changes, no api changes)
    - [ ] Tests
    - [ ] Other

### Motivation and Context

Several locale strings were missing or incomplete across supported languages, and some settings sections lacked proper labels, hints, and titles needed to support new and updated UI components.

### Summary of Changes

- Added `switch_label` keys for `template_message`, `agents_signature`, `required_tags`, and `queue_prioritization` across all locales (`en`, `es`, `pt_br`, `ro`).
- Added `hint` and `switch_label` fields to `agents_signature` in all locales.
- Added a `section_title`, `type` object (with `custom`, `default`, `label`, and `tooltip` keys) to the `csat` section in English.
- Added the full `automated_message` block (including `title`, `switch_when_waiting_label`, `switch_when_start_label`, `hint_when_waiting`, `hint_when_start`, and `field`) to `en`, `es`, `pt_br`, and `ro` locales, completing previously partial entries.
- Replaced `switch_active`/`switch_inactive` keys in `queue_prioritization` with a unified `switch_label` and added a `hint` field across all locales.
- Added a `general` tab label to `config_chats.tabs` in `es`, `pt_br`, and `ro`.
- Added `error_deleting`, `successfully_deleted`, and `description_new` keys to the quick messages section in `es` and `ro`.
- Added a top-level `select` key to `es` and `ro`.
- Fixed formatting issues such as misaligned indentation and missing newlines at end of file across locale files.
- Updated the sectors settings page to pass the `project.name` variable into the `section_sectors_title` translation and imported the `useConfig` store to retrieve it.