### PR TITLE
[ENGAGE-9073 - 3] feat: Add bulk quick message send progress tracking with store, WebSocket listener, and toast notifications

### DIFF
--- a/src/components/chats/QuickMessages/QuickMessageBulkForm.vue
+++ b/src/components/chats/QuickMessages/QuickMessageBulkForm.vue
@@ -31,6 +31,7 @@
         data-testid="quick-message-bulk-cancel-button"
         :text="$t('cancel')"
         type="tertiary"
+        :disabled="isSending"
         @click="emit('close')"
       />
       <UnnnicButton
@@ -42,9 +43,21 @@
           })
         "
         :disabled="!canSend"
+        :loading="isSending"
         @click="handleSend"
       />
     </footer>
+
+    <ModalProgressBar
+      v-if="isSending || !!sendingUuid"
+      data-testid="quick-message-bulk-progress-modal"
+      :modelValue="percentageSent"
+      :title="
+        $t('quick_messages.bulk.sending', {
+          count: totalToSend || selectedContactsCount,
+        })
+      "
+    />
   </section>
 </template>
 
@@ -53,6 +66,10 @@ import { computed, ref } from 'vue';
 import { storeToRefs } from 'pinia';
 
 import { useRooms } from '@/store/modules/chats/rooms';
+import { useBulkQuickMessageSend } from '@/store/modules/chats/bulkQuickMessageSend';
+
+import ModalProgressBar from '@/components/chats/BulkMessage/ModalProgressBar.vue';
+import QuickMessageService from '@/services/api/resources/chats/quickMessage';
 
 import i18n from '@/plugins/i18n';
 
@@ -60,18 +77,23 @@ defineOptions({
   name: 'QuickMessageBulkForm',
 });
 
-defineProps({
+const props = defineProps({
   quickMessage: {
     type: Object,
     default: null,
   },
 });
 
-const emit = defineEmits(['close', 'send']);
+const emit = defineEmits(['close']);
 
 const { t } = i18n.global;
 const roomsStore = useRooms();
 const { agentRooms } = storeToRefs(roomsStore);
+
+const bulkQuickMessageSendStore = useBulkQuickMessageSend();
+const { isSending, sendingUuid, percentageSent, totalToSend } = storeToRefs(
+  bulkQuickMessageSendStore,
+);
 
 const selectedContacts = ref(['all']);
 const agreeToSend = ref(false);
@@ -100,7 +122,9 @@ const selectedContactsCount = computed(() => {
 });
 
 const canSend = computed(() => {
-  return agreeToSend.value && selectedContactsCount.value > 0;
+  return (
+    agreeToSend.value && selectedContactsCount.value > 0 && !isSending.value
+  );
 });
 
 const updateSelectedContacts = (contacts) => {
@@ -108,13 +132,28 @@ const updateSelectedContacts = (contacts) => {
 };
 
 const handleSend = async () => {
-  if (!canSend.value) return;
+  if (!canSend.value || !props.quickMessage?.text) return;
 
-  const rooms = selectedContacts.value.includes('all')
+  const contacts = selectedContacts.value.includes('all')
     ? null
     : selectedContacts.value;
 
-  emit('send', { rooms });
+  try {
+    isSending.value = true;
+    const { status, uuid } = await QuickMessageService.sendBulk({
+      text: props.quickMessage.text,
+      contacts,
+    });
+
+    if (status === 'PROCESSING') {
+      bulkQuickMessageSendStore.sendingUuid = uuid;
+    } else {
+      isSending.value = false;
+    }
+  } catch (error) {
+    console.error('Error sending quick message in bulk', error);
+    isSending.value = false;
+  }
 };
 </script>
 

--- a/src/components/chats/QuickMessages/index.vue
+++ b/src/components/chats/QuickMessages/index.vue
@@ -19,7 +19,6 @@
       <QuickMessageBulkForm
         :quickMessage="messageToSendInBulk"
         @close="closeBulkForm"
-        @send="handleBulkSend"
       />
     </AsideSlotTemplateSection>
 
@@ -101,8 +100,6 @@ import QuickMessageBulkForm from './QuickMessageBulkForm.vue';
 
 import { useQuickMessages } from '@/store/modules/chats/quickMessages';
 import { useQuickMessageShared } from '@/store/modules/chats/quickMessagesShared';
-
-import QuickMessageService from '@/services/api/resources/chats/quickMessage';
 
 export default {
   name: 'QuickMessages',
@@ -258,13 +255,6 @@ export default {
     closeBulkForm() {
       this.showBulkForm = false;
       this.messageToSendInBulk = null;
-    },
-    handleBulkSend({ rooms }) {
-      QuickMessageService.sendBulk({
-        text: this.messageToSendInBulk.text,
-        contacts: rooms,
-      });
-      // TODO: handle success and open progress
     },
   },
 };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1052,7 +1052,19 @@
         "helper": "Only contacts in service can receive this message",
         "label": "Contacts"
       },
-      "send": "{count, plural, =0 {Send to all (0 contacts)} one {Send to all ({count} contact)} other {Send to all ({count} contacts)}}"
+      "send": "{count, plural, =0 {Send to all (0 contacts)} one {Send to all ({count} contact)} other {Send to all ({count} contacts)}}",
+      "sending": "{count, plural, one {Sending the message to {count} contact} other {Sending the message to {count} contacts}}",
+      "toast": {
+        "error": {
+          "message": "Couldn't send the message. Try again."
+        },
+        "partial_success": {
+          "message": "{success, plural, one {Message sent to {success} contact, {failed} failed.} other {Message sent to {success} contacts, {failed} failed.}}"
+        },
+        "success": {
+          "message": "{count, plural, one {Message sent to {count} contact} other {Message sent to {count} contacts}}"
+        }
+      }
     }
   },
   "discard": "Discard",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1054,7 +1054,19 @@
         "helper": "Solo los contactos en atención pueden recibir este mensaje",
         "label": "Contactos"
       },
