### PR TITLE
fix: Update room filtering logic to ensure known rooms are processed correctly

### DIFF
--- a/src/services/api/websocket/listeners/room/__tests__/update.unit.spec.js
+++ b/src/services/api/websocket/listeners/room/__tests__/update.unit.spec.js
@@ -450,6 +450,33 @@ describe('Room update', () => {
       });
     });
 
+    it('keeps dropping known waiting rooms outside the filter when not in view-mode', async () => {
+      useDashboard.mockReturnValue({
+        viewedAgent: { email: '' },
+      });
+      roomsStoreMock.rooms = [
+        {
+          uuid: 'known-waiting',
+          user: null,
+          is_waiting: false,
+          queue: { uuid: filteredQueueUuid },
+        },
+      ];
+
+      const room = {
+        uuid: 'known-waiting',
+        user: null,
+        is_waiting: false,
+        queue: { uuid: otherQueueUuid },
+      };
+
+      await wsRoomUpdate(room, { app: appMock });
+      flushPendingUpdates();
+
+      expect(roomsStoreMock.updateRoom).not.toHaveBeenCalled();
+      expect(countersMock.handleRoomUpdate).not.toHaveBeenCalled();
+    });
+
     it('moves ongoing → waiting counters when a known room is transferred to a filtered queue', async () => {
       roomsStoreMock.rooms = [
         {

--- a/src/services/api/websocket/listeners/room/__tests__/update.unit.spec.js
+++ b/src/services/api/websocket/listeners/room/__tests__/update.unit.spec.js
@@ -8,6 +8,7 @@ import wsRoomUpdate, {
 import wsDeleteRoom from '@/services/api/websocket/listeners/room/delete';
 import { useRooms } from '@/store/modules/chats/rooms';
 import { useRoomCounters } from '@/store/modules/chats/roomCounters';
+import { useDashboard } from '@/store/modules/dashboard';
 import SoundNotification from '@/services/api/websocket/soundNotification';
 
 vi.mock('@/store/modules/dashboard', () => ({
@@ -372,5 +373,81 @@ describe('Room update', () => {
     flushPendingUpdates();
 
     expect(roomsStoreMock.markNewChatReceived).not.toHaveBeenCalled();
+  });
+
+  describe('view-mode queue filter', () => {
+    const viewedAgentEmail = 'agent@example.com';
+    const filteredQueueUuid = 'queue-in-filter';
+    const otherQueueUuid = 'queue-outside-filter';
+
+    beforeEach(() => {
+      useDashboard.mockReturnValue({
+        viewedAgent: { email: viewedAgentEmail },
+      });
+      roomsStoreMock.filterQueues = [filteredQueueUuid];
+    });
+
+    it('drops unknown rooms outside the active queue filter in view-mode', async () => {
+      const room = {
+        uuid: 'unknown-room',
+        user: null,
+        is_waiting: false,
+        queue: { uuid: otherQueueUuid },
+        transfer_history: { action: 'transfer' },
+      };
+
+      await wsRoomUpdate(room, { app: appMock });
+      flushPendingUpdates();
+
+      expect(roomsStoreMock.updateRoom).not.toHaveBeenCalled();
+      expect(countersMock.handleRoomUpdate).not.toHaveBeenCalled();
+    });
+
+    it('still processes known rooms transferred outside the filter so counters update', async () => {
+      roomsStoreMock.rooms = [
+        {
+          uuid: 'known-room',
+          user: { email: viewedAgentEmail },
+          is_waiting: false,
+          queue: { uuid: filteredQueueUuid },
+        },
+      ];
+      roomsStoreMock.updateRoom.mockReturnValue({
+        wasInArray: true,
+        isNowInArray: false,
+        oldType: 'ongoing',
+        newType: 'waiting',
+        roomUuid: 'known-room',
+      });
+
+      const room = {
+        uuid: 'known-room',
+        user: null,
+        is_waiting: false,
+        queue: { uuid: otherQueueUuid },
+        transfer_history: {
+          action: 'transfer',
+          to: { type: 'queue' },
+          from: { type: 'user', email: viewedAgentEmail },
+        },
+      };
+
+      await wsRoomUpdate(room, { app: appMock });
+      flushPendingUpdates();
+
+      expect(roomsStoreMock.updateRoom).toHaveBeenCalledWith(
+        expect.objectContaining({
+          room,
+          viewedAgentEmail,
+        }),
+      );
+      expect(countersMock.handleRoomUpdate).toHaveBeenCalledWith({
+        wasInArray: true,
+        isNowInArray: false,
+        oldType: 'ongoing',
+        newType: 'waiting',
+        roomUuid: 'known-room',
+      });
+    });
   });
 });

--- a/src/services/api/websocket/listeners/room/__tests__/update.unit.spec.js
+++ b/src/services/api/websocket/listeners/room/__tests__/update.unit.spec.js
@@ -449,5 +449,46 @@ describe('Room update', () => {
         roomUuid: 'known-room',
       });
     });
+
+    it('moves ongoing → waiting counters when a known room is transferred to a filtered queue', async () => {
+      roomsStoreMock.rooms = [
+        {
+          uuid: 'known-in-filter',
+          user: { email: viewedAgentEmail },
+          is_waiting: false,
+          queue: { uuid: filteredQueueUuid },
+        },
+      ];
+      roomsStoreMock.updateRoom.mockReturnValue({
+        wasInArray: true,
+        isNowInArray: true,
+        oldType: 'ongoing',
+        newType: 'waiting',
+        roomUuid: 'known-in-filter',
+      });
+
+      const room = {
+        uuid: 'known-in-filter',
+        user: null,
+        is_waiting: false,
+        queue: { uuid: filteredQueueUuid },
+        transfer_history: {
+          action: 'transfer',
+          to: { type: 'queue' },
+          from: { type: 'user', email: viewedAgentEmail },
+        },
+      };
+
+      await wsRoomUpdate(room, { app: appMock });
+      flushPendingUpdates();
+
+      expect(countersMock.handleRoomUpdate).toHaveBeenCalledWith({
+        wasInArray: true,
+        isNowInArray: true,
+        oldType: 'ongoing',
+        newType: 'waiting',
+        roomUuid: 'known-in-filter',
+      });
+    });
   });
 });

