### PR TITLE
fix: Pass countryCode prop and fix add button styling in holiday modals

### DIFF
--- a/src/views/Settings/Forms/SectorWorkingDaySection.vue
+++ b/src/views/Settings/Forms/SectorWorkingDaySection.vue
@@ -178,6 +178,7 @@
     :enableHolidays="enableCountryHolidays"
     :isEditing="isEditing"
     :sectorUuid="modelValue.uuid"
+    :countryCode="countryCode"
     @update:enable-holidays="enableCountryHolidays = $event"
     @update:disabled-holidays="disabledCountryHolidays = $event"
     @close="handleModal('showCountryHolidaysModal', false)"

--- a/src/views/Settings/Forms/modals/CreateCustomHolidayModal.vue
+++ b/src/views/Settings/Forms/modals/CreateCustomHolidayModal.vue
@@ -41,7 +41,7 @@
         <UnnnicButton
           class="create-custom-holiday-modal__add-button"
           data-testid="add-button"
-          iconCenter="add-1"
+          iconLeft="add-1"
           type="tertiary"
           :text="$t('sector.managers.working_day.add_more_dates_or_periods')"
           @click="addForm"
@@ -150,7 +150,7 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped>
+<style scoped lang="scss">
 .create-custom-holiday-modal {
   &__form {
     display: flex;
@@ -162,6 +162,9 @@ export default {
       }
     }
   }
+  &__add-button {
+    align-self: flex-start;
+  }
   &__body {
     display: flex;
     flex-direction: column;
@@ -169,8 +172,5 @@ export default {
     padding: $unnnic-space-6;
     overflow-y: auto;
   }
-}
-:deep(.unnnic-button--size-large.create-custom-holiday-modal__add-button) {
-  width: 50%;
 }
 </style>


### PR DESCRIPTION
## Description
### Type of Change
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The country holidays modal was missing the `countryCode` prop, and the "Add more dates or periods" button had incorrect styling due to a deep CSS selector overriding its width.

### Summary of Changes
- Passes `countryCode` to the `CountryHolidaysModal` component so it receives the correct country context.
- Changes the "Add more dates or periods" button's icon from `iconCenter` to `iconLeft` for proper icon placement.
- Replaces the deep CSS selector that forced the button to `width: 50%` with a scoped `align-self: flex-start` style, allowing the button to size naturally based on its content.