-      "send": "{count, plural, =0 {Enviar a todos (0 contactos)} one {Enviar a todos ({count} contacto)} other {Enviar a todos ({count} contactos)}}"
+      "send": "{count, plural, =0 {Enviar a todos (0 contactos)} one {Enviar a todos ({count} contacto)} other {Enviar a todos ({count} contactos)}}",
+      "sending": "{count, plural, one {Enviando el mensaje a {count} contacto} other {Enviando el mensaje a {count} contactos}}",
+      "toast": {
+        "error": {
+          "message": "No se pudo enviar el mensaje. Inténtalo de nuevo."
+        },
+        "partial_success": {
+          "message": "{success, plural, one {Mensaje enviado a {success} contacto, {failed} falló.} other {Mensaje enviado a {success} contactos, {failed} fallaron.}}"
+        },
+        "success": {
+          "message": "{count, plural, one {Mensaje enviado a {count} contacto} other {Mensaje enviado a {count} contactos}}"
+        }
+      }
     }
   },
   "discard": "Descartar",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -1057,7 +1057,19 @@
         "helper": "Apenas contatos em atendimento podem receber esta mensagem",
         "label": "Contatos"
       },
-      "send": "{count, plural, =0 {Enviar para todos (0 contatos)} one {Enviar para todos ({count} contato)} other {Enviar para todos ({count} contatos)}}"
+      "send": "{count, plural, =0 {Enviar para todos (0 contatos)} one {Enviar para todos ({count} contato)} other {Enviar para todos ({count} contatos)}}",
+      "sending": "{count, plural, one {Enviando a mensagem para {count} contato} other {Enviando a mensagem para {count} contatos}}",
+      "toast": {
+        "error": {
+          "message": "Não foi possível enviar a mensagem. Tente novamente."
+        },
+        "partial_success": {
+          "message": "{success, plural, one {Mensagem enviada para {success} contato, {failed} falhou.} other {Mensagem enviada para {success} contatos, {failed} falharam.}}"
+        },
+        "success": {
+          "message": "{count, plural, one {Mensagem enviada para {count} contato} other {Mensagem enviada para {count} contatos}}"
+        }
+      }
     }
   },
   "discard": "Descartar",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -990,7 +990,19 @@
         "helper": "Doar contactele în curs de deservire pot primi acest mesaj",
         "label": "Contacte"
       },
