### PR TITLE
Add and update translations from PR#912

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -169,7 +169,7 @@
     "bulk_message": "Mass message sent by {sender}"
   },
   "inactive": "Inactive",
-  "inactive_room_tooltip": "{minutes, plural, one {The conversation has reached the {minutes}-minute inactivity limit.} other {The conversation has reached the {minutes}-minutes inactivity limit.}}",
+  "inactive_room_tooltip": "{minutes, plural, one {The conversation has reached the {minutes}-minute inactivity limit.} other {The conversation has reached the {minutes}-minute inactivity limit.}}",
   "reply": "Reply",
   "step_of": "Step {step} of {total}",
   "type_to_filter": "Type to filter",
@@ -565,7 +565,7 @@
     "tags_help": "Tags help you find chats and generate better reports",
     "chat_with_contact_ended": "Chat with {contact} was closed",
     "see_history": "General history",
-    "tag_request": "Please tag the chat",
+    "tag_request": "Tag the chat",
     "closed_in": "Chat closed in",
     "closed": "Closed chat",
     "transfer": {
@@ -623,7 +623,7 @@
       "close": "Close view",
       "assume_chat": "Take over only this chat",
       "assume_chat_question": "Take over chat with {contact}?",
-      "assume_chat_question_description": "Are you sure you want to take over chat with {contact}?<br /><br />If you confirm, you will remove the chat from the current representative and you will be responsible for it.",
+      "assume_chat_question_description": "Are you sure you want to take over the chat with {contact}?<br /><br />If you confirm, you'll be responsible for it and it will be removed from the current representative.",
       "assume_chat_confirmation": "If you confirm, this chat will be transferred from {viewedAgent} to you"
     }
   },
