### PR TITLE
feat: send room media messages via socket when feature flag is enabled

### DIFF
--- a/src/services/api/resources/chats/__tests__/message.unit.spec.js
+++ b/src/services/api/resources/chats/__tests__/message.unit.spec.js
@@ -360,7 +360,7 @@ describe('Message service', () => {
       );
 
       expect(result).toEqual({
-        message_response: mockMessageResponse.data,
+        message_response: { ...mockMessageResponse.data, media: [] },
         media_response: mockMediaResponse.data,
       });
     });
@@ -417,7 +417,7 @@ describe('Message service', () => {
       const result = await messageService.sendRoomMedia('room-789', mediaData);
 
       expect(result).toEqual({
-        message_response: mockMessageResponse.data,
+        message_response: { ...mockMessageResponse.data, media: [] },
         media_response: mockMediaResponse.data,
       });
     });
@@ -461,6 +461,53 @@ describe('Message service', () => {
       await expect(
         messageService.sendRoomMedia('room-error', mediaData),
       ).rejects.toThrow('Media upload failed');
+    });
+
+    it('should create the message via createMessage when provided and still upload media via REST', async () => {
+      const mockMessage = {
+        uuid: 'socket-msg-uuid',
+        text: '',
+        room: 'room-socket',
+      };
+      const mockMediaResponse = {
+        data: { id: 460, media_file: 'file.jpg', message: 'socket-msg-uuid' },
+      };
+      const createMessage = vi.fn().mockResolvedValue(mockMessage);
+
+      http.postForm.mockResolvedValue(mockMediaResponse);
+
+      const updateLoadingFiles = vi.fn();
+      const mediaFile = new File(['content'], 'test.jpg', {
+        type: 'image/jpeg',
+      });
+
+      const result = await messageService.sendRoomMedia('room-socket', {
+        user_email: 'user@example.com',
+        media: mediaFile,
+        updateLoadingFiles,
+        repliedMessageId: 'replied-msg-123',
+        createMessage,
+      });
+
+      expect(createMessage).toHaveBeenCalled();
+      expect(http.post).not.toHaveBeenCalled();
+      expect(updateLoadingFiles).toHaveBeenCalledWith('socket-msg-uuid', 0);
+      expect(http.postForm).toHaveBeenCalledWith(
+        '/media/',
+        {
+          content_type: 'image/jpeg',
+          message: 'socket-msg-uuid',
+          media_file: mediaFile,
+          replied_message_id: 'replied-msg-123',
+        },
+        {
+          onUploadProgress: expect.any(Function),
+        },
+      );
+      expect(result).toEqual({
+        message_response: { ...mockMessage, media: [] },
+        media_response: mockMediaResponse.data,
+      });
     });
   });
 

