### PR TITLE
fix: Use date-fns for date formatting and fix event name in ShippingHistoryModal

### DIFF
--- a/src/components/chats/BulkMessage/ShippingHistoryModal/HistoryTable.vue
+++ b/src/components/chats/BulkMessage/ShippingHistoryModal/HistoryTable.vue
@@ -32,9 +32,7 @@
         </template>
 
         <template #date>
-          {{
-            dateFnsFormat(new Date(item.date), $t('date_format').toLowerCase())
-          }}
+          {{ new Date(item.date).toLocaleDateString() }}
         </template>
 
         <template #status>

--- a/src/components/chats/BulkMessage/ShippingHistoryModal/HistoryTable.vue
+++ b/src/components/chats/BulkMessage/ShippingHistoryModal/HistoryTable.vue
@@ -32,7 +32,9 @@
         </template>
 
         <template #date>
-          {{ $d(new Date(item.date)) }}
+          {{
+            dateFnsFormat(new Date(item.date), $t('date_format').toLowerCase())
+          }}
         </template>
 
         <template #status>
@@ -56,6 +58,7 @@
 </template>
 
 <script setup lang="ts">
+import { format as dateFnsFormat } from 'date-fns';
 import { statusLabel, statusScheme } from './status';
 import type { ShippingHistoryItem, TableHeader } from './types';
 

--- a/src/components/chats/BulkMessage/ShippingHistoryModal/index.vue
+++ b/src/components/chats/BulkMessage/ShippingHistoryModal/index.vue
@@ -33,7 +33,7 @@
         :total="historyCount"
         :max="historyCountPages"
         :show="historyLimit"
-        @update:currentPage="handlePageChange"
+        @update:current-page="handlePageChange"
       />
     </UnnnicDialogContent>
   </UnnnicDialog>


### PR DESCRIPTION
## Description
### Type of Change
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The date displayed in the shipping history table was not respecting the application's locale format, and the pagination component was using a deprecated camelCase event name.

### Summary of Changes
- Replaced the `$d()` date formatter in `HistoryTable.vue` with `date-fns` `format` function, using the locale-aware `date_format` translation key to correctly format dates according to the current language.
- Fixed the pagination event binding in `index.vue` from `@update:currentPage` to the kebab-case `@update:current-page` to align with Vue 3 event naming conventions.