@@ -768,12 +768,12 @@
   "bulk_transfer": {
     "transfer_selected_contacts": "Transfer selected contacts",
     "transfer_all": "Transfer all",
-    "selected_chats_count": "{count, plural, one {{count} chat is selected for transfer.} other {{count} chats are selected for transfer.}}",
-    "success_message": "{count, plural, one {{count} chat transferred successfully!} other {{count} chats transferred successfully!}}",
-    "partial_success_message": "{success, plural, one {{success} chat transferred, {failed} failed. Please try again.} other {{success} chats transferred, {failed} failed. Please try again.}}",
+    "selected_chats_count": "{count, plural, one {{count} chat is selected for transfer} other {{count} chats are selected for transfer}}",
+    "success_message": "{count, plural, one {{count} chat transferred successfully} other {{count} chats transferred successfully}}",
+    "partial_success_message": "{success, plural, one {{success} chat transferred, {failed} failed. Try again.} other {{success} chats transferred, {failed} failed. Try again.}}",
     "error_message": "Unable to transfer chats, please try again",
-    "agent_transfer_success": "{count, plural, one {Contact successfully transferred to representative {agent}} other {Contacts successfully transferred to representative {agent}}}",
-    "queue_transfer_success": "{count, plural, one {Contact successfully transferred to queue {queue}} other {Contacts successfully transferred to queue {queue}}}",
+    "agent_transfer_success": "{count, plural, one {Contact transferred to representative {agent}} other {Contacts transferred to representative {agent}}}",
+    "queue_transfer_success": "{count, plural, one {Contact transferred to queue {queue} successfully} other {Contacts transferred to queue {queue} successfully}}",
     "error": "It was not possible to transfer the contacts, try again",
     "disclaimer": {
       "transfer_to_other_sector": "When transferring the chat to a queue in another department, tags will be removed.",
@@ -784,19 +784,19 @@
   "bulk_close": {
     "close_selected_contacts": "Close selected contacts",
     "confirm_close_selected": "Are you sure you want to close the selected contacts?",
-    "success_message": "{count, plural, one {{count} chat ended successfully!} other {{count} chats ended successfully!}}",
-    "partial_success_message": "{success, plural, one {{success} chat ended, {failed} failed. Please try again.} other {{success} chats ended, {failed} failed. Please try again.}}",
+    "success_message": "{count, plural, one {{count} chat completed successfully} other {{count} chats completed successfully}}",
+    "partial_success_message": "{success, plural, one {{success} chat ended, {failed} failed. Try again.} other {{success} chats ended, {failed} failed. Try again.}}",
     "error_message": "Unable to close chats, please try again",
     "end_all_selected_chats": "End all selected chats",
     "sector_tag": "Department {current} of {total}",
     "chats_count_sector": "{count, plural, one {{count} chat · {sector} department} other {{count} chats · {sector} department}}",
     "required_tags_title": "Tags are required to end chats in the {sector} department",
-    "required_tags_description": "{count, plural, one {If you select any tag below, it will be applied to the {count} chat and will replace any existing tags.} other {If you select any tag below, it will be applied to the {count} chats and will replace any existing tags.}}",
+    "required_tags_description": "{count, plural, one {If you select any tag below, it will apply to this chat and replace any existing tags.} other {If you select any tag below, it will apply to {count} chats and replace any existing tags.}}",
     "next_sector": "Next department",
     "end_all_chats": "End all ({count} chats)",
     "back": "Back",
     "optional_tags_title": "Tags aren't required to end chats in the {sector} department",
-    "optional_tags_description": "{count, plural, one {If you select any tag below, it will be applied to the {count} chat and will replace any existing tags.} other {If you select any tag below, it will be applied to the {count} chats and will replace any existing tags.}}",
+    "optional_tags_description": "{count, plural, one {If you select any tag below, it will apply to this chat and replace any existing tags.} other {If you select any tag below, it will apply to {count} chats and replace any existing tags.}}",
     "no_tags_in_sector": "No tags to select in this department"
   },
   "close_chat": {
@@ -804,11 +804,11 @@
   },
   "bulk_take": {
     "title": "Take over all selected chats",
-    "selected_chats_count": "{count, plural, one {{count} chat is selected for takeover.} other {{count} chats are selected for takeover.}}",
+    "selected_chats_count": "{count, plural, one {{count} chat is selected for takeover} other {{count} chats are selected for takeover}}",
     "confirm_take_over_selected": "Are you sure you want to take over all selected chats?",
     "take_over_all": "Take over all",
-    "success_message": "{count, plural, one {{count} chat taken over successfully!} other {{count} chats taken over successfully!}}",
-    "partial_success_message": "{success, plural, one {{success} chat taken over, {failed} failed. Please try again.} other {{success} chats taken over, {failed} failed. Please try again.}}",
+    "success_message": "{count, plural, one {{count} chat taken over successfully} other {{count} chats taken over successfully}}",
+    "partial_success_message": "{success, plural, one {{success} chat taken over, {failed} failed. Try again.} other {{success} chats taken over, {failed} failed. Try again.}}",
     "error_message": "Unable to take over chats, please try again"
   },
   "contact_info": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -135,7 +135,7 @@
     "description": "Suelta tu archivo aquí para enviar"
   },
   "waiting_for": {
-    "minutes": "{count, plural, one {Esperando por un minuto} other {Esperando por {count} minutos}}"
+    "minutes": "{count, plural, one {1 minuto esperando} other {{count} minutos esperando}}"
   },
   "chat_message": {
     "reply_message": {
@@ -169,7 +169,7 @@
     "bulk_message": "Mensaje en masa enviado por {sender}"
   },
   "inactive": "Inactivo",
-  "inactive_room_tooltip": "{minutes, plural, one {La conversación ha alcanzado el límite de inactividad de {minutes} minuto.} other {La conversación ha alcanzado el límite de inactividad de {minutes} minutos.}}",
+  "inactive_room_tooltip": "{minutes, plural, one {La conversación alcanzó el límite de inactividad de {minutes} minuto.} other {La conversación alcanzó el límite de inactividad de {minutes} minutos.}}",
   "reply": "Responder",
   "step_of": "Paso {step} de {total}",
   "type_to_filter": "Escribe para filtrar",
@@ -568,7 +568,7 @@
     "tags_help": "Las tags te ayudan a encontrar chats y generar mejores informes",
     "chat_with_contact_ended": "El chat con {contact} se cerró",
     "see_history": "Historial general",
-    "tag_request": "Agregar tag al chat",
+    "tag_request": "Agrega una tag al chat",
     "closed_in": "Chat cerrado en",
     "closed": "Chat cerrado",
     "transfer": {
@@ -626,7 +626,7 @@
       "close": "Cerrar vista",
       "assume_chat": "Asignarme solamente este chat",
       "assume_chat_question": "¿Asignarse el chat con {contact}?",
-      "assume_chat_question_description": "¿Seguro de que deseas asignarte el chat con {contact}?<br /><br />Al confirmar, el chat se removerá del representante actual y quedará bajo tu responsabilidad.",
+      "assume_chat_question_description": "¿Realmente deseas asignarte el chat con {contact}?<br /><br />Si confirmas, el chat se removerá del representante actual y quedará bajo tu responsabilidad.",
       "assume_chat_confirmation": "Si confirmas, este chat se transferirá de {viewedAgent} a ti"
     }
   },
@@ -666,7 +666,7 @@
   "close": "Cerrar",
   "ended_by": "Finalizado por",
   "all": "Todos",
-  "back_to_chats": "Volver a los chats",
+  "back_to_chats": "Atrás a chats",
   "filter": {
     "label": "Filtro",
     "empty_tags": "No hay tags disponibles",
@@ -771,10 +771,10 @@
     "transfer_selected_contacts": "Transferir contactos seleccionados",
     "transfer_all": "Transferir todos",
     "selected_chats_count": "{count, plural, one {{count} chat seleccionado para transferencia.} other {{count} chats seleccionados para transferencia.}}",
-    "success_message": "{count, plural, one {¡{count} chat transferido con éxito!} other {¡{count} chats transferidos con éxito!}}",
-    "partial_success_message": "{success, plural, one {{success} chat transferido, {failed} falló. Intente nuevamente.} other {{success} chats transferidos, {failed} fallaron. Intente nuevamente.}}",
+    "success_message": "{count, plural, one {{count} chat transferido con éxito} other {{count} chats transferidos con éxito}}",
+    "partial_success_message": "{success, plural, one {{success} chat transferido; {failed} sin transferir. Vuelve a intentarlo.} other {{success} chats transferidos; {failed} sin transferir. Vuelve a intentarlo.}}",
     "error_message": "No fue posible transferir los chats, intente nuevamente",
-    "agent_transfer_success": "{count, plural, one {Contacto transferido con éxito al representante {agent}} other {Contactos transferidos con éxito al representante {agent}}}",
+    "agent_transfer_success": "{count, plural, one {Contacto transferido con éxito al agente {agent}} other {Contactos transferidos con éxito al agente {agent}}}",
     "queue_transfer_success": "{count, plural, one {Contacto transferido con éxito a la cola {queue}} other {Contactos transferidos con éxito a la cola {queue}}}",
     "error": "No fue posible transferir los contactos, intente nuevamente",
     "disclaimer": {
@@ -786,19 +786,19 @@
   "bulk_close": {
     "close_selected_contacts": "Cerrar contactos seleccionados",
     "confirm_close_selected": "¿Está seguro de que desea cerrar los contactos seleccionados?",
-    "success_message": "{count, plural, one {¡{count} chat finalizado con éxito!} other {¡{count} chats finalizados con éxito!}}",
-    "partial_success_message": "{success, plural, one {{success} chat finalizado, {failed} falló. Intente nuevamente.} other {{success} chats finalizados, {failed} fallaron. Intente nuevamente.}}",
+    "success_message": "{count, plural, one {{count} chat finalizado con éxito} other {{count} chats finalizados con éxito}}",
+    "partial_success_message": "{success, plural, one {{success} chat finalizado; {failed} falló. Vuelve a intentarlo.} other {{success} chats finalizados; {failed} fallaron. Vuelve a intentarlo.}}",
     "error_message": "No fue posible cerrar los chats, intente nuevamente",
     "end_all_selected_chats": "Finalizar todos los chats seleccionados",
     "sector_tag": "Departamento {current} de {total}",
     "chats_count_sector": "{count, plural, one {{count} chat · departamento {sector}} other {{count} chats · departamento {sector}}}",
     "required_tags_title": "Las tags son obligatorias para finalizar chats en el departamento {sector}",
-    "required_tags_description": "{count, plural, one {Si selecciona alguna tag a continuación, se aplicará al {count} chat y reemplazará cualquier tag existente.} other {Si selecciona alguna tag a continuación, se aplicará a los {count} chats y reemplazará cualquier tag existente.}}",
+    "required_tags_description": "{count, plural, one {Si seleccionas alguna de las tags a continuación, se aplicará a {count} chat y reemplazará las tags existentes.} other {Si seleccionas alguna de las tags a continuación, se aplicará a los {count} chats y reemplazará las tags existentes.}}",
     "next_sector": "Siguiente departamento",
     "end_all_chats": "Finalizar todos ({count} chats)",
     "back": "Volver",
     "optional_tags_title": "Las tags no son obligatorias para finalizar chats en el departamento {sector}",
-    "optional_tags_description": "{count, plural, one {Si selecciona alguna tag a continuación, se aplicará al {count} chat y reemplazará cualquier tag existente.} other {Si selecciona alguna tag a continuación, se aplicará a los {count} chats y reemplazará cualquier tag existente.}}",
+    "optional_tags_description": "{count, plural, one {Si seleccionas alguna de las tags a continuación, se aplicará a {count} chat y reemplazará cualquier tag existente.} other {Si seleccionas alguna de las tags a continuación, se aplicará a los {count} chats y reemplazará cualquier tag existente.}}",
     "no_tags_in_sector": "No hay tags registradas en este departamento para ser seleccionadas."
   },
   "close_chat": {
@@ -806,11 +806,11 @@
   },
   "bulk_take": {
     "title": "Asignarme todos los chats seleccionados",
-    "selected_chats_count": "{count, plural, one {{count} chat está seleccionado para asumir.} other {{count} chats están seleccionados para asumir.}}",
+    "selected_chats_count": "{count, plural, one {{count} chat seleccionado para asignártelo} other {{count} chats seleccionados para asignártelos}}",
     "confirm_take_over_selected": "¿Está seguro de que desea asumir todos los chats seleccionados?",
     "take_over_all": "Asumir todos",
-    "success_message": "{count, plural, one {¡{count} chat asumido con éxito!} other {¡{count} chats asumidos con éxito!}}",
-    "partial_success_message": "{success, plural, one {{success} chat asumido, {failed} falló. Intente nuevamente.} other {{success} chats asumidos, {failed} fallaron. Intente nuevamente.}}",
+    "success_message": "{count, plural, one {{count} chat asignado con éxito} other {{count} chats asignados con éxito}}",
+    "partial_success_message": "{success, plural, one {{success} chat asignado; {failed} falló. Vuelve a intentarlo.} other {{success} chats asignados; {failed} fallaron. Vuelve a intentarlo.}}",
     "error_message": "No fue posible asumir los chats, intente nuevamente"
   },
   "contact_info": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -568,7 +568,7 @@
     "tags_help": "As tags ajudam a encontrar chats e gerar relatórios melhores",
     "chat_with_contact_ended": "O chat com {contact} foi encerrado",
     "see_history": "Histórico geral",
-    "tag_request": "Adicionar tag ao chat",
+    "tag_request": "Classifique o atendimento",
     "closed_in": "Chat encerrado em",
     "closed": "Chat encerrado",
     "transfer": {
@@ -626,7 +626,7 @@
       "close": "Fechar visualização",
       "assume_chat": "Assumir apenas este chat",
       "assume_chat_question": "Assumir o chat com {contact}?",
-      "assume_chat_question_description": "Tem certeza de que deseja assumir o chat com {contact}?<br /><br />Ao confirmar, você removerá o chat do atendente atual e será responsável pelo chat.",
+      "assume_chat_question_description": "Tem certeza de que deseja assumir o chat com {contact}?<br /><br />Ao confirmar, você removerá o chat do atendente atual e passará a ser responsável por ele.",
       "assume_chat_confirmation": "Se confirmar, este chat será transferido de {viewedAgent} para você"
     }
   },
@@ -771,12 +771,12 @@
   "bulk_transfer": {
     "transfer_selected_contacts": "Transferir contatos selecionados",
     "transfer_all": "Transferir todos",
-    "selected_chats_count": "{count, plural, one {{count} chat selecionado para transferência.} other {{count} chats selecionados para transferência.}}",
-    "success_message": "{count, plural, one {{count} chat transferido com sucesso!} other {{count} chats transferidos com sucesso!}}",
+    "selected_chats_count": "{count, plural, one {{count} chat selecionado para transferência} other {{count} chats selecionados para transferência}}",
+    "success_message": "{count, plural, one {{count} chat transferido com sucesso} other {{count} chats transferidos com sucesso}}",
     "partial_success_message": "{success, plural, one {{success} chat transferido, {failed} falhou. Tente novamente.} other {{success} chats transferidos, {failed} falharam. Tente novamente.}}",
     "error_message": "Não foi possível transferir os chats, tente novamente",
-    "agent_transfer_success": "{count, plural, one {Contato transferido com sucesso para atendente {agent}} other {Contatos transferidos com sucesso para atendente {agent}}}",
-    "queue_transfer_success": "{count, plural, one {Contato transferido com sucesso para fila {queue}} other {Contatos transferidos com sucesso para fila {queue}}}",
+    "agent_transfer_success": "{count, plural, one {Contato transferido com sucesso para o atendente {agent}} other {Contatos transferidos com sucesso para o atendente {agent}}}",
+    "queue_transfer_success": "{count, plural, one {Contato transferido com sucesso para a fila {queue}} other {Contatos transferidos com sucesso para a fila {queue}}}",
     "error": "Não foi possível transferir os contatos, tente novamente",
     "disclaimer": {
       "transfer_to_other_sector": "Ao transferir o chat para uma fila de outro setor, as tags serão removidas.",
@@ -787,19 +787,19 @@
   "bulk_close": {
     "close_selected_contacts": "Encerrar contatos selecionados",
     "confirm_close_selected": "Tem certeza que deseja encerrar os contatos selecionados?",
-    "success_message": "{count, plural, one {{count} chat encerrado com sucesso!} other {{count} chats encerrados com sucesso!}}",
-    "partial_success_message": "{success, plural, one {{success} chat encerrado, {failed} falhou. Tente novamente.} other {{success} chats encerrados, {failed} falharam. Tente novamente.}}",
+    "success_message": "{count, plural, one {{count} chat encerrado com sucesso} other {{count} chats encerrados com sucesso}}",
+    "partial_success_message": "{success, plural, one {{success} chat finalizado, {failed} falhou. Tente novamente.} other {{success} chats finalizados, {failed} falharam. Tente novamente.}}",
     "error_message": "Não foi possível encerrar os chats, tente novamente",
     "end_all_selected_chats": "Encerrar todos os chats selecionados",
     "sector_tag": "Setor {current} de {total}",
     "chats_count_sector": "{count, plural, one {{count} chat · setor {sector}} other {{count} chats · setor {sector}}}",
     "required_tags_title": "Tags são obrigatórias para finalizar chats no setor {sector}",
-    "required_tags_description": "{count, plural, one {Se você selecionar alguma tag abaixo, ela será aplicada ao {count} chat e substituirá quaisquer tags existentes.} other {Se você selecionar alguma tag abaixo, ela será aplicada aos {count} chats e substituirá quaisquer tags existentes.}}",
+    "required_tags_description": "{count, plural, one {Se você selecionar alguma das tags abaixo, ela será aplicada ao {count} chat e substituirá as tags existentes.} other {Se você selecionar alguma das tags abaixo, ela será aplicada aos {count} chats e substituirá as tags existentes.}}",
     "next_sector": "Próximo setor",
     "end_all_chats": "Encerrar todos ({count} chats)",
     "back": "Voltar",
     "optional_tags_title": "Tags não são obrigatórias para finalizar chats no setor {sector}",
-    "optional_tags_description": "{count, plural, one {Se você selecionar alguma tag abaixo, ela será aplicada ao {count} chat e substituirá quaisquer tags existentes.} other {Se você selecionar alguma tag abaixo, ela será aplicada aos {count} chats e substituirá quaisquer tags existentes.}}",
+    "optional_tags_description": "{count, plural, one {Se você selecionar alguma das tags abaixo, ela será aplicada ao {count} chat e substituirá as tags existentes.} other {Se você selecionar alguma das tags abaixo, ela será aplicada aos {count} chats e substituirá as tags existentes.}}",
     "no_tags_in_sector": "Não há tags cadastradas neste setor para serem selecionadas."
   },
   "close_chat": {
@@ -807,10 +807,10 @@
   },
   "bulk_take": {
     "title": "Assumir todos os chats selecionados",
-    "selected_chats_count": "{count, plural, one {{count} chat está selecionado para assumir.} other {{count} chats estão selecionados para assumir.}}",
+    "selected_chats_count": "{count, plural, one {{count} chat está selecionado para ser assumido} other {{count} chats estão selecionados para serem assumidos}}",
     "confirm_take_over_selected": "Tem certeza que deseja assumir todos os chats selecionados?",
     "take_over_all": "Assumir todos",
-    "success_message": "{count, plural, one {{count} chat assumido com sucesso!} other {{count} chats assumidos com sucesso!}}",
+    "success_message": "{count, plural, one {{count} chat assumido com sucesso} other {{count} chats assumidos com sucesso}}",
     "partial_success_message": "{success, plural, one {{success} chat assumido, {failed} falhou. Tente novamente.} other {{success} chats assumidos, {failed} falharam. Tente novamente.}}",
     "error_message": "Não foi possível assumir os chats, tente novamente"
   },

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -115,7 +115,7 @@
     "description": "Trage fișierul aici pentru a-l trimite"
   },
   "waiting_for": {
-    "minutes": "1 minut de așteptare | {n} minute de așteptare"
+    "minutes": "{count, plural, one {1 minut de așteptare} few {{count} minute de așteptare} other {{count} de minute de așteptare}}"
   },
   "chat_message": {
     "reply_message": {
@@ -148,7 +148,9 @@
     "inactive_close_message": "Mesaj de încheiere",
     "bulk_message": "Mesaj în masă trimis de {sender}"
   },
+  "inactive_room_tooltip": "{minutes, plural, one {Conversația a atins limita de inactivitate de {minutes} minut.} few {Conversația a atins limita de inactivitate de {minutes} minute.} other {Conversația a atins limita de inactivitate de {minutes} de minute.}}",
   "reply": "Răspuns",
+  "chats_count": "{count, plural, one {{count} chat} few {{count} chaturi} other {{count} de chaturi}}",
   "attention": "Avertisment",
   "updates_saved": "Actualizări salvate",
   "updated_info": "Informații actualizate",
@@ -171,7 +173,7 @@
   "transfer_all_selected_chats": "Transferă toate chaturile selectate",
   "take_over_all_selected_chats_tooltip": "Preia toate chaturile selectate",
   "end_all_selected_chats_tooltip": "Închide toate chaturile selectate",
-  "number_of_chats_selected": "{count} chat selectat | {count} chaturi selectate",
+  "number_of_chats_selected": "{count, plural, one {{count} chat selectat} few {{count} chaturi selectate} other {{count} de chaturi selectate}}",
   "image": "Imagine",
   "image_preview": {
     "count": "Imaginea {current} din {total}",
@@ -575,7 +577,7 @@
       "close": "Închide vizualizarea",
       "assume_chat": "Preia doar acest chat",
       "assume_chat_question": "Preiei chatul cu {contact}?",
-      "assume_chat_question_description": "Sigur dorești să preiei chatul cu {contact}?<br /><br />Dacă confirmi, vei elimina chatul de la reprezentantul actual și vei fi responsabil pentru acesta.",
+      "assume_chat_question_description": "Ești sigur că vrei să preiei chatul cu {contact}?<br /><br />Dacă confirmi, vei fi responsabil de acesta și va fi eliminat de la reprezentantul curent.",
       "assume_chat_confirmation": "Dacă confirmi, acest chat va fi transferat de la {viewedAgent} către tine"
     }
   },
@@ -622,7 +624,7 @@
     "by_tag": "Filtrează după etichetă",
     "by_tags": "Filtrează după etichete",
     "by_agent": "Filtrează după reprezentant",
-    "by_date": "Filtrează după @.lower:dată",
+    "by_date": "Filtrează după dată",
     "clear_all": "Elimină filtrele",
     "dates": {
       "today": "Astăzi",
@@ -638,7 +640,7 @@
   },
   "pagination": "{from} – {to} din {total}",
   "contact": "Contact",
-  "unread_messages": "{count, plural, one {{count} mesaj necitit} other {{count} mesaje necitite}}",
+  "unread_messages": "{count, plural, one {{count} mesaj necitit} few {{count} mesaje necitite} other {{count} de mesaje necitite}}",
   "unnamed_contact": "Contact fără nume",
   "unnamed_agent": "Reprezentant fără nume",
   "no_agent_assigned": "Niciun reprezentant atribuit",
@@ -716,8 +718,11 @@
   "transfer_contact": "Transferă contact | Transferă contacte",
   "bulk_transfer": {
     "transfer_selected_contacts": "Transferă contactele selectate",
-    "agent_transfer_success": "Contactul a fost transferat cu succes reprezentantului {agent} | Contactele au fost transferate cu succes reprezentantului {agent}",
-    "queue_transfer_success": "Contactul a fost transferat cu succes în coada {queue} | Contactele au fost transferate cu succes în coada {queue}",
+    "selected_chats_count": "{count, plural, one {{count} chat este selectat pentru transfer} few {{count} chaturi sunt selectate pentru transfer} other {{count} de chaturi sunt selectate pentru transfer}}",
+    "success_message": "{count, plural, one {{count} chat transferat cu succes} few {{count} chaturi transferate cu succes} other {{count} de chaturi transferate cu succes}}",
+    "partial_success_message": "{success, plural, one {{success} chat transferat, {failed} eșuat. Încearcă din nou.} few {{success} chaturi transferate, {failed} eșuate. Încearcă din nou.} other {{success} de chaturi transferate, {failed} eșuate. Încearcă din nou.}}",
+    "agent_transfer_success": "{count, plural, one {Contactul a fost transferat reprezentantului {agent}} few {Contactele au fost transferate reprezentantului {agent}} other {Contactele au fost transferate reprezentantului {agent}}}",
+    "queue_transfer_success": "{count, plural, one {Contactul a fost transferat cu succes în coada {queue}} few {Contactele au fost transferate cu succes în coada {queue}} other {Contactele au fost transferate cu succes în coada {queue}}}",
     "error": "Eroare la transferul contactelor. Încearcă din nou.",
     "disclaimer": {
       "transfer_to_other_sector": "Când transferi chatul într-o coadă dintr-un alt departament, etichetele vor fi eliminate",
@@ -728,19 +733,19 @@
   "bulk_close": {
     "close_selected_contacts": "Închide contactele selectate",
     "confirm_close_selected": "Sigur vrei să închizi contactele selectate?",
-    "success_message": "{count} chat s-a încheiat cu succes | {count} chaturi s-au încheiat cu succes",
-    "partial_success_message": "{success} chat încheiat, {failed} eșuat. Încearcă din nou. | {success} chaturi încheiate, {failed} eșuate. Încearcă din nou.",
+    "success_message": "{count, plural, one {{count} chat finalizat cu succes} few {{count} chaturi finalizate cu succes} other {{count} de chaturi finalizate cu succes}}",
+    "partial_success_message": "{success, plural, one {{success} chat încheiat, {failed} eșuat. Încearcă din nou.} few {{success} chaturi încheiate, {failed} eșuate. Încearcă din nou.} other {{success} de chaturi încheiate, {failed} eșuate. Încearcă din nou.}}",
     "error_message": "Eroare la închiderea chaturilor. Încearcă din nou.",
     "end_all_selected_chats": "Închide toate chaturile selectate",
     "sector_tag": "Departamentul {current} din {total}",
-    "chats_count_sector": "{count} chat · departament {sector} | {count} chaturi · departament {sector}",
+    "chats_count_sector": "{count, plural, one {{count} chat · departament {sector}} few {{count} chaturi · departament {sector}} other {{count} de chaturi · departament {sector}}}",
     "required_tags_title": "Etichetele sunt necesare pentru a închide chaturile în departamentul {sector}",
-    "required_tags_description": "Dacă selectezi unul sau mai multe etichete de mai jos, acestea vor fi aplicate la {count} chat şi vor înlocui orice etichete existente.",
+    "required_tags_description": "{count, plural, one {Dacă selectezi orice etichetă de mai jos, aceasta va fi aplicată acestui chat și va înlocui orice etichete existente.} few {Dacă selectezi orice etichetă de mai jos, aceasta va fi aplicată la {count} chaturi și va înlocui orice etichete existente.} other {Dacă selectezi orice etichetă de mai jos, aceasta va fi aplicată la {count} de chaturi și va înlocui orice etichete existente.}}",
     "next_sector": "Următorul departament",
     "end_all_chats": "Închide toate ({count} chaturi)",
     "back": "Înapoi",
     "optional_tags_title": "Etichetele nu sunt necesare pentru a închide chaturile în departamentul {sector}",
-    "optional_tags_description": "Dacă selectezi una sau mai multe etichete de mai jos, acestea vor fi aplicate la {count} chat și vor înlocui orice etichete existente. | Dacă selectezi una sau mai multe etichete de mai jos, acestea vor fi aplicate la {count} chaturi și vor înlocui orice etichete existente.",
+    "optional_tags_description": "{count, plural, one {Dacă selectezi orice etichetă de mai jos, aceasta va fi aplicată acestui chat și va înlocui orice etichete existente.} few {Dacă selectezi orice etichetă de mai jos, aceasta va fi aplicată la {count} chaturi și va înlocui orice etichete existente.} other {Dacă selectezi orice etichetă de mai jos, aceasta va fi aplicată la {count} de chaturi și va înlocui orice etichete existente.}}",
     "no_tags_in_sector": "Nu există etichete de selectat în acest departament"
   },
   "close_chat": {
@@ -748,11 +753,11 @@
   },
   "bulk_take": {
     "title": "Preia toate chaturile selectate",
-    "selected_chats_count": "{count} chat este selectat pentru preluare. | {count} chaturi sunt selectate pentru preluare.",
+    "selected_chats_count": "{count, plural, one {{count} chat este selectat pentru preluare} few {{count} chaturi sunt selectate pentru preluare} other {{count} de chaturi sunt selectate pentru preluare}}",
     "confirm_take_over_selected": "Sigur vrei să preiei toate chaturile selectate?",
     "take_over_all": "Preia toate",
-    "success_message": "{count} chat preluat cu succes | {count} chaturi preluate cu succes",
-    "partial_success_message": "{success} chat preluat, {failed} nereușite. Încearcă din nou. | {success} chaturi preluate, {failed} nereușite. Încearcă din nou.",
+    "success_message": "{count, plural, one {{count} chat preluat cu succes} few {{count} chaturi preluate cu succes} other {{count} de chaturi preluate cu succes}}",
+    "partial_success_message": "{success, plural, one {{success} chat preluat, {failed} eșuat. Încearcă din nou.} few {{success} chaturi preluate, {failed} eșuate. Încearcă din nou.} other {{success} de chaturi preluate, {failed} eșuate. Încearcă din nou.}}",
     "error_message": "Eroare la preluarea chaturilor. Încearcă din nou."
   },
   "contact_info": {
@@ -788,7 +793,7 @@
     }
   },
   "discussions": {
-    "title": "Discuție | Discuții",
+    "title": "Discuție",
     "start_discussion": {
       "title": "Începe discuția",
       "form": {
@@ -887,9 +892,9 @@
   "send_media": "Trimite media",
   "send_photo_or_video": "Trimite fotografie sau video",
   "photo_or_video": "Fotografie sau video",
-  "send_docs": "Trimite document | Trimite document | Trimite documente",
+  "send_docs": "",
   "doc": "Document",
-  "send_images": "Trimite imagine | Trimite imagini",
+  "send_images": "",
   "quick_message": "Mesaje rapide",
   "flows": "Fluxuri",
   "flows_trigger": {
@@ -901,7 +906,7 @@
       "trigger_time": "Ora declanșării"
     },
     "groups": "Grupuri ({length})",
-    "group_contacts": "{n} contact | {n} contacte",
+    "group_contacts": "{n, plural, one {{n} contact} few {{n} contacte} other {{n} de contacte}}",
     "letter_group": "{letter} ({length})",
     "letter_group_unnamed": "Fără nume ({length})",
     "unnamed_contact": "Contact fără nume",
@@ -938,7 +943,7 @@
       "confirmation_helper": "Asigură-te că fiecare câmp este mapat corect. Mesajul tău va fi personalizat pentru fiecare contact selectat pe baza acestor mapări.",
       "confirmation_checkbox": "Am verificat și sunt gata să o trimit",
       "next_template": "Șablonul următor",
-      "send_templates": "{count, plural, one {Trimite ({count} șablon)} other {Trimite ({count} șabloane)}}",
+      "send_templates": "{count, plural, one {Trimite ({count} șablon)} few {Trimite ({count} șabloane)} other {Trimite ({count} de șabloane)}}",
       "local_variables": {
         "contact_name": "Nume contact",
         "contact_urn": "Telefon de contact",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -715,7 +715,7 @@
   "chat_closed_by": {
     "agent": "Chat închis de reprezentant"
   },
-  "transfer_contact": "Transferă contact | Transferă contacte",
+  "transfer_contact": "{count, plural, one {Transferă contactul} few {Transferă contactele} other {Transferă contactele}}",
   "bulk_transfer": {
     "transfer_selected_contacts": "Transferă contactele selectate",
     "selected_chats_count": "{count, plural, one {{count} chat este selectat pentru transfer} few {{count} chaturi sunt selectate pentru transfer} other {{count} de chaturi sunt selectate pentru transfer}}",

--- a/src/utils/i18n/__tests__/icuMessageCompiler.spec.js
+++ b/src/utils/i18n/__tests__/icuMessageCompiler.spec.js
@@ -88,13 +88,13 @@ describe('icuMessageCompiler plural messages', () => {
         success: 1,
         failed: 2,
       }),
-    ).toBe('1 chat taken over, 2 failed. Please try again.');
+    ).toBe('1 chat taken over, 2 failed. Try again.');
     expect(
       compileMessage(en.bulk_take.partial_success_message, {
         success: 3,
         failed: 1,
       }),
-    ).toBe('3 chats taken over, 1 failed. Please try again.');
+    ).toBe('3 chats taken over, 1 failed. Try again.');
   });
 
   it('formats plural with named variable n', () => {
@@ -129,7 +129,7 @@ describe('icuMessageCompiler plural messages', () => {
       'The conversation has reached the 1-minute inactivity limit.',
     );
     expect(compileMessage(en.inactive_room_tooltip, { minutes: 30 })).toBe(
-      'The conversation has reached the 30-minutes inactivity limit.',
+      'The conversation has reached the 30-minute inactivity limit.',
     );
   });
 

--- a/src/views/Settings/Forms/__tests__/__snapshots__/ExtraOptions.spec.js.snap
+++ b/src/views/Settings/Forms/__tests__/__snapshots__/ExtraOptions.spec.js.snap
@@ -4,9 +4,9 @@ exports[`SectorExtraOptions > Should match the snapshot 1`] = `
 "<section data-v-8e9664ba="" class="sector-extra-options-form">
   <section data-v-8e9664ba="" class="switchs">
     <h2 data-v-8e9664ba="" class="switchs__title" data-testid="switchs-title">Additional options</h2>
-    <unnnic-switch-stub data-v-8e9664ba="" size="small" label="" option="" helper="" textleft="" textright="Triggering message templates" disabled="false" modelvalue="false" class="margin-y-space-1" data-testid="config-switch"></unnnic-switch-stub>
+    <unnnic-switch-stub data-v-8e9664ba="" size="small" label="" option="" helper="" textleft="" textright="Trigger message templates" disabled="false" modelvalue="false" class="margin-y-space-1" data-testid="config-switch"></unnnic-switch-stub>
     <section data-v-8e9664ba="" class="switchs__container">
-      <unnnic-switch-stub data-v-8e9664ba="" size="small" label="" option="" helper="Each message exchanged will have the name of the agent who is answering." textleft="" textright="Use signature" disabled="false" modelvalue="false" class="margin-y-space-1" data-testid="config-switch"></unnnic-switch-stub>
+      <unnnic-switch-stub data-v-8e9664ba="" size="small" label="" option="" helper="Each message exchanged will have the name of the representative who is answering." textleft="" textright="Use signature" disabled="false" modelvalue="false" class="margin-y-space-1" data-testid="config-switch"></unnnic-switch-stub>
     </section>
     <unnnic-switch-stub data-v-8e9664ba="" size="small" label="" option="" helper="When active, it allows representatives to edit the custom fields of the contact in the &quot;All Information&quot; section." textleft="" textright="Allow representatives to edit custom fields" disabled="false" modelvalue="false" class="margin-y-space-1" data-testid="config-switch"></unnnic-switch-stub>
   </section>


### PR DESCRIPTION
Applies Crowdin-approved ICU MessageFormat locale updates for [LOC-26932](https://vtex.atlassian.net/browse/LOC-26932), sourced from [#912](https://github.com/weni-ai/chats-webapp/pull/912).

Updates en/es/pt_br/ro strings (plurals and related chat UI copy) to match the reviewed Crowdin export.