--- a/src/services/api/websocket/listeners/room/update.js
+++ b/src/services/api/websocket/listeners/room/update.js
@@ -282,7 +282,10 @@ export default async (room, { app }) => {
 
   const isRoomForMe = room.user?.email === app.me.email;
 
-  if (!isValidRoomFilterQueue && (isWaitingRoom || isViewMode)) {
+  // Known rooms must still be processed so they can leave the list and update
+  // counters (e.g. view-mode transfer to a queue outside the active filter).
+  // Only drop unknown rooms that do not match the queue filter.
+  if (!isKnown && !isValidRoomFilterQueue && (isWaitingRoom || isViewMode)) {
     return;
   }
 

--- a/src/services/api/websocket/listeners/room/update.js
+++ b/src/services/api/websocket/listeners/room/update.js
@@ -282,11 +282,14 @@ export default async (room, { app }) => {
 
   const isRoomForMe = room.user?.email === app.me.email;
 
-  // Known rooms must still be processed so they can leave the list and update
-  // counters (e.g. view-mode transfer to a queue outside the active filter).
-  // Only drop unknown rooms that do not match the queue filter.
-  if (!isKnown && !isValidRoomFilterQueue && (isWaitingRoom || isViewMode)) {
-    return;
+  // Queue-filter drop must stay identical outside view-mode.
+  // Only in view-mode we still process known rooms so transfers can leave the
+  // list and update counters when the destination queue is outside the filter.
+  if (!isValidRoomFilterQueue && (isWaitingRoom || isViewMode)) {
+    const shouldProcessKnownViewModeRoom = isViewMode && isKnown;
+    if (!shouldProcessKnownViewModeRoom) {
+      return;
+    }
   }
 
   if (!isKnown && !notifiedRoomUuids.has(room.uuid)) {

--- a/src/store/modules/chats/__tests__/roomCounters.spec.js
+++ b/src/store/modules/chats/__tests__/roomCounters.spec.js
@@ -187,20 +187,20 @@ describe('useRoomCounters', () => {
         expect(counters.counts.ongoing).toBe(4);
       });
 
-      it('should decrement ongoing when a view-mode room is transferred to queue', () => {
+      it('should move count from ongoing to waiting on view-mode transfer to queue', () => {
         counters.syncFromApi('ongoing', 3, 3);
         counters.syncFromApi('waiting', 1, 1);
 
         counters.handleRoomUpdate({
           wasInArray: true,
-          isNowInArray: false,
+          isNowInArray: true,
           oldType: 'ongoing',
           newType: 'waiting',
           roomUuid: 'vm-transfer',
         });
 
         expect(counters.counts.ongoing).toBe(2);
-        expect(counters.counts.waiting).toBe(1);
+        expect(counters.counts.waiting).toBe(2);
       });
 
       it('should clamp count to 0', () => {

--- a/src/store/modules/chats/__tests__/roomCounters.spec.js
+++ b/src/store/modules/chats/__tests__/roomCounters.spec.js
@@ -187,6 +187,22 @@ describe('useRoomCounters', () => {
         expect(counters.counts.ongoing).toBe(4);
       });
 
+      it('should decrement ongoing when a view-mode room is transferred to queue', () => {
+        counters.syncFromApi('ongoing', 3, 3);
+        counters.syncFromApi('waiting', 1, 1);
+
+        counters.handleRoomUpdate({
+          wasInArray: true,
+          isNowInArray: false,
+          oldType: 'ongoing',
+          newType: 'waiting',
+          roomUuid: 'vm-transfer',
+        });
+
+        expect(counters.counts.ongoing).toBe(2);
+        expect(counters.counts.waiting).toBe(1);
+      });
+
       it('should clamp count to 0', () => {
         counters.handleRoomUpdate({
           wasInArray: true,

--- a/src/store/modules/chats/__tests__/rooms.spec.js
+++ b/src/store/modules/chats/__tests__/rooms.spec.js
@@ -702,6 +702,58 @@ describe('State Rooms', () => {
     });
   });
 
+  describe('updateRoom (view-mode transfer to queue)', () => {
+    let roomsStore;
+    const managerEmail = 'manager@weni.ai';
+    const viewedAgentEmail = 'agent@weni.ai';
+
+    beforeEach(() => {
+      mocks.useProfile.mockReturnValue(mockProfileAdminState);
+      roomsStore = useRooms();
+    });
+
+    it('removes the room and returns leave-array metadata so counters can decrement', () => {
+      const initialRoom = {
+        uuid: 'vm-transfer',
+        user: { email: viewedAgentEmail, first_name: 'Agent', last_name: '' },
+        is_waiting: false,
+        queue: { uuid: 'queue-a', name: 'Queue A' },
+      };
+      roomsStore.$patch({
+        rooms: [initialRoom],
+        activeRoom: { ...initialRoom },
+      });
+
+      const result = roomsStore.updateRoom({
+        room: {
+          uuid: 'vm-transfer',
+          user: null,
+          is_waiting: false,
+          queue: { uuid: 'queue-b', name: 'Queue B' },
+          transfer_history: {
+            action: 'transfer',
+            to: { type: 'queue' },
+            from: { type: 'user', email: viewedAgentEmail },
+            requested_by: { email: managerEmail },
+          },
+        },
+        userEmail: managerEmail,
+        routerReplace: vi.fn(),
+        viewedAgentEmail,
+      });
+
+      expect(existRoomByUuid(roomsStore, 'vm-transfer')).toBe(false);
+      expect(roomsStore.activeRoom).toBeNull();
+      expect(result).toEqual({
+        wasInArray: true,
+        isNowInArray: false,
+        oldType: 'ongoing',
+        newType: 'waiting',
+        roomUuid: 'vm-transfer',
+      });
+    });
+  });
+
   describe('isNewChatReceived flag', () => {
     let roomsStore;
 

--- a/src/store/modules/chats/__tests__/rooms.spec.js
+++ b/src/store/modules/chats/__tests__/rooms.spec.js
@@ -712,7 +712,7 @@ describe('State Rooms', () => {
       roomsStore = useRooms();
     });
 
-    it('removes the room and returns leave-array metadata so counters can decrement', () => {
+    it('keeps the room as waiting and returns type-change metadata when the queue is visible', () => {
       const initialRoom = {
         uuid: 'vm-transfer',
         user: { email: viewedAgentEmail, first_name: 'Agent', last_name: '' },
@@ -722,6 +722,7 @@ describe('State Rooms', () => {
       roomsStore.$patch({
         rooms: [initialRoom],
         activeRoom: { ...initialRoom },
+        filterQueues: [],
       });
 
       const result = roomsStore.updateRoom({
@@ -742,14 +743,62 @@ describe('State Rooms', () => {
         viewedAgentEmail,
       });
 
-      expect(existRoomByUuid(roomsStore, 'vm-transfer')).toBe(false);
+      expect(existRoomByUuid(roomsStore, 'vm-transfer')).toBe(true);
+      expect(
+        roomsStore.waitingQueue.some((r) => r.uuid === 'vm-transfer'),
+      ).toBe(true);
+      expect(roomsStore.agentRooms.some((r) => r.uuid === 'vm-transfer')).toBe(
+        false,
+      );
+      expect(roomsStore.activeRoom).toBeNull();
+      expect(result).toEqual({
+        wasInArray: true,
+        isNowInArray: true,
+        oldType: 'ongoing',
+        newType: 'waiting',
+        roomUuid: 'vm-transfer',
+      });
+    });
+
+    it('removes the room when the destination queue is outside the active filter', () => {
+      const initialRoom = {
+        uuid: 'vm-transfer-filtered',
+        user: { email: viewedAgentEmail, first_name: 'Agent', last_name: '' },
+        is_waiting: false,
+        queue: { uuid: 'queue-a', name: 'Queue A' },
+      };
+      roomsStore.$patch({
+        rooms: [initialRoom],
+        activeRoom: { ...initialRoom },
+        filterQueues: ['queue-a'],
+      });
+
+      const result = roomsStore.updateRoom({
+        room: {
+          uuid: 'vm-transfer-filtered',
+          user: null,
+          is_waiting: false,
+          queue: { uuid: 'queue-outside', name: 'Outside' },
+          transfer_history: {
+            action: 'transfer',
+            to: { type: 'queue' },
+            from: { type: 'user', email: viewedAgentEmail },
+            requested_by: { email: managerEmail },
+          },
+        },
+        userEmail: managerEmail,
+        routerReplace: vi.fn(),
+        viewedAgentEmail,
+      });
+
+      expect(existRoomByUuid(roomsStore, 'vm-transfer-filtered')).toBe(false);
       expect(roomsStore.activeRoom).toBeNull();
       expect(result).toEqual({
         wasInArray: true,
         isNowInArray: false,
         oldType: 'ongoing',
         newType: 'waiting',
-        roomUuid: 'vm-transfer',
+        roomUuid: 'vm-transfer-filtered',
       });
     });
   });

--- a/src/store/modules/chats/rooms.js
+++ b/src/store/modules/chats/rooms.js
@@ -157,7 +157,19 @@ export const useRooms = defineStore('rooms', {
         const isProjectAdmin = profileStore.me.project_permission_role === 1;
 
         if (viewedAgentEmail) {
-          return room.user?.email === viewedAgentEmail;
+          if (room.user?.email === viewedAgentEmail) return true;
+
+          // Waiting rooms (no agent) remain visible in view-mode when they match
+          // the active queue filter, so ongoing → queue transfers update the
+          // waiting list and counter instead of only removing the room.
+          if (!room.user && !room.is_waiting) {
+            const emptyQueuesFilter = this.filterQueues.length === 0;
+            return (
+              emptyQueuesFilter || this.filterQueues.includes(room.queue?.uuid)
+            );
+          }
+
+          return false;
         }
 
         if (isProjectAdmin && !room.user) return true;
@@ -512,6 +524,12 @@ export const useRooms = defineStore('rooms', {
           if (!viewedAgentEmail && routerReplace) {
             routerReplace();
           }
+          return;
+        }
+        // View-mode: room moved to the waiting queue (no agent). Keep it in the
+        // waiting list/counter, but close the open chat since it left the agent.
+        if (viewedAgentEmail && !room.user) {
+          this.setActiveRoom(null);
           return;
         }
         this.setActiveRoom({ ...room });


### PR DESCRIPTION
## Description
### Type of Change
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
In view-mode, when a manager transfers a room from the viewed agent to a queue, the room was being silently dropped instead of transitioning to the waiting list and updating the counters accordingly. This caused the ongoing and waiting counters to fall out of sync and left the UI in an inconsistent state.

### Summary of Changes
- Updated the queue-filter early-return logic in the WebSocket `room/update` listener so that, in view-mode, rooms that are already known are still processed even when the destination queue is outside the active filter. This allows transfers to properly remove the room from the ongoing list and update counters.
- Extended `isRoomForViewedAgent` in the rooms store to treat agent-less, non-waiting rooms as visible in view-mode when their queue matches the active queue filter (or when no filter is set), enabling ongoing → waiting counter transitions instead of plain removals.
- Added a view-mode guard in the active-room update path so that when a room moves to the waiting queue (no agent), the open chat is closed without overwriting the active room with stale data.
- Added unit tests covering:
  - Unknown rooms outside the active queue filter being dropped in view-mode.
  - Known rooms transferred outside the filter still triggering counter updates and being removed from the list.
  - Known rooms transferred to a filtered queue moving from ongoing to waiting with correct counter metadata.
  - The `roomCounters` store correctly moving a count from ongoing to waiting on a view-mode queue transfer.
  - The `rooms` store returning the correct type-change metadata for both in-filter and out-of-filter queue transfers in view-mode.