### PR TITLE
refactor: Remove pinia from module federation shared dependencies

### DIFF
--- a/rspack.config.js
+++ b/rspack.config.js
@@ -162,11 +162,6 @@ module.exports = defineConfig({
           requiredVersion: pkg.dependencies['vue-i18n'],
           eager: true,
         },
-        pinia: {
-          singleton: true,
-          requiredVersion: pkg.dependencies['pinia'],
-          eager: true,
-        },
         'vue-router': {
           singleton: true,
           requiredVersion: pkg.dependencies['vue-router'],


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Pinia's shared module configuration in the Rspack module federation setup is no longer needed and has been removed to simplify the configuration.

### Summary of Changes
Removed `pinia` from the shared modules list in the Rspack module federation configuration, eliminating its `singleton`, `requiredVersion`, and `eager` settings.