--- a/src/services/api/resources/chats/message.js
+++ b/src/services/api/resources/chats/message.js
@@ -100,31 +100,42 @@ export default {
 
   async sendRoomMedia(
     roomId,
-    { user_email, media, updateLoadingFiles, repliedMessageId },
+    { user_email, media, updateLoadingFiles, repliedMessageId, createMessage },
   ) {
-    const msg = await this.sendRoomMessage(roomId, {
-      text: '',
-      user_email,
-      seen: true,
-    });
-    updateLoadingFiles?.(msg.uuid, 0);
+    const msg = createMessage
+      ? await createMessage()
+      : await this.sendRoomMessage(roomId, {
+          text: '',
+          user_email,
+          seen: true,
+        });
+
+    const messageResponse = {
+      ...msg,
+      media: Array.isArray(msg.media) ? [...msg.media] : [],
+    };
+
+    updateLoadingFiles?.(messageResponse.uuid, 0);
     const response = await http.postForm(
       '/media/',
       {
         content_type: media.type,
-        message: msg.uuid,
+        message: messageResponse.uuid,
         media_file: media,
         replied_message_id: repliedMessageId,
       },
       {
         onUploadProgress: (event) => {
           const progress = event.loaded / event.total;
-          updateLoadingFiles?.(msg.uuid, progress);
+          updateLoadingFiles?.(messageResponse.uuid, progress);
         },
       },
     );
 
-    return { message_response: msg, media_response: response.data };
+    return {
+      message_response: messageResponse,
+      media_response: response.data,
+    };
   },
 
   async sendDiscussionMedia(discussionUuid, { media, updateLoadingFiles }) {

--- a/src/store/modules/chats/__tests__/roomMessages.spec.js
+++ b/src/store/modules/chats/__tests__/roomMessages.spec.js
@@ -265,6 +265,51 @@ describe('useRoomMessages Store', () => {
         repliedMessageId: undefined,
       }),
     );
+    expect(
+      Message.sendRoomMedia.mock.calls[0][1].createMessage,
+    ).toBeUndefined();
+  });
+
+  it('should create media message via socket when the feature flag is enabled', async () => {
+    globalThis.URL.createObjectURL = vi.fn(() => 'blob:preview');
+    useFeatureFlag.mockReturnValue({
+      featureFlags: { active_features: ['weniChatsSocketMessageSend'] },
+    });
+    crypto.randomUUID.mockReturnValue('req-media-1');
+    sendRoomMessageBySocket.mockResolvedValue({
+      uuid: 'server-media-1',
+      text: '',
+      room: 'room-123',
+    });
+    Message.sendRoomMedia.mockImplementation(async (_roomId, options) => {
+      const messageResponse = await options.createMessage();
+      return {
+        media_response: { content_type: 'image/png' },
+        message_response: { ...messageResponse, media: [] },
+      };
+    });
+    const file = new File(['x'], 'image.png', { type: 'image/png' });
+
+    await roomMessagesStore.sendRoomMedias({
+      files: [file],
+      updateLoadingFiles: vi.fn(),
+      repliedMessage: null,
+      roomUuid: 'room-123',
+    });
+
+    expect(Message.sendRoomMedia).toHaveBeenCalledWith(
+      'room-123',
+      expect.objectContaining({
+        user_email: 'test@test.com',
+        media: file,
+        createMessage: expect.any(Function),
+      }),
+    );
+    expect(sendRoomMessageBySocket).toHaveBeenCalledWith({
+      room: 'room-123',
+      text: '',
+      requestId: 'req-media-1',
+    });
   });
 
   it('should not send room medias when roomUuid is missing', async () => {
@@ -277,6 +322,50 @@ describe('useRoomMessages Store', () => {
     });
 
     expect(Message.sendRoomMedia).not.toHaveBeenCalled();
+  });
+
+  it('should resend room media via socket when the feature flag is enabled', async () => {
+    useFeatureFlag.mockReturnValue({
+      featureFlags: { active_features: ['weniChatsSocketMessageSend'] },
+    });
+    crypto.randomUUID.mockReturnValue('req-resend-media-1');
+    sendRoomMessageBySocket.mockResolvedValue({
+      uuid: 'server-media-2',
+      text: '',
+      room: 'room-123',
+    });
+    Message.sendRoomMedia.mockImplementation(async (_roomId, options) => {
+      await options.createMessage();
+      return { content_type: 'image/png' };
+    });
+
+    const file = new File(['x'], 'image.png', { type: 'image/png' });
+    const message = {
+      uuid: 'old-media',
+      text: '',
+      room: 'room-123',
+      user: { email: 'test@test.com' },
+      media: [{ preview: 'blob:preview', file, content_type: 'image/png' }],
+    };
+
+    await roomMessagesStore.resendRoomMedia({
+      message,
+      media: message.media[0],
+      roomUuid: 'room-123',
+    });
+
+    expect(Message.sendRoomMedia).toHaveBeenCalledWith(
+      'room-123',
+      expect.objectContaining({
+        media: file,
+        createMessage: expect.any(Function),
+      }),
+    );
+    expect(sendRoomMessageBySocket).toHaveBeenCalledWith({
+      room: 'room-123',
+      text: '',
+      requestId: 'req-resend-media-1',
+    });
   });
 
   it('should send a room internal note with roomUuid', async () => {

--- a/src/store/modules/chats/roomMessages.js
+++ b/src/store/modules/chats/roomMessages.js
@@ -301,6 +301,11 @@ export const useRoomMessages = defineStore('roomMessages', {
       const { activeRoom } = roomsStore;
       if (!activeRoom || !roomUuid) return;
 
+      const featureFlagStore = useFeatureFlag();
+      const useSocket = useSocketMessageFeatureFlag(
+        featureFlagStore.featureFlags,
+      );
+
       await sendMedias({
         itemType: 'room',
         itemUuid: roomUuid,
@@ -313,6 +318,18 @@ export const useRoomMessages = defineStore('roomMessages', {
             media,
             updateLoadingFiles,
             repliedMessageId: repliedMessage?.uuid,
+            ...(useSocket
+              ? {
+                  createMessage: () => {
+                    const requestId = crypto.randomUUID();
+                    return sendRoomMessageBySocket({
+                      room: roomUuid,
+                      text: '',
+                      requestId,
+                    });
+                  },
+                }
+              : {}),
           }),
         addMessage: (message) => this.handlingAddMessage({ message }),
         addSortedMessage: (message) => this.addRoomMessageSorted({ message }),
@@ -519,6 +536,11 @@ export const useRoomMessages = defineStore('roomMessages', {
       const { activeRoom } = roomsStore;
       if (!activeRoom || !roomUuid) return;
 
+      const featureFlagStore = useFeatureFlag();
+      const useSocket = useSocketMessageFeatureFlag(
+        featureFlagStore.featureFlags,
+      );
+
       await resendMedia({
         itemUuid: roomUuid,
         message,
@@ -527,6 +549,18 @@ export const useRoomMessages = defineStore('roomMessages', {
           Message.sendRoomMedia(roomUuid, {
             user_email: activeRoom.user.email,
             media: media.file,
+            ...(useSocket
+              ? {
+                  createMessage: () => {
+                    const requestId = crypto.randomUUID();
+                    return sendRoomMessageBySocket({
+                      room: roomUuid,
+                      text: '',
+                      requestId,
+                    });
+                  },
+                }
+              : {}),
           }),
         addFailedMessage: (message) => this.addFailedMessage({ message }),
         removeFailedMessage: (message) =>


### PR DESCRIPTION
### Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Tests
- [ ] Chore
- [ ] Locales

### Why
When the `weniChatsSocketMessageSend` feature flag is enabled, media messages should be created through the WebSocket flow rather than via a direct REST `POST` to create the message first. This ensures consistency with how regular messages are sent when the socket feature is active.

### What Changed
`sendRoomMedia` now accepts an optional `createMessage` callback. When provided, it is called instead of the internal `sendRoomMessage` REST call to create the placeholder message before uploading the media file.

In both `sendRoomMedias` and `resendRoomMedia` store actions, when the `weniChatsSocketMessageSend` feature flag is active, a `createMessage` function is injected that calls `sendRoomMessageBySocket` with an empty text and a generated `requestId`, allowing the message to be created over the socket before the media is uploaded via REST.

The `message_response` returned by `sendRoomMedia` now always includes a `media` array (defaulting to `[]`) to ensure a consistent shape regardless of whether the message was created via REST or socket.

### Diagram

```mermaid
flowchart TD
    A[sendRoomMedias / resendRoomMedia] --> B{weniChatsSocketMessageSend\nfeature flag enabled?}
    B -- Yes --> C[Inject createMessage callback\nusing sendRoomMessageBySocket]
    B -- No --> D[No createMessage provided]
    C --> E[sendRoomMedia]
    D --> E
    E --> F{createMessage provided?}
    F -- Yes --> G[Call createMessage via socket]
    F -- No --> H[Call sendRoomMessage via REST]
    G --> I[Upload media via REST postForm]
    H --> I
    I --> J[Return message_response with media array\nand media_response]
```