### PR TITLE
feat: Add filter_moderators option to hide moderators during chat transfer

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1146,8 +1146,8 @@
         "switch_inactive": "Block chats transfer to offline representatives"
       },
       "hide_moderators_from_transfer": {
-        "switch_active": "Hide moderators from chat transfer",
-        "switch_inactive": "Hide moderators from chat transfer"
+        "hint": "When enabled, only users assigned to the queue as representatives are shown. Moderators are only displayed if they are also assigned to the queue as representatives. When disabled, all users, including moderators, are shown.",
+        "switch_label": "Hide moderator profiles when transferring chats"
       },
       "bulk_close": {
         "switch_active": "End chats in bulk",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1145,6 +1145,10 @@
         "switch_active": "Block chats transfer to offline representatives",
         "switch_inactive": "Block chats transfer to offline representatives"
       },
+      "hide_moderators_from_transfer": {
+        "switch_active": "Hide moderators from chat transfer",
+        "switch_inactive": "Hide moderators from chat transfer"
+      },
       "bulk_close": {
         "switch_active": "End chats in bulk",
         "switch_inactive": "End chats in bulk"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1148,8 +1148,8 @@
         "switch_inactive": "Bloquear transferencia de chats a representantes offline"
       },
       "hide_moderators_from_transfer": {
-        "switch_active": "Ocultar moderadores en la transferencia de chats",
-        "switch_inactive": "Ocultar moderadores en la transferencia de chats"
+        "hint": "Cuando está activa, solo se muestran los usuarios asignados a la cola como representantes. Los moderadores solo aparecen si también están asignados a la cola como representantes. Cuando está desactivada, se muestran todos los usuarios, incluidos los moderadores.",
+        "switch_label": "Ocultar perfiles de moderadores al transferir chats"
       },
       "bulk_close": {
         "switch_active": "Finalizar chats en masa",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1147,6 +1147,10 @@
         "switch_active": "Bloquear transferencia de chats a representantes offline",
         "switch_inactive": "Bloquear transferencia de chats a representantes offline"
       },
+      "hide_moderators_from_transfer": {
+        "switch_active": "Ocultar moderadores en la transferencia de chats",
+        "switch_inactive": "Ocultar moderadores en la transferencia de chats"
+      },
       "bulk_close": {
         "switch_active": "Finalizar chats en masa",
         "switch_inactive": "Finalizar chats en masa"

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -1150,6 +1150,10 @@
         "switch_active": "Bloquear transferência de chats para atendentes offline",
         "switch_inactive": "Bloquear transferência de chats para atendentes offline"
       },
+      "hide_moderators_from_transfer": {
+        "switch_active": "Ocultar moderadores na transferência de chats",
+        "switch_inactive": "Ocultar moderadores na transferência de chats"
+      },
       "bulk_close": {
         "switch_active": "Encerrar chats em massa",
         "switch_inactive": "Encerrar chats em massa"

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -1151,8 +1151,8 @@
         "switch_inactive": "Bloquear transferência de chats para atendentes offline"
       },
       "hide_moderators_from_transfer": {
-        "switch_active": "Ocultar moderadores na transferência de chats",
-        "switch_inactive": "Ocultar moderadores na transferência de chats"
+        "hint": "Quando ativada, apenas usuários atribuídos à fila como atendentes são exibidos. Moderadores só aparecem se também estiverem atribuídos à fila como atendentes. Quando desativada, todos os usuários, incluindo moderadores, são exibidos.",
+        "switch_label": "Ocultar perfis moderadores ao transferir chats"
       },
       "bulk_close": {
         "switch_active": "Encerrar chats em massa",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -1085,6 +1085,10 @@
         "switch_active": "Blochează transferul chaturilor către reprezentanți offline",
         "switch_inactive": "Blochează transferul chaturilor către reprezentanți offline"
       },