-      "send": "{count, plural, =0 {Trimite către toate (0 contacte)} one {Trimite către toate ({count} contact)} other {Trimite către toate ({count} contacte)}}"
+      "send": "{count, plural, =0 {Trimite către toate (0 contacte)} one {Trimite către toate ({count} contact)} other {Trimite către toate ({count} contacte)}}",
+      "sending": "{count, plural, one {Se trimite mesajul către {count} contact} few {Se trimite mesajul către {count} contacte} other {Se trimite mesajul către {count} de contacte}}",
+      "toast": {
+        "error": {
+          "message": "Nu s-a putut trimite mesajul. Încearcă din nou."
+        },
+        "partial_success": {
+          "message": "{success, plural, one {Mesaj trimis către {success} contact, {failed} eșuat.} few {Mesaj trimis către {success} contacte, {failed} eșuate.} other {Mesaj trimis către {success} de contacte, {failed} eșuate.}}"
+        },
+        "success": {
+          "message": "{count, plural, one {Mesaj trimis către {count} contact} few {Mesaj trimis către {count} contacte} other {Mesaj trimis către {count} de contacte}}"
+        }
+      }
     }
   },
   "discard": "Șterge",

--- a/src/services/api/websocket/listeners/bulkQuickMessage/__tests__/progressUpdate.unit.spec.js
+++ b/src/services/api/websocket/listeners/bulkQuickMessage/__tests__/progressUpdate.unit.spec.js
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+
+import progressUpdate from '../progressUpdate';
+import { useBulkQuickMessageSend } from '@/store/modules/chats/bulkQuickMessageSend';
+
+vi.mock('@weni/unnnic-system', async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    UnnnicToastManager: {
+      ...mod.UnnnicToastManager,
+      success: vi.fn(),
+      error: vi.fn(),
+      attention: vi.fn(),
+    },
+  };
+});
+
+describe('bulkQuickMessage progressUpdate', () => {
+  let store;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    store = useBulkQuickMessageSend();
+    store.clearData();
+    store.sendingUuid = 'send-uuid';
+    vi.clearAllMocks();
+  });
+
+  it('should ignore updates for a different uuid', () => {
+    progressUpdate(
+      {
+        uuid: 'other-uuid',
+        total_to_send: 10,
+        percentage: 50,
+      },
+      {},
+    );
+
+    expect(store.totalToSend).toBe(0);
+    expect(store.percentageSent).toBe(0);
+  });
+
+  it('should update progress totals for the current sending uuid', () => {
+    progressUpdate(
+      {
+        uuid: 'send-uuid',
+        total_to_send: 200,
+        percentage: 50.12,
+        success_total: 100,
+        failed_total: 10,
+      },
+      {},
+    );
+
+    expect(store.totalToSend).toBe(200);
+    expect(store.percentageSent).toBe(50.12);
+  });
+
+  it('should call showFinishedAlert when percentage reaches 100', () => {
+    const showFinishedAlert = vi
+      .spyOn(store, 'showFinishedAlert')
+      .mockImplementation(() => {});
+
+    progressUpdate(
+      {
+        uuid: 'send-uuid',
+        total_to_send: 10,
+        percentage: 100,
+        success_total: 8,
+        failed_total: 2,
+      },
+      {},
+    );
+
+    expect(store.successTotal).toBe(8);
+    expect(store.failedTotal).toBe(2);
+    expect(showFinishedAlert).toHaveBeenCalled();
+  });
+});

--- a/src/services/api/websocket/listeners/bulkQuickMessage/index.js
+++ b/src/services/api/websocket/listeners/bulkQuickMessage/index.js
@@ -1,0 +1,5 @@
+import progressUpdate from './progressUpdate';
+
+export default {
+  progressUpdate,
+};

