### PR TITLE
feat: Enhance ViewModeHeader with dashboard integration

### DIFF
--- a/src/views/Dashboard/ViewMode/components/ViewModeHeader.vue
+++ b/src/views/Dashboard/ViewMode/components/ViewModeHeader.vue
@@ -42,6 +42,7 @@
 import { mapActions } from 'pinia';
 import { useRooms } from '@/store/modules/chats/rooms';
 import { emitToHost } from '@/utils/hostBridge';
+import { useDashboard } from '@/store/modules/dashboard';
 
 export default {
   name: 'ViewModeHeader',
@@ -59,8 +60,14 @@ export default {
     };
   },
 
+  unmounted() {
+    console.log('unmounted ViewModeHeader - setViewedAgent to empty object');
+    this.setViewedAgent({ email: '', name: '' });
+  },
+
   methods: {
     ...mapActions(useRooms, ['setActiveRoom']),
+    ...mapActions(useDashboard, ['setViewedAgent']),
     async closeViewMode() {
       await this.setActiveRoom(null);
 

--- a/src/views/Dashboard/ViewMode/components/ViewModeHeader.vue
+++ b/src/views/Dashboard/ViewMode/components/ViewModeHeader.vue
@@ -61,7 +61,6 @@ export default {
   },
 
   unmounted() {
-    console.log('unmounted ViewModeHeader - setViewedAgent to empty object');
     this.setViewedAgent({ email: '', name: '' });
   },
 


### PR DESCRIPTION
## Description
### Type of Change
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
When the `ViewModeHeader` component was unmounted, the viewed agent state was not being cleared, which could cause stale agent data to persist in the dashboard store after leaving the view mode.

### Summary of Changes
When the `ViewModeHeader` component is unmounted, `setViewedAgent` is now called with an empty object to reset the viewed agent state, ensuring no stale agent data remains in the dashboard store after the component is destroyed.