### PR TITLE
[ENGAGE-9117] fix: Improve custom fields reactivity and immutability in ContactInfo

### DIFF
--- a/src/components/chats/ContactInfo/index.vue
+++ b/src/components/chats/ContactInfo/index.vue
@@ -387,7 +387,7 @@ export default {
     },
 
     computedCustomFields() {
-      const customFields = this.room?.custom_fields || {};
+      const customFields = { ...(this.customFields || {}) };
       const roomService = this.contactService;
       if (roomService?.length > 0) {
         customFields[this.$t('service')] = roomService;
@@ -459,9 +459,16 @@ export default {
       immediate: true,
       handler(newRoom) {
         if (newRoom) {
-          this.customFields = this.room.custom_fields;
+          this.customFields = { ...(this.room.custom_fields || {}) };
           this.loadAllTags();
           this.loadRoomTags();
+        }
+      },
+    },
+    'room.custom_fields': {
+      handler(newCustomFields) {
+        if (newCustomFields) {
+          this.customFields = { ...newCustomFields };
         }
       },
     },
@@ -475,15 +482,17 @@ export default {
 
   async created() {
     const { closedRoom, room } = this;
+    const sourceRoom =
+      closedRoom && Object.keys(closedRoom).length > 0 ? closedRoom : room;
 
-    this.customFields = (closedRoom || room)?.custom_fields;
+    this.customFields = { ...(sourceRoom?.custom_fields || {}) };
 
     if (this.isHistory) {
       return;
     }
 
     if (
-      moment((closedRoom || room).contact.created_on).format('YYYY-MM-DD') <
+      moment(sourceRoom.contact.created_on).format('YYYY-MM-DD') <
       moment().format('YYYY-MM-DD')
     ) {
       this.contactHaveHistory = true;
@@ -594,12 +603,22 @@ export default {
 
       if (currentCustomFieldValue) {
         if (
-          currentCustomFieldValue !== this.customFields[currentCustomFieldKey]
+          currentCustomFieldValue !== this.customFields?.[currentCustomFieldKey]
         ) {
           Room.updateCustomFields(this.room.uuid, this.currentCustomField);
         }
 
-        this.customFields[currentCustomFieldKey] = currentCustomFieldValue;
+        this.customFields = {
+          ...(this.customFields || {}),
+          [currentCustomFieldKey]: currentCustomFieldValue,
+        };
+
+        if (this.room) {
+          this.room.custom_fields = {
+            ...(this.room.custom_fields || {}),
+            [currentCustomFieldKey]: currentCustomFieldValue,
+          };
+        }
       }
 
       this.updateCurrentCustomField({});

--- a/src/components/chats/ContactInfo/index.vue
+++ b/src/components/chats/ContactInfo/index.vue
@@ -343,7 +343,6 @@ export default {
       handler(newRoom) {
         if (newRoom) {
           this.customFields = { ...(this.room.custom_fields || {}) };
-          this.loadRoomTags();
         }
       },
     },


### PR DESCRIPTION
### Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Tests
- [ ] Chore
- [ ] Locales

### Why
Custom fields were being mutated directly by reference, which caused stale or inconsistent state when the room changed or when fields were updated. This led to incorrect values being displayed or saved in the contact info panel.

### What Changed
- `customFields` is now always initialized as a shallow copy (`{ ...source }`) instead of a direct reference to `room.custom_fields`, preventing unintended mutations.
- Added a dedicated watcher for `room.custom_fields` to keep `customFields` in sync when the room's custom fields change externally.
- When saving a custom field, `customFields` is updated immutably using object spread instead of direct property assignment.
- `room.custom_fields` is also updated immutably after a successful save to keep the room object consistent.
- The `closedRoom` fallback logic now explicitly checks if `closedRoom` has keys before using it, avoiding issues with empty objects being treated as valid sources.
- Optional chaining (`?.`) is used when accessing `customFields` keys during comparison to guard against null/undefined states.