--- a/src/services/api/websocket/listeners/bulkQuickMessage/progressUpdate.js
+++ b/src/services/api/websocket/listeners/bulkQuickMessage/progressUpdate.js
@@ -1,0 +1,25 @@
+import { storeToRefs } from 'pinia';
+
+import { useBulkQuickMessageSend } from '@/store/modules/chats/bulkQuickMessageSend';
+
+export default (data, _ctx) => {
+  const bulkQuickMessageSendStore = useBulkQuickMessageSend();
+  const {
+    sendingUuid,
+    percentageSent,
+    successTotal,
+    failedTotal,
+    totalToSend,
+  } = storeToRefs(bulkQuickMessageSendStore);
+
+  if (sendingUuid.value !== data.uuid) return;
+
+  totalToSend.value = data.total_to_send;
+  percentageSent.value = data.percentage;
+
+  if (data.percentage === 100) {
+    successTotal.value = data.success_total;
+    failedTotal.value = data.failed_total;
+    bulkQuickMessageSendStore.showFinishedAlert();
+  }
+};

--- a/src/services/api/websocket/listeners/index.js
+++ b/src/services/api/websocket/listeners/index.js
@@ -4,6 +4,7 @@ import statusListener from './status';
 import customStatusListener from './customStatus';
 import mediaListener from './media';
 import bulkMessageListener from './bulkMessage';
+import bulkQuickMessageListener from './bulkQuickMessage';
 
 export default ({ ws, app }) => {
   const createListener = (callback) => (payload) => {
@@ -55,5 +56,10 @@ export default ({ ws, app }) => {
   ws.on(
     'bulk_message_progress_update',
     createListener(bulkMessageListener.progressUpdate),
+  );
+
+  ws.on(
+    'bulk_quick_message_send_progress',
+    createListener(bulkQuickMessageListener.progressUpdate),
   );
 };

--- a/src/store/modules/chats/__tests__/bulkQuickMessageSend.spec.js
+++ b/src/store/modules/chats/__tests__/bulkQuickMessageSend.spec.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { UnnnicToastManager } from '@weni/unnnic-system';
+
+import { useBulkQuickMessageSend } from '@/store/modules/chats/bulkQuickMessageSend';
+
+vi.mock('@weni/unnnic-system', async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    UnnnicToastManager: {
+      ...mod.UnnnicToastManager,
+      success: vi.fn(),
+      error: vi.fn(),
+      attention: vi.fn(),
+    },
+  };
+});
+
+describe('useBulkQuickMessageSend', () => {
+  let store;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    store = useBulkQuickMessageSend();
+    vi.clearAllMocks();
+  });
+
+  describe('clearData', () => {
+    it('should reset all sending state', () => {
+      store.sendingUuid = 'uuid-1';
+      store.isSending = true;
+      store.successTotal = 5;
+      store.failedTotal = 2;
+      store.totalToSend = 7;
+      store.percentageSent = 80;
+
+      store.clearData();
+
+      expect(store.sendingUuid).toBeNull();
+      expect(store.isSending).toBe(false);
+      expect(store.successTotal).toBe(0);
+      expect(store.failedTotal).toBe(0);
+      expect(store.totalToSend).toBe(0);
+      expect(store.percentageSent).toBe(0);
+    });
+  });
+
+  describe('showFinishedAlert', () => {
+    it('should show success toast when all messages succeed', () => {
+      store.totalToSend = 10;
+      store.successTotal = 10;
+      store.failedTotal = 0;
+      store.sendingUuid = 'uuid-1';
+      store.isSending = true;
+
+      store.showFinishedAlert();
+
+      expect(UnnnicToastManager.success).toHaveBeenCalled();
+      expect(UnnnicToastManager.error).not.toHaveBeenCalled();
+      expect(UnnnicToastManager.attention).not.toHaveBeenCalled();
+      expect(store.sendingUuid).toBeNull();
+      expect(store.isSending).toBe(false);
+    });
+
+    it('should show error toast when all messages fail', () => {
+      store.totalToSend = 5;
+      store.successTotal = 0;
+      store.failedTotal = 5;
+
+      store.showFinishedAlert();
+
+      expect(UnnnicToastManager.error).toHaveBeenCalled();
+      expect(UnnnicToastManager.success).not.toHaveBeenCalled();
+      expect(UnnnicToastManager.attention).not.toHaveBeenCalled();
+    });
+
+    it('should show attention toast for partial success', () => {
+      store.totalToSend = 10;
+      store.successTotal = 7;
+      store.failedTotal = 3;
+
+      store.showFinishedAlert();
+
+      expect(UnnnicToastManager.attention).toHaveBeenCalled();
+      expect(store.sendingUuid).toBeNull();
+    });
+  });
+});

