### PR TITLE
chore: Upgrade Node.js to v24 and update CI/Docker base images

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -5,11 +5,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup Node 18
-        uses: actions/setup-node@v2
+        uses: actions/checkout@v4
+      - name: Setup Node 24
+        uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "24"
       - name: Install dependencies
         run: npm install
       - name: Run lint

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1
 
-ARG NODE_VERSION="18.17.0"
-ARG BASE_VERSION="alpine3.17"
+ARG NODE_VERSION="24"
+ARG BASE_VERSION="alpine3.22"
 ARG OLD_IMAGE="chats-webapp:latest"
 ARG KEEP_DAYS=60
 


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The Node.js and Alpine base image versions used in the Dockerfile and CI workflow were outdated. Upgrading ensures access to the latest security patches, performance improvements, and long-term support coverage.

### Summary of Changes
- Upgraded the Node.js version from `18.17.0` to `24` in the Dockerfile
- Upgraded the Alpine base image from `alpine3.17` to `alpine3.22`
- Updated the CI workflow to use Node 24 via `actions/setup-node@v4` and `actions/checkout@v4`