+      "hide_moderators_from_transfer": {
+        "switch_active": "Ascunde moderatorii din transferul de chaturi",
+        "switch_inactive": "Ascunde moderatorii din transferul de chaturi"
+      },
       "bulk_close": {
         "switch_active": "Închide chaturile în masă",
         "switch_inactive": "Închide chaturile în masă"

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -1086,8 +1086,8 @@
         "switch_inactive": "Blochează transferul chaturilor către reprezentanți offline"
       },
       "hide_moderators_from_transfer": {
-        "switch_active": "Ascunde moderatorii din transferul de chaturi",
-        "switch_inactive": "Ascunde moderatorii din transferul de chaturi"
+        "hint": "Când este activată, sunt afișați doar utilizatorii atribuiți cozii ca reprezentanți. Moderatorii sunt afișați doar dacă sunt și atribuiți cozii ca reprezentanți. Când este dezactivată, sunt afișați toți utilizatorii, inclusiv moderatorii.",
+        "switch_label": "Ascunde profilurile moderatorilor la transferul chaturilor"
       },
       "bulk_close": {
         "switch_active": "Închide chaturile în masă",

--- a/src/views/Settings/SettingsProjectOptions/__tests__/SettingsProjectOptions.spec.js
+++ b/src/views/Settings/SettingsProjectOptions/__tests__/SettingsProjectOptions.spec.js
@@ -30,6 +30,7 @@ vi.mock('@/services/api/resources/settings/agentBuilder', () => ({
 const defaultConfig = {
   can_use_bulk_transfer: false,
   filter_offline_agents: false,
+  filter_moderators: false,
   can_use_bulk_close: false,
   can_close_chats_in_queue: false,
   can_use_bulk_take: false,
@@ -191,6 +192,7 @@ describe('SettingsProjectOptions.vue', () => {
       const alwaysVisibleKeys = [
         'can_use_bulk_transfer',
         'filter_offline_agents',
+        'filter_moderators',
         'can_close_chats_in_queue',
         'can_use_queue_prioritization',
         'can_see_waiting_rooms_count',
@@ -222,6 +224,7 @@ describe('SettingsProjectOptions.vue', () => {
       'restrict_offline_agents',
       'can_use_bulk_transfer',
       'filter_offline_agents',
+      'filter_moderators',
       'can_use_bulk_close',
       'can_close_chats_in_queue',
       'can_use_queue_prioritization',

--- a/src/views/Settings/SettingsProjectOptions/__tests__/SettingsProjectOptions.spec.js
+++ b/src/views/Settings/SettingsProjectOptions/__tests__/SettingsProjectOptions.spec.js
@@ -206,6 +206,39 @@ describe('SettingsProjectOptions.vue', () => {
       });
     });
 
+    it('should place filter_moderators after filter_offline_agents and before bulk close', () => {
+      wrapper = createWrapper({ activeFeatures: ['weniChatsBulkClose'] });
+
+      const keys = wrapper.vm.optionsItems.map((item) => item.key);
+      const offlineAgentsIndex = keys.indexOf('filter_offline_agents');
+      const moderatorsIndex = keys.indexOf('filter_moderators');
+      const bulkCloseIndex = keys.indexOf('can_use_bulk_close');
+
+      expect(offlineAgentsIndex).toBeGreaterThan(-1);
+      expect(moderatorsIndex).toBeGreaterThan(-1);
+      expect(moderatorsIndex).toBe(offlineAgentsIndex + 1);
+      expect(bulkCloseIndex).toBeGreaterThan(moderatorsIndex);
+    });
+
+    it('should include hint text on filter_moderators item', () => {
+      wrapper = createWrapper({ activeFeatures: [] });
+
+      const item = wrapper.vm.optionsItems.find(
+        (option) => option.key === 'filter_moderators',
+      );
+
+      expect(item.name).toBe(
+        wrapper.vm.$t(
+          'config_chats.project_configs.hide_moderators_from_transfer.switch_label',
+        ),
+      );
+      expect(item.hint).toBe(
+        wrapper.vm.$t(
+          'config_chats.project_configs.hide_moderators_from_transfer.hint',
+        ),
+      );
+    });
+
     it('should have prompt config on flag-prompt items', async () => {
       await flushPromises();
 

--- a/src/views/Settings/SettingsProjectOptions/index.vue
+++ b/src/views/Settings/SettingsProjectOptions/index.vue
@@ -99,6 +99,7 @@ export default {
       projectConfig: {
         can_use_bulk_transfer: false,
         filter_offline_agents: false,
+        filter_moderators: false,
         can_use_bulk_close: false,
         can_close_chats_in_queue: false,
         can_use_bulk_take: false,
@@ -159,6 +160,14 @@ export default {
       return this.$t(
         `config_chats.project_configs.block_transfer_to_off_agents.switch_${
           filterOfflineAgents ? 'active' : 'inactive'
+        }`,
+      );
+    },
+    configHideModeratorsFromTransferTranslation() {
+      const filterModerators = this.projectConfig.filter_moderators;
+      return this.$t(
+        `config_chats.project_configs.hide_moderators_from_transfer.switch_${
+          filterModerators ? 'active' : 'inactive'
         }`,
       );
     },
@@ -238,6 +247,12 @@ export default {
           type: 'flag',
           visible: !this.isSecondaryProject,
           name: this.configBlockTransferToOffAgentsTranslation,
+        },
+        {
+          key: 'filter_moderators',
+          type: 'flag',
+          visible: !this.isSecondaryProject,
+          name: this.configHideModeratorsFromTransferTranslation,
         },
         {
           key: 'can_use_bulk_close',
@@ -381,6 +396,7 @@ export default {
       const {
         can_use_bulk_transfer,
         filter_offline_agents,
+        filter_moderators,
         can_use_bulk_close,
         can_close_chats_in_queue,
         can_use_bulk_take,
@@ -394,6 +410,7 @@ export default {
       await Project.update({
         can_use_bulk_transfer,
         filter_offline_agents,
+        filter_moderators,
         can_use_bulk_close,
         can_close_chats_in_queue,
         can_use_bulk_take,

--- a/src/views/Settings/SettingsProjectOptions/index.vue
+++ b/src/views/Settings/SettingsProjectOptions/index.vue
@@ -163,14 +163,6 @@ export default {
         }`,
       );
     },
-    configHideModeratorsFromTransferTranslation() {
-      const filterModerators = this.projectConfig.filter_moderators;
-      return this.$t(
-        `config_chats.project_configs.hide_moderators_from_transfer.switch_${
-          filterModerators ? 'active' : 'inactive'
-        }`,
-      );
-    },
     configBulkCloseTranslation() {
       const canBulkClose = this.projectConfig.can_use_bulk_close;
       return this.$t(
@@ -252,7 +244,12 @@ export default {
           key: 'filter_moderators',
           type: 'flag',
           visible: !this.isSecondaryProject,
-          name: this.configHideModeratorsFromTransferTranslation,
+          name: this.$t(
+            'config_chats.project_configs.hide_moderators_from_transfer.switch_label',
+          ),
+          hint: this.$t(
+            'config_chats.project_configs.hide_moderators_from_transfer.hint',
+          ),
         },
         {
           key: 'can_use_bulk_close',


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
When transferring chats, moderators were always visible in the transfer list regardless of whether they were assigned to the queue as representatives. This could cause confusion and unintended transfers to moderators who are not acting as representatives in a given queue.

### Summary of Changes
- Added a new `filter_moderators` project configuration option that, when enabled, hides moderator profiles from the chat transfer list unless they are also assigned to the queue as representatives.
- The new setting is positioned between the existing `filter_offline_agents` and `bulk_close` options in the project settings view.
- Added localization strings for the new setting (hint and switch label) in English, Spanish, Portuguese (Brazil), and Romanian.
- Updated the `Project.update` call to include `filter_moderators` when saving project configurations.
- Added unit tests to verify the correct ordering of `filter_moderators` in the options list, the presence of its hint text, and its inclusion in the always-visible keys and update payload.