--- a/src/store/modules/chats/bulkQuickMessageSend.ts
+++ b/src/store/modules/chats/bulkQuickMessageSend.ts
@@ -1,0 +1,63 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import { UnnnicToastManager } from '@weni/unnnic-system';
+
+import i18n from '@/plugins/i18n';
+
+export const useBulkQuickMessageSend = defineStore(
+  'bulkQuickMessageSend',
+  () => {
+    const sendingUuid = ref<string | null>(null);
+    const isSending = ref<boolean>(false);
+    const successTotal = ref<number>(0);
+    const failedTotal = ref<number>(0);
+    const totalToSend = ref<number>(0);
+    const percentageSent = ref<number>(0);
+
+    const clearData = () => {
+      sendingUuid.value = null;
+      isSending.value = false;
+      successTotal.value = 0;
+      failedTotal.value = 0;
+      totalToSend.value = 0;
+      percentageSent.value = 0;
+    };
+
+    const showFinishedAlert = () => {
+      if (successTotal.value === totalToSend.value && failedTotal.value === 0) {
+        UnnnicToastManager.success(
+          i18n.global.t('quick_messages.bulk.toast.success.message', {
+            count: totalToSend.value,
+          }),
+        );
+      } else if (
+        failedTotal.value === totalToSend.value &&
+        successTotal.value === 0
+      ) {
+        UnnnicToastManager.error(
+          i18n.global.t('quick_messages.bulk.toast.error.message'),
+        );
+      } else {
+        UnnnicToastManager.attention(
+          i18n.global.t('quick_messages.bulk.toast.partial_success.message', {
+            success: successTotal.value,
+            failed: failedTotal.value,
+          }),
+        );
+      }
+
+      clearData();
+    };
+
+    return {
+      clearData,
+      showFinishedAlert,
+      sendingUuid,
+      isSending,
+      successTotal,
+      failedTotal,
+      totalToSend,
+      percentageSent,
+    };
+  },
+);


### PR DESCRIPTION
### Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Tests
- [ ] Chore
- [x] Locales

### Why
The bulk quick message send flow previously had no feedback mechanism after triggering a send — it lacked progress tracking, loading states, and result notifications. This change completes the feature by wiring up real-time progress updates and user-facing feedback.

### What Changed
- Moved the bulk send logic from `QuickMessages/index.vue` into `QuickMessageBulkForm.vue`, where it now calls `QuickMessageService.sendBulk` directly and manages the sending state.
- Created a new `useBulkQuickMessageSend` Pinia store to track `isSending`, `sendingUuid`, `percentageSent`, `totalToSend`, `successTotal`, and `failedTotal`.
- Added a `ModalProgressBar` to `QuickMessageBulkForm.vue` that displays while a bulk send is in progress.
- Disabled the cancel button and send button while sending is in progress.
- Added a new WebSocket listener (`bulk_quick_message_send_progress`) that updates the store's progress state in real time via `progressUpdate.js`.
- Added `showFinishedAlert` to the store, which fires a success, error, or partial-success toast via `UnnnicToastManager` when the send completes (percentage reaches 100).
- Added localization keys for `sending`, `toast.success`, `toast.error`, and `toast.partial_success` across all supported locales (en, es, pt_br, ro).
- Added unit tests for the `useBulkQuickMessageSend` store and the `progressUpdate` WebSocket listener.

### Diagram

```mermaid
flowchart TD
    A[User clicks Send in QuickMessageBulkForm] --> B[QuickMessageService.sendBulk called]
    B --> C{status === PROCESSING?}
    C -- Yes --> D[Store sendingUuid set, ModalProgressBar shown]
    C -- No --> E[isSending set to false]
    D --> F[WebSocket: bulk_quick_message_send_progress]
    F --> G[progressUpdate listener updates store]
    G --> H{percentage === 100?}
    H -- Yes --> I[showFinishedAlert called]
    I --> J{Result type?}
    J -- All success --> K[Success toast]
    J -- All failed --> L[Error toast]
    J -- Partial --> M[Attention toast]
    I --> N[clearData resets store]
```