### PR TITLE
style: Clean up HomeChatHeaders.vue by removing unused CSS and adding spacing

### DIFF
--- a/src/views/Dashboard/ViewMode/index.vue
+++ b/src/views/Dashboard/ViewMode/index.vue
@@ -387,16 +387,6 @@ export default {
 
     &--open {
       background-color: $unnnic-color-bg-purple-plain;
-      &::after {
-        content: '';
-        position: fixed;
-        top: 106px; // This distance corresponds to the positioning of the summary balloon point.
-        transform: rotate(-45deg);
-        width: $unnnic-space-3;
-        height: $unnnic-space-3;
-        background-color: $unnnic-color-bg-purple-plain;
-        border-radius: $unnnic-space-1;
-      }
     }
   }
   &__active-chat {
@@ -405,10 +395,10 @@ export default {
 
     height: 100%;
 
-    padding-bottom: $unnnic-spacing-xs;
+    padding-bottom: $unnnic-space-2;
 
     .chat-messages__container {
-      padding-left: $unnnic-spacing-sm;
+      padding-left: $unnnic-space-4;
     }
 
     .discussion-header {
@@ -425,7 +415,7 @@ export default {
   }
 
   .assume-chat {
-    margin: $unnnic-spacing-nano $unnnic-spacing-inline-sm 0;
+    margin: $unnnic-space-1 $unnnic-space-4 0;
   }
 }
 </style>

--- a/src/views/chats/Home/HomeChatHeaders.vue
+++ b/src/views/chats/Home/HomeChatHeaders.vue
@@ -347,6 +347,7 @@ export default {
 <style lang="scss" scoped>
 .home-chat-headers {
   background-color: $unnnic-color-bg-base;
+
   &__icon {
     width: 38px;
     height: 38px;
@@ -363,16 +364,6 @@ export default {
   &__summary-icon {
     &--open {
       background-color: $unnnic-color-bg-purple-plain;
-      &::after {
-        content: '';
-        position: fixed;
-        top: 49px;
-        transform: rotate(-45deg);
-        width: $unnnic-space-3;
-        height: $unnnic-space-3;
-        background-color: $unnnic-color-bg-purple-plain;
-        border-radius: $unnnic-space-1;
-      }
     }
   }
   &__actions {


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [ ] Feature
* * [x] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The decorative arrow/pointer pseudo-element (`::after`) on the summary icon's open state was causing visual inconsistencies and has been removed. Additionally, spacing tokens were updated to use the correct design system variables.

### Summary of Changes
- Removed the `::after` pseudo-element from the `--open` state of the summary icon in both `ViewMode/index.vue` and `HomeChatHeaders.vue`, eliminating the fixed-position decorative triangle that appeared when the summary balloon was open.
- Replaced `$unnnic-spacing-xs` with `$unnnic-space-2` for `padding-bottom` in the active chat section.
- Replaced `$unnnic-spacing-sm` with `$unnnic-space-4` for `padding-left` in the chat messages container.
- Replaced `$unnnic-spacing-nano` and `$unnnic-spacing-inline-sm` with `$unnnic-space-1` and `$unnnic-space-4` respectively for the `assume-chat` margin.