### PR TITLE
feat: add ContactInfo redesign layout behind assisted sales feature flag

### DIFF
--- a/src/components/chats/ContactInfo/Redesign/AboutContactCard.vue
+++ b/src/components/chats/ContactInfo/Redesign/AboutContactCard.vue
@@ -1,0 +1,279 @@
+<template>
+  <section
+    class="about-contact-card"
+    data-testid="about-contact-card"
+  >
+    <header class="about-contact-card__header">
+      <h3 class="about-contact-card__title">
+        {{ $t('contact_info.title') }}
+      </h3>
+
+      <section
+        v-if="isLinkedToOtherAgent"
+        class="about-contact-card__linked-contact"
+      >
+        <UnnnicIcon
+          icon="info"
+          size="ant"
+          scheme="fg-warning"
+        />
+        <p>
+          {{
+            $t('contact_info.linked_contact', {
+              name: linkedUserName,
+            })
+          }}
+        </p>
+      </section>
+
+      <section
+        v-else-if="showLinkSwitch"
+        class="about-contact-card__sync-contact"
+      >
+        <UnnnicSwitch
+          :modelValue="isLinkedUser"
+          size="small"
+          :textRight="
+            isLinkedUser
+              ? $t('contact_info.switch_disassociate_contact')
+              : $t('contact_info.switch_associate_contact')
+          "
+          @update:model-value="emit('update:isLinkedUser', $event)"
+        />
+        <UnnnicToolTip
+          enabled
+          :text="$t('contact_info.switch_tooltip')"
+          side="left"
+        >
+          <UnnnicIconSvg
+            icon="info"
+            scheme="fg-base"
+            size="sm"
+          />
+        </UnnnicToolTip>
+      </section>
+    </header>
+
+    <section class="about-contact-card__content">
+      <p
+        v-if="isOnline"
+        class="about-contact-card__status"
+      >
+        {{ $t('status.online') }}
+      </p>
+      <p
+        v-if="lastMessageText"
+        class="about-contact-card__last-message"
+      >
+        {{ lastMessageText }}
+      </p>
+
+      <section class="about-contact-card__item">
+        <section class="about-contact-card__item-content">
+          <p class="about-contact-card__item-title">{{ $t('name') }}:</p>
+          <p class="about-contact-card__item-value">
+            {{ contactName }}
+          </p>
+        </section>
+        <CopyValueButton :value="contactName" />
+      </section>
+
+      <section class="about-contact-card__item">
+        <section class="about-contact-card__item-content">
+          <p class="about-contact-card__item-title">
+            {{ contactPlatform || $t('URN') }}:
+          </p>
+          <p class="about-contact-card__item-value">
+            {{ contactNumber }}
+          </p>
+        </section>
+        <CopyValueButton :value="contactNumber" />
+      </section>
+
+      <Transition name="expand-with-fade">
+        <section
+          v-if="hasCustomFields && openCustomFields"
+          class="about-contact-card__custom-fields"
+        >
+          <CustomField
+            v-for="(value, key) in customFields"
+            :key="key"
+            :title="key"
+            :description="value"
+            :isEditable="canEditCustomFields"
+            :isCurrent="isCurrentCustomField(key)"
+            :value="currentCustomField?.[key]"
+            @update-current-custom-field="
+              emit('update-current-custom-field', $event)
+            "
+            @save-value="emit('save-value')"
+          />
+        </section>
+      </Transition>
+
+      <section
+        v-if="hasCustomFields"
+        class="about-contact-card__slide"
+      >
+        <UnnnicIcon
+          :icon="openCustomFields ? 'expand_less' : 'expand_more'"
+          clickable
+          @click="emit('update:openCustomFields', !openCustomFields)"
+        />
+      </section>
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import CustomField from '../CustomField.vue';
+import CopyValueButton from '../CopyValueButton.vue';
+
+defineOptions({
+  name: 'AboutContactCard',
+});
+
+type CustomFields = Record<string, string>;
+
+const props = withDefaults(
+  defineProps<{
+    contactName?: string;
+    contactNumber?: string;
+    contactPlatform?: string;
+    isOnline?: boolean;
+    lastMessageText?: string;
+    customFields?: CustomFields;
+    currentCustomField?: CustomFields;
+    canEditCustomFields?: boolean;
+    openCustomFields?: boolean;
+    isLinkedUser?: boolean;
+    isLinkedToOtherAgent?: boolean;
+    linkedUserName?: string;
+    showLinkSwitch?: boolean;
+  }>(),
+  {
+    contactName: '',
+    contactNumber: '',
+    contactPlatform: '',
+    isOnline: false,
+    lastMessageText: '',
+    customFields: () => ({}),
+    currentCustomField: () => ({}),
+    canEditCustomFields: false,
+    openCustomFields: true,
+    isLinkedUser: false,
+    isLinkedToOtherAgent: false,
+    linkedUserName: '',
+    showLinkSwitch: false,
+  },
+);
+
+const emit = defineEmits<{
+  'update:isLinkedUser': [value: boolean];
+  'update:openCustomFields': [value: boolean];
+  'update-current-custom-field': [customField: CustomFields];
+  'save-value': [];
+}>();
+
+const hasCustomFields = computed(
+  () => Object.keys(props.customFields || {}).length > 0,
+);
+
+const isCurrentCustomField = (key: string): boolean => {
+  const currentKey = Object.keys(props.currentCustomField || {})?.[0];
+  return currentKey === key;
+};
+</script>
+
+<style lang="scss" scoped>
+@import '@/styles/animations';
+
+.about-contact-card {
+  display: flex;
+  flex-direction: column;
+  gap: $unnnic-space-3;
+  padding: $unnnic-space-4;
+  background-color: $unnnic-color-bg-base;
+  border: 1px solid $unnnic-color-border-base;
+  border-radius: $unnnic-radius-2;
+  overflow: hidden;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: $unnnic-space-2;
+  }
+
+  &__title {
+    font: $unnnic-font-emphasis;
+    color: $unnnic-color-fg-emphasized;
+  }
+
+  &__linked-contact {
+    display: flex;
+    align-items: center;
+    gap: $unnnic-space-1;
+    font: $unnnic-font-emphasis;
+    color: $unnnic-color-fg-warning;
+  }
+
+  &__sync-contact {
+    display: flex;
+    align-items: center;
+    gap: $unnnic-space-2;
+    flex-shrink: 0;
+
+    :deep(.unnnic-tooltip) {
+      display: flex;
+    }
+  }
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-1;
+  }
+
+  &__status,
+  &__item-value {
+    font: $unnnic-font-body;
+    color: $unnnic-color-fg-base;
+  }
+
+  &__last-message {
+    font: $unnnic-font-caption-2;
+    color: $unnnic-color-fg-base;
+  }
+
+  &__item {
+    display: flex;
+    align-items: center;
+    gap: $unnnic-space-2;
+
+    &-content {
+      display: flex;
+      align-items: center;
+      gap: $unnnic-space-1;
+    }
+
+    &-title {
+      font: $unnnic-font-emphasis;
+      color: $unnnic-color-fg-base;
+    }
+  }
+
+  &__custom-fields {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-1;
+  }
+
+  &__slide {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+}
+</style>

--- a/src/components/chats/ContactInfo/Redesign/AboutSupportCard.vue
+++ b/src/components/chats/ContactInfo/Redesign/AboutSupportCard.vue
@@ -1,0 +1,392 @@
+<template>
+  <section
+    class="about-support-card"
+    data-testid="about-support-card"
+  >
+    <header class="about-support-card__header">
+      <h3 class="about-support-card__title">
+        {{ $t('contact_info.about_support') }}
+      </h3>
+      <section class="about-support-card__header-buttons">
+        <UnnnicPopover
+          v-if="showAddTagButton"
+          :open="openDropdownTags"
+          @update:open="openDropdownTags = $event"
+        >
+          <UnnnicPopoverTrigger>
+            <UnnnicButton
+              iconLeft="add-1"
+              type="secondary"
+              size="small"
+            >
+              {{ $t('tag') }}
+            </UnnnicButton>
+          </UnnnicPopoverTrigger>
+          <UnnnicPopoverContent align="end">
+            <UnnnicInput
+              v-model="tagsFilter"
+              iconLeft="search"
+              :placeholder="$t('tags.search')"
+              class="about-support-card__tags-dropdown-input"
+            />
+            <section
+              ref="tagsListContainer"
+              class="about-support-card__tags-dropdown"
+            >
+              <UnnnicCheckbox
+                v-for="tag in allTags"
+                :key="tag.uuid"
+                :modelValue="
+                  roomTags.some((roomTag) => roomTag.uuid === tag.uuid)
+                "
+                :textRight="tag.name"
+                @change="handleTagClick(tag)"
+              />
+              <UnnnicIconLoading
+                v-if="isLoadingTags"
+                class="about-support-card__tags-loading"
+              />
+            </section>
+          </UnnnicPopoverContent>
+        </UnnnicPopover>
+        <UnnnicToolTip
+          enabled
+          :text="$t('discussions.start_discussion.title')"
+          side="left"
+        >
+          <UnnnicButton
+            v-if="!isViewMode && !isMobile"
+            iconCenter="communication"
+            size="small"
+            type="secondary"
+            @click="handleModalStartDiscussion()"
+          />
+        </UnnnicToolTip>
+      </section>
+    </header>
+
+    <section class="about-support-card__content">
+      <TagGroup
+        v-if="roomTags?.length > 0"
+        class="about-support-card__tag-group"
+        :modelValue="roomTags"
+        :tags="roomTags"
+        selectable
+        :useCloseClick="tagUseCloseOnClick"
+        @close="handleTagClick"
+      />
+      <ProtocolText :protocol="contactProtocol" />
+      <CsatInfo
+        v-if="closedRoom?.uuid"
+        :note="closedRoom?.csat_note"
+        :commentary="closedRoom?.csat_commentary"
+      />
+      <DiscussionsSession v-if="isHistory" />
+    </section>
+
+    <ModalStartDiscussion
+      v-if="isShowModalStartDiscussion"
+      v-model="isShowModalStartDiscussion"
+      @close="handleModalStartDiscussion()"
+    />
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch, onUnmounted, useTemplateRef } from 'vue';
+import { storeToRefs } from 'pinia';
+import { useInfiniteScroll, watchDebounced } from '@vueuse/core';
+import isMobileLib from 'is-mobile';
+
+import TagGroup from '@/components/TagGroup.vue';
+import ProtocolText from '../ProtocolText.vue';
+import CsatInfo from '../CsatInfo.vue';
+import DiscussionsSession from '../DiscussionsSession.vue';
+import ModalStartDiscussion from '../ModalStartDiscussion.vue';
+
+import { useRooms } from '@/store/modules/chats/rooms';
+import Queues from '@/services/api/resources/settings/queue';
+import Room from '@/services/api/resources/chats/room';
+
+defineOptions({
+  name: 'AboutSupportCard',
+});
+
+type RoomTag = {
+  uuid: string;
+  name: string;
+};
+
+type ClosedRoom = {
+  uuid?: string;
+  protocol?: string;
+  csat_note?: number;
+  csat_commentary?: string;
+  [key: string]: unknown;
+};
+
+const props = withDefaults(
+  defineProps<{
+    closedRoom?: ClosedRoom;
+    isHistory?: boolean;
+    isViewMode?: boolean;
+  }>(),
+  {
+    closedRoom: () => ({}),
+    isHistory: false,
+    isViewMode: false,
+  },
+);
+
+const roomsStore = useRooms();
+const {
+  activeRoom: room,
+  activeRoomTags: roomTags,
+  activeRoomTagsNext: roomTagsNext,
+} = storeToRefs(roomsStore);
+
+const TAGS_PAGE_SIZE = 20;
+
+const openDropdownTags = ref(false);
+const allTags = ref<RoomTag[]>([]);
+const allTagsNext = ref('');
+const tagsFilter = ref('');
+const isLoadingTags = ref(false);
+const hasAvailableTags = ref(false);
+const isShowModalStartDiscussion = ref(false);
+const tagsListContainer = useTemplateRef<HTMLElement>('tagsListContainer');
+let loadTagsRequestId = 0;
+
+const isMobile = computed(() => isMobileLib());
+
+const canManageTags = computed(
+  () => !props.isHistory && !props.isViewMode && !!room.value?.user,
+);
+
+const showAddTagButton = computed(
+  () => canManageTags.value && hasAvailableTags.value,
+);
+
+const tagUseCloseOnClick = computed(
+  () => !props.isViewMode && !props.isHistory && !!room.value?.user,
+);
+
+const hideTagCloseIcon = computed(() =>
+  props.isViewMode || props.isHistory || !room.value?.user ? 'none' : 'flex',
+);
+
+const contactProtocol = computed(
+  () => (props.closedRoom || room.value)?.protocol || '',
+);
+
+const canLoadMoreTags = computed(
+  () => !!allTagsNext.value && !isLoadingTags.value,
+);
+
+async function loadAllTags({ reset = false }: { reset?: boolean } = {}) {
+  const { queue } = room.value || {};
+  if (!queue) return;
+  if (!reset && (isLoadingTags.value || !allTagsNext.value)) return;
+
+  const requestId = ++loadTagsRequestId;
+  isLoadingTags.value = true;
+
+  if (reset) {
+    allTags.value = [];
+    allTagsNext.value = '';
+  }
+
+  try {
+    const { results, next } = await Queues.tags(queue.uuid, {
+      limit: TAGS_PAGE_SIZE,
+      next: reset ? '' : allTagsNext.value,
+      search: tagsFilter.value,
+    });
+
+    if (requestId !== loadTagsRequestId) return;
+
+    allTags.value = reset ? results : allTags.value.concat(results);
+    allTagsNext.value = next || '';
+
+    if (!tagsFilter.value) {
+      hasAvailableTags.value = allTags.value.length > 0 || !!allTagsNext.value;
+    }
+  } catch (error) {
+    console.error('Error loading all tags', error);
+  } finally {
+    if (requestId === loadTagsRequestId) {
+      isLoadingTags.value = false;
+    }
+  }
+}
+
+async function loadRoomTags({ reset = false }: { reset?: boolean } = {}) {
+  try {
+    if (reset) {
+      roomTags.value = [];
+      roomTagsNext.value = '';
+    }
+
+    const roomUuid = props.closedRoom?.uuid || room.value?.uuid;
+    if (!roomUuid) return;
+
+    const { results, next } = await Room.getRoomTags(roomUuid, {
+      next: roomTagsNext.value,
+      limit: TAGS_PAGE_SIZE,
+    });
+    roomTags.value = roomTags.value.concat(results);
+    roomTagsNext.value = next;
+
+    if (roomTagsNext.value) {
+      await loadRoomTags();
+    }
+  } catch (error) {
+    console.error('Error loading room tags', error);
+  }
+}
+
+async function removeRoomTag(tag: RoomTag) {
+  try {
+    await Room.removeRoomTag(room.value.uuid, tag.uuid);
+    roomTags.value = roomTags.value.filter(
+      (roomTag: RoomTag) => roomTag.uuid !== tag.uuid,
+    );
+  } catch (error) {
+    console.log(error);
+  }
+}
+
+async function addRoomTag(tag: RoomTag) {
+  try {
+    await Room.addRoomTag(room.value.uuid, tag.uuid);
+    roomTags.value.push(tag);
+  } catch (error) {
+    console.log(error);
+  }
+}
+
+function handleTagClick(tag: RoomTag) {
+  if (!room.value?.user) return;
+
+  const hasSelectedTag = roomTags.value.some(
+    (roomTag: RoomTag) => roomTag.uuid === tag.uuid,
+  );
+
+  if (hasSelectedTag) {
+    removeRoomTag(tag);
+  } else {
+    addRoomTag(tag);
+  }
+}
+
+function handleModalStartDiscussion() {
+  isShowModalStartDiscussion.value = !isShowModalStartDiscussion.value;
+}
+
+useInfiniteScroll(
+  tagsListContainer,
+  () => {
+    loadAllTags();
+  },
+  {
+    distance: 40,
+    canLoadMore: () => canLoadMoreTags.value,
+  },
+);
+
+watch(
+  () => room.value?.uuid,
+  (newRoomUuid) => {
+    if (!newRoomUuid) return;
+
+    tagsFilter.value = '';
+    hasAvailableTags.value = false;
+    loadAllTags({ reset: true });
+    loadRoomTags({ reset: true });
+  },
+  { immediate: true },
+);
+
+watchDebounced(
+  tagsFilter,
+  () => {
+    if (!hasAvailableTags.value) return;
+    loadAllTags({ reset: true });
+  },
+  { debounce: 400 },
+);
+
+onUnmounted(() => {
+  roomTags.value = [];
+  roomTagsNext.value = '';
+});
+</script>
+
+<style lang="scss" scoped>
+.about-support-card {
+  display: flex;
+  flex-direction: column;
+  gap: $unnnic-space-3;
+  padding: $unnnic-space-4;
+  background-color: $unnnic-color-bg-base;
+  border: 1px solid $unnnic-color-border-base;
+  border-radius: $unnnic-radius-2;
+  overflow: hidden;
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-2;
+
+    :deep(.about-support-card__tag-group) {
+      margin-top: 0;
+
+      .unnnic-icon {
+        display: v-bind(hideTagCloseIcon);
+      }
+    }
+  }
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: $unnnic-space-2;
+
+    &-buttons {
+      display: flex;
+      align-items: center;
+      gap: $unnnic-space-2;
+      flex-shrink: 0;
+    }
+  }
+
+  &__title {
+    font: $unnnic-font-emphasis;
+    color: $unnnic-color-fg-emphasized;
+  }
+
+  &__tags-dropdown {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-6;
+    width: 100%;
+    height: 204px;
+    overflow-y: auto;
+    padding-right: $unnnic-space-2;
+
+    &-input {
+      margin-bottom: $unnnic-space-6;
+    }
+  }
+
+  &__tags-loading {
+    align-self: center;
+    margin-top: $unnnic-space-2;
+  }
+
+  :deep(.unnnic-tooltip) {
+    display: flex;
+  }
+}
+</style>

--- a/src/components/chats/ContactInfo/Redesign/AboutSupportCard.vue
+++ b/src/components/chats/ContactInfo/Redesign/AboutSupportCard.vue
@@ -246,21 +246,25 @@ async function loadRoomTags({ reset = false }: { reset?: boolean } = {}) {
 }
 
 async function removeRoomTag(tag: RoomTag) {
+  const previousTags = [...roomTags.value];
   try {
     await Room.removeRoomTag(room.value.uuid, tag.uuid);
     roomTags.value = roomTags.value.filter(
       (roomTag: RoomTag) => roomTag.uuid !== tag.uuid,
     );
   } catch (error) {
+    roomTags.value = previousTags;
     console.log(error);
   }
 }
 
 async function addRoomTag(tag: RoomTag) {
+  const previousTags = [...roomTags.value];
   try {
     await Room.addRoomTag(room.value.uuid, tag.uuid);
     roomTags.value.push(tag);
   } catch (error) {
+    roomTags.value = previousTags;
     console.log(error);
   }
 }

--- a/src/components/chats/ContactInfo/Redesign/Header.vue
+++ b/src/components/chats/ContactInfo/Redesign/Header.vue
@@ -1,0 +1,94 @@
+<template>
+  <header
+    class="contact-info-redesign-header"
+    data-testid="contact-info-redesign-header"
+  >
+    <UnnnicSegmentedControl
+      class="contact-info-redesign-header__segmented"
+      defaultValue="information"
+    >
+      <UnnnicSegmentedControlList>
+        <UnnnicSegmentedControlTrigger
+          value="desk_copilot"
+          disabled
+          data-testid="segmented-desk-copilot"
+        >
+          {{ $t('contact_info.header.desk_copilot') }}
+        </UnnnicSegmentedControlTrigger>
+        <UnnnicSegmentedControlTrigger
+          value="information"
+          data-testid="segmented-information"
+        >
+          {{ $t('contact_info.header.information') }}
+        </UnnnicSegmentedControlTrigger>
+      </UnnnicSegmentedControlList>
+    </UnnnicSegmentedControl>
+
+    <section class="contact-info-redesign-header__actions">
+      <UnnnicButton
+        v-if="showRefresh"
+        iconCenter="sync"
+        type="tertiary"
+        size="small"
+        :disabled="isRefreshDisabled"
+        data-testid="refresh-button"
+        @click="emit('refresh')"
+      />
+      <UnnnicButton
+        v-if="showClose"
+        iconCenter="close"
+        type="tertiary"
+        size="small"
+        data-testid="close-button"
+        @click="emit('close')"
+      />
+    </section>
+  </header>
+</template>
+
+<script setup lang="ts">
+defineOptions({
+  name: 'ContactInfoRedesignHeader',
+});
+
+withDefaults(
+  defineProps<{
+    showRefresh?: boolean;
+    showClose?: boolean;
+    isRefreshDisabled?: boolean;
+  }>(),
+  {
+    showRefresh: true,
+    showClose: true,
+    isRefreshDisabled: false,
+  },
+);
+
+const emit = defineEmits<{
+  refresh: [];
+  close: [];
+}>();
+</script>
+
+<style lang="scss" scoped>
+.contact-info-redesign-header {
+  display: flex;
+  align-items: center;
+  gap: $unnnic-space-2;
+  padding: $unnnic-space-2;
+  min-height: var(--chats-column-header-height, 57px);
+  background-color: $unnnic-color-bg-base;
+
+  &__segmented {
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    gap: $unnnic-space-2;
+    flex-shrink: 0;
+  }
+}
+</style>

--- a/src/components/chats/ContactInfo/Redesign/MediaTabs.vue
+++ b/src/components/chats/ContactInfo/Redesign/MediaTabs.vue
@@ -1,0 +1,166 @@
+<template>
+  <UnnnicTab
+    v-model="activeTab"
+    size="md"
+    :tabs="tabsKeys"
+    class="contact-info-redesign-media"
+    data-testid="contact-info-redesign-media"
+  >
+    <template
+      v-for="key in Object.keys(tabs)"
+      #[`tab-head-${key}`]
+      :key="`tab-head-${key}`"
+    >
+      {{ $t(tabs[key].name) }}
+    </template>
+
+    <template
+      v-for="key in Object.keys(tabs) as TabKey[]"
+      #[`tab-panel-${key}`]
+      :key="`tab-panel-${key}`"
+    >
+      <component
+        :is="tabs[key].component"
+        v-if="room?.uuid"
+        :data-testid="`tab-panel-${key}`"
+        v-bind="getComponentProps(key)"
+        v-on="getComponentEvents(key)"
+      />
+    </template>
+  </UnnnicTab>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onUnmounted, type Component } from 'vue';
+import NotesTabContent from './NotesTabContent.vue';
+import MediasContent from '../tabs/MediasContent.vue';
+import DocumentsContent from '../tabs/DocumentsContent.vue';
+import AudiosContent from '../tabs/AudiosContent.vue';
+import { useContactInfos } from '@/store/modules/chats/contactInfos';
+
+defineOptions({
+  name: 'ContactInfoRedesignMediaTabs',
+});
+
+type Room = {
+  uuid?: string;
+  [key: string]: unknown;
+};
+
+type ContactInfo = Record<string, unknown>;
+
+type TabKey = 'notes' | 'media' | 'docs' | 'audio';
+
+type TabPropName = 'room' | 'contactInfo' | 'history';
+
+type TabConfig = {
+  name: string;
+  component: Component;
+  props: TabPropName[];
+  events: Array<'loaded' | 'fullscreen'>;
+};
+
+type MediaItem = {
+  url: string;
+  [key: string]: unknown;
+};
+
+const props = withDefaults(
+  defineProps<{
+    room?: Room;
+    contactInfo?: ContactInfo;
+    history?: boolean;
+  }>(),
+  {
+    room: () => ({}),
+    contactInfo: () => ({}),
+    history: false,
+  },
+);
+
+const emit = defineEmits<{
+  fullscreen: [url: string, images: MediaItem[]];
+  'loaded-medias': [];
+}>();
+
+const contactInfosStore = useContactInfos();
+
+const activeTab = ref<TabKey>('notes');
+
+const tabs: Record<TabKey, TabConfig> = {
+  notes: {
+    name: 'notes',
+    component: NotesTabContent,
+    props: ['room'],
+    events: ['loaded'],
+  },
+  media: {
+    name: 'medias',
+    component: MediasContent,
+    props: ['room', 'contactInfo', 'history'],
+    events: ['fullscreen', 'loaded'],
+  },
+  docs: {
+    name: 'docs',
+    component: DocumentsContent,
+    props: ['room', 'contactInfo', 'history'],
+    events: ['loaded'],
+  },
+  audio: {
+    name: 'audios',
+    component: AudiosContent,
+    props: ['room', 'contactInfo', 'history'],
+    events: ['loaded'],
+  },
+};
+
+const tabsKeys = computed(() => Object.keys(tabs) as TabKey[]);
+
+const getComponentProps = (tabKey: TabKey) => {
+  const tab = tabs[tabKey];
+  const componentProps: Record<string, unknown> = {};
+
+  tab.props.forEach((propName) => {
+    if (propName in props) {
+      componentProps[propName] = props[propName];
+    }
+  });
+
+  return componentProps;
+};
+
+const getComponentEvents = (tabKey: TabKey) => {
+  const tab = tabs[tabKey];
+  const events: Record<string, (...args: unknown[]) => void> = {};
+
+  tab.events.forEach((eventName) => {
+    if (eventName === 'fullscreen') {
+      events.fullscreen = handleFullscreen as (...args: unknown[]) => void;
+    } else if (eventName === 'loaded') {
+      events.loaded = handleTabLoaded;
+    }
+  });
+
+  return events;
+};
+
+const handleFullscreen = (url: string, images: MediaItem[]) => {
+  emit('fullscreen', url, images);
+};
+
+const handleTabLoaded = () => {
+  emit('loaded-medias');
+};
+
+onUnmounted(() => {
+  contactInfosStore.clearAll();
+});
+</script>
+
+<style lang="scss" scoped>
+.contact-info-redesign-media {
+  :deep(.tab-content) {
+    gap: $unnnic-space-0;
+  }
+}
+</style>

--- a/src/components/chats/ContactInfo/Redesign/MediaTabs.vue
+++ b/src/components/chats/ContactInfo/Redesign/MediaTabs.vue
@@ -1,23 +1,24 @@
 <template>
-  <UnnnicTab
+  <UnnnicTabs
     v-model="activeTab"
-    size="md"
-    :tabs="tabsKeys"
+    defaultValue="notes"
     class="contact-info-redesign-media"
     data-testid="contact-info-redesign-media"
   >
-    <template
-      v-for="key in Object.keys(tabs)"
-      #[`tab-head-${key}`]
-      :key="`tab-head-${key}`"
-    >
-      {{ $t(tabs[key].name) }}
-    </template>
-
-    <template
-      v-for="key in Object.keys(tabs) as TabKey[]"
-      #[`tab-panel-${key}`]
-      :key="`tab-panel-${key}`"
+    <UnnnicTabsList>
+      <UnnnicTabsTrigger
+        v-for="key in tabsKeys"
+        :key="key"
+        :value="key"
+      >
+        {{ $t(tabs[key].name) }}
+      </UnnnicTabsTrigger>
+    </UnnnicTabsList>
+    <UnnnicTabsContent
+      v-for="key in tabsKeys"
+      :key="key"
+      :value="key"
+      class="contact-info-redesign-media__content"
     >
       <component
         :is="tabs[key].component"
@@ -26,8 +27,8 @@
         v-bind="getComponentProps(key)"
         v-on="getComponentEvents(key)"
       />
-    </template>
-  </UnnnicTab>
+    </UnnnicTabsContent>
+  </UnnnicTabs>
 </template>
 
 <script setup lang="ts">
@@ -159,8 +160,13 @@ onUnmounted(() => {
 
 <style lang="scss" scoped>
 .contact-info-redesign-media {
-  :deep(.tab-content) {
-    gap: $unnnic-space-0;
+  :deep(.unnnic-tabs-trigger) {
+    flex: 1;
+    justify-content: center;
+  }
+
+  &__content {
+    padding-top: $unnnic-space-3;
   }
 }
 </style>

--- a/src/components/chats/ContactInfo/Redesign/NoteCard.vue
+++ b/src/components/chats/ContactInfo/Redesign/NoteCard.vue
@@ -1,0 +1,147 @@
+<template>
+  <section
+    class="note-card"
+    data-testid="note-card"
+  >
+    <section
+      class="note-card__content"
+      @click="emit('click-note')"
+    >
+      <p
+        v-if="agentName"
+        class="note-card__agent-name"
+      >
+        {{ agentName }}
+      </p>
+      <p
+        v-if="formattedText"
+        class="note-card__text"
+        v-html="formattedText"
+      />
+    </section>
+    <UnnnicIcon
+      v-if="canDelete"
+      class="note-card__delete"
+      icon="delete"
+      size="ant"
+      scheme="fg-critical"
+      clickable
+      data-testid="note-card-delete"
+      @click="handleShowModalDeleteInternalNote()"
+    />
+    <ModalDeleteInternalNote
+      v-if="showModalDeleteInternalNote"
+      :modelValue="showModalDeleteInternalNote"
+      :noteUuid="noteUuid"
+      @update:model-value="handleShowModalDeleteInternalNote()"
+    />
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { storeToRefs } from 'pinia';
+import { useProfile } from '@/store/modules/profile';
+import { useRooms } from '@/store/modules/chats/rooms';
+import { formatMessageText } from '@/utils/string';
+import ModalDeleteInternalNote from '@/components/chats/chat/ChatMessages/ChatMessageInternalNote/ModalDeleteInternalNote.vue';
+
+defineOptions({
+  name: 'NoteCard',
+});
+
+type NoteUser = {
+  name?: string;
+  email?: string;
+};
+
+type InternalNote = {
+  uuid: string;
+  text?: string;
+  is_deletable?: boolean;
+  user?: NoteUser;
+};
+
+type NoteMessage = InternalNote & {
+  internal_note?: InternalNote;
+};
+
+const props = defineProps<{
+  message: NoteMessage;
+}>();
+
+const emit = defineEmits<{
+  'click-note': [];
+}>();
+
+const { me } = storeToRefs(useProfile());
+const { activeRoom } = storeToRefs(useRooms());
+
+const showModalDeleteInternalNote = ref(false);
+
+const note = computed(() => props.message.internal_note || props.message);
+
+const agentName = computed(() => note.value.user?.name || '');
+
+const agentEmail = computed(
+  () => props.message.internal_note?.user?.email || props.message.user?.email,
+);
+
+const formattedText = computed(() => formatMessageText(note.value.text || ''));
+
+const noteUuid = computed(() => note.value.uuid);
+
+const canDelete = computed(() => {
+  const isMeInternalNote = me.value?.email === agentEmail.value;
+  return (
+    isMeInternalNote && !!note.value.is_deletable && !activeRoom.value?.ended_at
+  );
+});
+
+function handleShowModalDeleteInternalNote() {
+  showModalDeleteInternalNote.value = !showModalDeleteInternalNote.value;
+}
+</script>
+
+<style lang="scss" scoped>
+.note-card {
+  display: flex;
+  align-items: center;
+  gap: $unnnic-space-1;
+  width: 100%;
+
+  &__content {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-1;
+    padding: $unnnic-space-2 $unnnic-space-4;
+    background-color: $unnnic-color-bg-yellow-plain;
+    border-radius: $unnnic-radius-2;
+    box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.1);
+    cursor: pointer;
+  }
+
+  &__agent-name {
+    font: $unnnic-font-emphasis;
+    color: $unnnic-color-fg-base;
+  }
+
+  &__text {
+    font: $unnnic-font-body;
+    color: $unnnic-color-fg-base;
+    word-break: break-word;
+    max-height: 80px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 4;
+  }
+
+  &__delete {
+    flex-shrink: 0;
+  }
+}
+</style>

--- a/src/components/chats/ContactInfo/Redesign/NotesTabContent.vue
+++ b/src/components/chats/ContactInfo/Redesign/NotesTabContent.vue
@@ -1,0 +1,86 @@
+<template>
+  <section
+    class="notes-tab-content"
+    data-testid="notes-tab-content"
+  >
+    <NoteCard
+      v-for="note in roomInternalNotes"
+      :key="note.uuid"
+      :message="note"
+      @click-note="handleInternalNoteClick(note)"
+    />
+  </section>
+</template>
+
+<script setup lang="ts">
+import { onMounted, onUnmounted } from 'vue';
+import { storeToRefs } from 'pinia';
+import NoteCard from './NoteCard.vue';
+import { useRoomMessages } from '@/store/modules/chats/roomMessages';
+import RoomNotes from '@/services/api/resources/chats/roomNotes';
+
+defineOptions({
+  name: 'NotesTabContent',
+});
+
+type Room = {
+  uuid?: string;
+  [key: string]: unknown;
+};
+
+type InternalNote = {
+  uuid: string;
+  text?: string;
+  [key: string]: unknown;
+};
+
+const props = withDefaults(
+  defineProps<{
+    room?: Room;
+  }>(),
+  {
+    room: () => ({}),
+  },
+);
+
+const emit = defineEmits<{
+  loaded: [];
+}>();
+
+const roomMessagesStore = useRoomMessages();
+const { toScrollNote, roomInternalNotes } = storeToRefs(roomMessagesStore);
+
+const loadInternalNotes = async () => {
+  try {
+    const response = await RoomNotes.getInternalNotes({
+      room: props.room.uuid,
+    });
+
+    roomInternalNotes.value = response.results;
+  } catch (error) {
+    console.error('Error loading internal notes:', error);
+    roomInternalNotes.value = [];
+  }
+};
+
+const handleInternalNoteClick = (note: InternalNote) => {
+  toScrollNote.value = note;
+};
+
+onMounted(async () => {
+  await loadInternalNotes();
+  emit('loaded');
+});
+
+onUnmounted(() => {
+  roomInternalNotes.value = [];
+});
+</script>
+
+<style lang="scss" scoped>
+.notes-tab-content {
+  display: flex;
+  flex-direction: column;
+  gap: $unnnic-space-3;
+}
+</style>

--- a/src/components/chats/ContactInfo/Redesign/__tests__/AboutContactCard.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/__tests__/AboutContactCard.spec.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, afterEach, beforeAll, afterAll } from 'vitest';
+import { mount, config } from '@vue/test-utils';
+import AboutContactCard from '../AboutContactCard.vue';
+import i18n from '@/plugins/i18n';
+
+beforeAll(() => {
+  config.global.plugins = (config.global.plugins || []).filter(
+    (plugin) => plugin !== i18n,
+  );
+});
+
+afterAll(() => {
+  if (config.global.plugins && !config.global.plugins.includes(i18n)) {
+    config.global.plugins.push(i18n);
+  }
+});
+
+const createWrapper = (props = {}) =>
+  mount(AboutContactCard, {
+    props: {
+      contactName: 'Aline',
+      contactNumber: '+5565469488148',
+      lastMessageText: 'Last message 10 days ago',
+      ...props,
+    },
+    global: {
+      mocks: {
+        $t: (key) => key,
+      },
+      stubs: {
+        UnnnicSwitch: true,
+        UnnnicToolTip: true,
+        UnnnicIcon: true,
+        UnnnicIconSvg: true,
+        CopyValueButton: true,
+        CustomField: true,
+      },
+    },
+  });
+
+describe('AboutContactCard', () => {
+  let wrapper;
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('renders contact name, number and last message', () => {
+    wrapper = createWrapper();
+
+    expect(wrapper.find('[data-testid="about-contact-card"]').exists()).toBe(
+      true,
+    );
+    expect(wrapper.text()).toContain('Aline');
+    expect(wrapper.text()).toContain('+5565469488148');
+    expect(wrapper.text()).toContain('Last message 10 days ago');
+  });
+
+  it('shows link switch when enabled', () => {
+    wrapper = createWrapper({ showLinkSwitch: true });
+
+    expect(wrapper.findComponent({ name: 'UnnnicSwitch' }).exists()).toBe(true);
+  });
+
+  it('emits open custom fields toggle', async () => {
+    wrapper = createWrapper({
+      customFields: { city: 'São Paulo' },
+      openCustomFields: true,
+    });
+
+    const icon = wrapper.findComponent({ name: 'UnnnicIcon' });
+    await icon.vm.$emit('click');
+
+    expect(wrapper.emitted('update:openCustomFields')).toBeTruthy();
+    expect(wrapper.emitted('update:openCustomFields')[0]).toEqual([false]);
+  });
+});

--- a/src/components/chats/ContactInfo/Redesign/__tests__/Header.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/__tests__/Header.spec.js
@@ -1,0 +1,97 @@
+import { describe, it, expect, afterEach, beforeAll, afterAll } from 'vitest';
+import { mount, config } from '@vue/test-utils';
+import Header from '../Header.vue';
+import i18n from '@/plugins/i18n';
+
+beforeAll(() => {
+  config.global.plugins = (config.global.plugins || []).filter(
+    (plugin) => plugin !== i18n,
+  );
+});
+
+afterAll(() => {
+  if (config.global.plugins && !config.global.plugins.includes(i18n)) {
+    config.global.plugins.push(i18n);
+  }
+});
+
+const createWrapper = (props = {}) =>
+  mount(Header, {
+    props,
+    global: {
+      mocks: {
+        $t: (key) => key,
+      },
+      stubs: {
+        UnnnicSegmentedControl: {
+          name: 'UnnnicSegmentedControl',
+          template: '<div class="unnnic-segmented-control"><slot /></div>',
+        },
+        UnnnicSegmentedControlList: {
+          name: 'UnnnicSegmentedControlList',
+          template: '<div class="unnnic-segmented-control-list"><slot /></div>',
+        },
+        UnnnicSegmentedControlTrigger: {
+          name: 'UnnnicSegmentedControlTrigger',
+          template:
+            '<button class="unnnic-segmented-control-trigger" :disabled="disabled" :data-testid="$attrs[\'data-testid\']"><slot /></button>',
+          props: ['value', 'disabled'],
+          inheritAttrs: false,
+        },
+        UnnnicButton: {
+          name: 'UnnnicButton',
+          template:
+            '<button class="unnnic-button" :data-testid="$attrs[\'data-testid\']" @click="$emit(\'click\')" />',
+          props: ['iconCenter', 'type', 'size', 'disabled'],
+          emits: ['click'],
+        },
+      },
+    },
+  });
+
+describe('ContactInfoRedesignHeader', () => {
+  let wrapper;
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('renders segmented control with desk copilot disabled and information active', () => {
+    wrapper = createWrapper();
+
+    expect(
+      wrapper.find('[data-testid="contact-info-redesign-header"]').exists(),
+    ).toBe(true);
+    expect(
+      wrapper.find('[data-testid="segmented-desk-copilot"]').exists(),
+    ).toBe(true);
+    expect(
+      wrapper
+        .find('[data-testid="segmented-desk-copilot"]')
+        .attributes('disabled'),
+    ).toBeDefined();
+    expect(wrapper.find('[data-testid="segmented-information"]').exists()).toBe(
+      true,
+    );
+  });
+
+  it('emits refresh and close events', async () => {
+    wrapper = createWrapper();
+
+    await wrapper.find('[data-testid="refresh-button"]').trigger('click');
+    await wrapper.find('[data-testid="close-button"]').trigger('click');
+
+    expect(wrapper.emitted('refresh')).toBeTruthy();
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+
+  it('hides refresh and close buttons when props disable them', () => {
+    wrapper = createWrapper({
+      showRefresh: false,
+      showClose: false,
+    });
+
+    expect(wrapper.find('[data-testid="refresh-button"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="close-button"]').exists()).toBe(false);
+  });
+});

--- a/src/components/chats/ContactInfo/Redesign/__tests__/NoteCard.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/__tests__/NoteCard.spec.js
@@ -1,0 +1,108 @@
+import {
+  describe,
+  it,
+  expect,
+  afterEach,
+  beforeAll,
+  afterAll,
+  vi,
+} from 'vitest';
+import { mount, config } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
+import NoteCard from '../NoteCard.vue';
+import i18n from '@/plugins/i18n';
+
+vi.mock('@/utils/string', () => ({
+  formatMessageText: (text) => text,
+}));
+
+beforeAll(() => {
+  config.global.plugins = (config.global.plugins || []).filter(
+    (plugin) => plugin !== i18n,
+  );
+});
+
+afterAll(() => {
+  if (config.global.plugins && !config.global.plugins.includes(i18n)) {
+    config.global.plugins.push(i18n);
+  }
+});
+
+const mockNote = {
+  uuid: 'note-1',
+  text: 'Internal note: Problem solved',
+  is_deletable: true,
+  user: {
+    name: 'Representative name',
+    email: 'agent@weni.ai',
+  },
+};
+
+const createWrapper = (props = {}, piniaState = {}) =>
+  mount(NoteCard, {
+    props: {
+      message: mockNote,
+      ...props,
+    },
+    global: {
+      plugins: [
+        createTestingPinia({
+          createSpy: vi.fn,
+          initialState: {
+            profile: {
+              me: { email: 'agent@weni.ai' },
+            },
+            rooms: {
+              activeRoom: { ended_at: null },
+            },
+            ...piniaState,
+          },
+        }),
+      ],
+      mocks: {
+        $t: (key) => key,
+      },
+      stubs: {
+        UnnnicIcon: {
+          name: 'UnnnicIcon',
+          template:
+            '<button class="unnnic-icon" :data-testid="$attrs[\'data-testid\']" @click="$emit(\'click\')" />',
+          props: ['icon', 'size', 'scheme', 'clickable'],
+          emits: ['click'],
+        },
+        ModalDeleteInternalNote: true,
+      },
+    },
+  });
+
+describe('NoteCard', () => {
+  let wrapper;
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('renders agent name and note text', () => {
+    wrapper = createWrapper();
+
+    expect(wrapper.find('[data-testid="note-card"]').exists()).toBe(true);
+    expect(wrapper.text()).toContain('Representative name');
+    expect(wrapper.text()).toContain('Internal note: Problem solved');
+  });
+
+  it('emits click-note when content is clicked', async () => {
+    wrapper = createWrapper();
+
+    await wrapper.find('.note-card__content').trigger('click');
+
+    expect(wrapper.emitted('click-note')).toBeTruthy();
+  });
+
+  it('shows delete icon when the note is deletable by current user', () => {
+    wrapper = createWrapper();
+
+    expect(wrapper.find('[data-testid="note-card-delete"]').exists()).toBe(
+      true,
+    );
+  });
+});

--- a/src/components/chats/ContactInfo/Redesign/__tests__/NotesTabContent.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/__tests__/NotesTabContent.spec.js
@@ -1,0 +1,99 @@
+import {
+  describe,
+  it,
+  expect,
+  afterEach,
+  beforeAll,
+  afterAll,
+  vi,
+} from 'vitest';
+import { mount, config, flushPromises } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
+import NotesTabContent from '../NotesTabContent.vue';
+import RoomNotes from '@/services/api/resources/chats/roomNotes';
+import i18n from '@/plugins/i18n';
+
+vi.mock('@/services/api/resources/chats/roomNotes', () => ({
+  default: {
+    getInternalNotes: vi.fn(() => Promise.resolve({ results: [] })),
+  },
+}));
+
+beforeAll(() => {
+  config.global.plugins = (config.global.plugins || []).filter(
+    (plugin) => plugin !== i18n,
+  );
+});
+
+afterAll(() => {
+  if (config.global.plugins && !config.global.plugins.includes(i18n)) {
+    config.global.plugins.push(i18n);
+  }
+});
+
+const mockNotes = [
+  {
+    uuid: 'note-1',
+    text: 'Note 1',
+    user: { name: 'Agent', email: 'a@weni.ai' },
+  },
+];
+
+const createWrapper = () =>
+  mount(NotesTabContent, {
+    props: {
+      room: { uuid: 'room-123' },
+    },
+    global: {
+      plugins: [
+        createTestingPinia({
+          createSpy: vi.fn,
+          initialState: {
+            roomMessages: {
+              toScrollNote: null,
+              roomInternalNotes: [],
+            },
+          },
+        }),
+      ],
+      mocks: {
+        $t: (key) => key,
+      },
+      stubs: {
+        NoteCard: true,
+      },
+    },
+  });
+
+describe('NotesTabContent', () => {
+  let wrapper;
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  it('loads internal notes and emits loaded', async () => {
+    RoomNotes.getInternalNotes.mockResolvedValue({ results: mockNotes });
+    wrapper = createWrapper();
+
+    await flushPromises();
+
+    expect(RoomNotes.getInternalNotes).toHaveBeenCalledWith({
+      room: 'room-123',
+    });
+    expect(wrapper.emitted('loaded')).toBeTruthy();
+  });
+
+  it('renders note cards from store', async () => {
+    RoomNotes.getInternalNotes.mockResolvedValue({ results: mockNotes });
+    wrapper = createWrapper();
+    await flushPromises();
+
+    const store = wrapper.vm.$pinia.state.value.roomMessages;
+    store.roomInternalNotes = mockNotes;
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.findAllComponents({ name: 'NoteCard' }).length).toBe(1);
+  });
+});

--- a/src/components/chats/ContactInfo/Redesign/index.vue
+++ b/src/components/chats/ContactInfo/Redesign/index.vue
@@ -1,0 +1,160 @@
+<template>
+  <AsideSlotTemplate
+    class="contact-info-redesign"
+    data-testid="contact-info-redesign"
+  >
+    <template #header>
+      <ContactInfoRedesignHeader
+        :showRefresh="!isHistory"
+        :showClose="!isHistory"
+        :isRefreshDisabled="isRefreshDisabled"
+        @refresh="emit('refresh')"
+        @close="emit('close')"
+      />
+    </template>
+
+    <section class="contact-info-redesign__scrollable">
+      <AboutContactCard
+        :contactName="contactName"
+        :contactNumber="contactNumber"
+        :contactPlatform="contactPlatform"
+        :isOnline="isOnline"
+        :lastMessageText="lastMessageText"
+        :customFields="customFields"
+        :currentCustomField="currentCustomField"
+        :canEditCustomFields="canEditCustomFields"
+        :openCustomFields="openCustomFields"
+        :isLinkedUser="isLinkedUser"
+        :isLinkedToOtherAgent="isLinkedToOtherAgent"
+        :linkedUserName="linkedUserName"
+        :showLinkSwitch="showLinkSwitch"
+        @update:is-linked-user="emit('update:isLinkedUser', $event)"
+        @update:open-custom-fields="emit('update:openCustomFields', $event)"
+        @update-current-custom-field="
+          emit('update-current-custom-field', $event)
+        "
+        @save-value="emit('save-value')"
+      />
+
+      <AboutSupportCard
+        :closedRoom="closedRoom"
+        :isHistory="isHistory"
+        :isViewMode="isViewMode"
+      />
+
+      <MediaTabs
+        :room="room"
+        :history="isHistory"
+        :contactInfo="contactInfo"
+        @fullscreen="handleFullscreen"
+        @loaded-medias="emit('loaded-medias')"
+      />
+    </section>
+
+    <slot name="previews" />
+  </AsideSlotTemplate>
+</template>
+
+<script setup lang="ts">
+import AsideSlotTemplate from '@/components/layouts/chats/AsideSlotTemplate/index.vue';
+import ContactInfoRedesignHeader from './Header.vue';
+import AboutContactCard from './AboutContactCard.vue';
+import AboutSupportCard from './AboutSupportCard.vue';
+import MediaTabs from './MediaTabs.vue';
+
+defineOptions({
+  name: 'ContactInfoRedesign',
+});
+
+type CustomFields = Record<string, string>;
+
+type Room = {
+  uuid?: string;
+  [key: string]: unknown;
+};
+
+type ClosedRoom = {
+  uuid?: string;
+  [key: string]: unknown;
+};
+
+type ContactInfo = Record<string, unknown>;
+
+type MediaItem = {
+  url: string;
+  [key: string]: unknown;
+};
+
+withDefaults(
+  defineProps<{
+    room?: Room;
+    closedRoom?: ClosedRoom;
+    contactInfo?: ContactInfo;
+    isHistory?: boolean;
+    isViewMode?: boolean;
+    isRefreshDisabled?: boolean;
+    contactName?: string;
+    contactNumber?: string;
+    contactPlatform?: string;
+    isOnline?: boolean;
+    lastMessageText?: string;
+    customFields?: CustomFields;
+    currentCustomField?: CustomFields;
+    canEditCustomFields?: boolean;
+    openCustomFields?: boolean;
+    isLinkedUser?: boolean;
+    isLinkedToOtherAgent?: boolean;
+    linkedUserName?: string;
+    showLinkSwitch?: boolean;
+  }>(),
+  {
+    room: () => ({}),
+    closedRoom: () => ({}),
+    contactInfo: () => ({}),
+    isHistory: false,
+    isViewMode: false,
+    isRefreshDisabled: false,
+    contactName: '',
+    contactNumber: '',
+    contactPlatform: '',
+    isOnline: false,
+    lastMessageText: '',
+    customFields: () => ({}),
+    currentCustomField: () => ({}),
+    canEditCustomFields: false,
+    openCustomFields: true,
+    isLinkedUser: false,
+    isLinkedToOtherAgent: false,
+    linkedUserName: '',
+    showLinkSwitch: false,
+  },
+);
+
+const emit = defineEmits<{
+  refresh: [];
+  close: [];
+  'update:isLinkedUser': [value: boolean];
+  'update:openCustomFields': [value: boolean];
+  'update-current-custom-field': [customField: CustomFields];
+  'save-value': [];
+  fullscreen: [url: string, images: MediaItem[]];
+  'loaded-medias': [];
+}>();
+
+const handleFullscreen = (url: string, images: MediaItem[]) => {
+  emit('fullscreen', url, images);
+};
+</script>
+
+<style lang="scss" scoped>
+.contact-info-redesign {
+  &__scrollable {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-3;
+    padding: $unnnic-space-2;
+    overflow: hidden auto;
+    height: 100%;
+  }
+}
+</style>

--- a/src/components/chats/ContactInfo/__tests__/ContactInfo.featureFlag.spec.js
+++ b/src/components/chats/ContactInfo/__tests__/ContactInfo.featureFlag.spec.js
@@ -1,0 +1,147 @@
+import {
+  describe,
+  it,
+  expect,
+  afterEach,
+  beforeAll,
+  afterAll,
+  vi,
+} from 'vitest';
+import { mount, config } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
+import ContactInfo from '../index.vue';
+import i18n from '@/plugins/i18n';
+import { ASSISTED_SALES_FEATURE_FLAG } from '@/composables/useAssistedSalesFeatureFlag';
+
+vi.mock('@/services/api/resources/chats/linkContact', () => ({
+  default: {
+    getLinketContact: vi.fn(() => Promise.resolve({ Detail: true })),
+    linkContactToAgent: vi.fn(),
+    removeContactFromAgent: vi.fn(),
+  },
+}));
+
+vi.mock('is-mobile', () => ({
+  default: () => false,
+}));
+
+beforeAll(() => {
+  config.global.plugins = (config.global.plugins || []).filter(
+    (plugin) => plugin !== i18n,
+  );
+});
+
+afterAll(() => {
+  if (config.global.plugins && !config.global.plugins.includes(i18n)) {
+    config.global.plugins.push(i18n);
+  }
+});
+
+const mockRoom = {
+  uuid: 'room-1',
+  queue: { sector: 'sector-1', uuid: 'queue-1' },
+  contact: {
+    uuid: 'contact-1',
+    name: 'Aline',
+    status: 'offline',
+    created_on: '2024-01-01',
+  },
+  custom_fields: {},
+  can_edit_custom_fields: false,
+  user: { first_name: 'Agent', last_name: 'One' },
+  linked_user: '',
+};
+
+const createWrapper = ({ activeFeatures = [] } = {}) =>
+  mount(ContactInfo, {
+    props: {
+      isHistory: false,
+      isViewMode: false,
+    },
+    global: {
+      plugins: [
+        createTestingPinia({
+          createSpy: vi.fn,
+          initialState: {
+            rooms: {
+              activeRoom: mockRoom,
+            },
+            roomMessages: {
+              roomMessages: [],
+              roomInternalNotes: [],
+            },
+            featureFlag: {
+              featureFlags: {
+                active_features: activeFeatures,
+              },
+              featureFlagsLoaded: true,
+            },
+          },
+        }),
+      ],
+      mocks: {
+        $t: (key) => key,
+      },
+      stubs: {
+        ContactInfosLoading: true,
+        ContactInfoRedesign: {
+          name: 'ContactInfoRedesign',
+          template:
+            '<div data-testid="contact-info-redesign"><slot name="previews" /></div>',
+        },
+        AsideSlotTemplate: {
+          name: 'AsideSlotTemplate',
+          template:
+            '<div data-testid="contact-info-legacy"><slot name="header" /><slot /></div>',
+        },
+        AsideSlotTemplateSection: true,
+        AboutSupport: true,
+        ContactMedia: true,
+        CustomField: true,
+        CopyValueButton: true,
+        FullscreenPreview: true,
+        VideoPreview: true,
+        UnnnicButton: true,
+        UnnnicSwitch: true,
+        UnnnicToolTip: true,
+        UnnnicIcon: true,
+        UnnnicIconSvg: true,
+      },
+    },
+  });
+
+describe('ContactInfo feature flag branching', () => {
+  let wrapper;
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('renders legacy layout when assisted sales flag is disabled', async () => {
+    wrapper = createWrapper({ activeFeatures: [] });
+    wrapper.vm.isLoading = false;
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('[data-testid="contact-info-legacy"]').exists()).toBe(
+      true,
+    );
+    expect(wrapper.find('[data-testid="contact-info-redesign"]').exists()).toBe(
+      false,
+    );
+  });
+
+  it('renders redesign layout when assisted sales flag is enabled', async () => {
+    wrapper = createWrapper({
+      activeFeatures: [ASSISTED_SALES_FEATURE_FLAG],
+    });
+    wrapper.vm.isLoading = false;
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('[data-testid="contact-info-redesign"]').exists()).toBe(
+      true,
+    );
+    expect(wrapper.find('[data-testid="contact-info-legacy"]').exists()).toBe(
+      false,
+    );
+  });
+});

--- a/src/components/chats/ContactInfo/index.vue
+++ b/src/components/chats/ContactInfo/index.vue
@@ -2,197 +2,259 @@
 <template>
   <div class="contact-info__container">
     <ContactInfosLoading v-show="isLoading" />
-    <AsideSlotTemplate
-      v-show="!isLoading"
-      v-if="closedRoom || room"
-      class="contact-info"
-    >
-      <template #header>
-        <header class="contact-info__header">
-          <p>{{ $t('chats.room_contact_info.title') }}</p>
-          <div>
-            <UnnnicButton
-              v-if="!isHistory"
-              iconCenter="sync"
-              type="tertiary"
-              size="small"
-              :disabled="isRefreshContactDisabled"
-              @click="refreshContactInfos"
+
+    <template v-if="closedRoom || room">
+      <ContactInfoRedesign
+        v-if="isAssistedSalesEnabled"
+        v-show="!isLoading"
+        :room="room"
+        :closedRoom="closedRoom"
+        :contactInfo="(closedRoom || room).contact"
+        :isHistory="isHistory"
+        :isViewMode="isViewMode"
+        :isRefreshDisabled="isRefreshContactDisabled"
+        :contactName="(closedRoom || room).contact.name"
+        :contactNumber="contactNumber?.contactNum"
+        :contactPlatform="contactNumber?.plataform"
+        :isOnline="room?.contact.status === 'online'"
+        :lastMessageText="lastMessageText"
+        :customFields="computedCustomFields"
+        :currentCustomField="currentCustomField"
+        :canEditCustomFields="!isHistory && room?.can_edit_custom_fields"
+        :openCustomFields="openCustomFields"
+        :isLinkedUser="isLinkedUser"
+        :isLinkedToOtherAgent="isLinkedToOtherAgent"
+        :linkedUserName="room?.linked_user"
+        :showLinkSwitch="!isLinkedToOtherAgent && !isViewMode && !isHistory"
+        @refresh="refreshContactInfos"
+        @close="emitClose"
+        @update:is-linked-user="handleLinkedUserUpdate"
+        @update:open-custom-fields="openCustomFields = $event"
+        @update-current-custom-field="updateCurrentCustomField"
+        @save-value="saveCurrentCustomFieldValue"
+        @fullscreen="openFullScreen"
+        @loaded-medias="isLoading = false"
+      >
+        <template #previews>
+          <FullscreenPreview
+            v-if="isFullscreen && currentMedia"
+            :downloadMediaUrl="currentMedia?.url"
+            :downloadMediaName="currentMedia?.message"
+            :mediaCurrent="currentMediaIndex"
+            :mediaTotal="images.length"
+            @close="isFullscreen = false"
+            @next="nextMedia"
+            @previous="previousMedia"
+          >
+            <VideoPreview
+              v-if="currentMedia.content_type.includes('mp4')"
+              :src="currentMedia.url"
+              @keypress.enter="() => {}"
+              @click.stop="() => {}"
             />
-            <UnnnicButton
-              v-if="!isHistory"
-              iconCenter="close"
-              type="tertiary"
-              size="small"
-              @click="emitClose"
+            <img
+              v-else
+              :src="currentMedia.url"
+              :alt="currentMedia.url"
+              @keypress.enter="() => {}"
+              @click.stop="() => {}"
             />
-          </div>
-        </header>
-      </template>
-      <section class="scrollable">
-        <AsideSlotTemplateSection class="contact-info__section">
-          <section class="infos-header">
-            <section class="infos-header__title-container">
-              <h3 class="infos-header__title">
-                {{ $t('contact_info.title') }}
-              </h3>
+          </FullscreenPreview>
+        </template>
+      </ContactInfoRedesign>
+
+      <AsideSlotTemplate
+        v-else
+        v-show="!isLoading"
+        class="contact-info"
+      >
+        <template #header>
+          <header class="contact-info__header">
+            <p>{{ $t('chats.room_contact_info.title') }}</p>
+            <div>
+              <UnnnicButton
+                v-if="!isHistory"
+                iconCenter="sync"
+                type="tertiary"
+                size="small"
+                :disabled="isRefreshContactDisabled"
+                @click="refreshContactInfos"
+              />
+              <UnnnicButton
+                v-if="!isHistory"
+                iconCenter="close"
+                type="tertiary"
+                size="small"
+                @click="emitClose"
+              />
+            </div>
+          </header>
+        </template>
+        <section class="scrollable">
+          <AsideSlotTemplateSection class="contact-info__section">
+            <section class="infos-header">
+              <section class="infos-header__title-container">
+                <h3 class="infos-header__title">
+                  {{ $t('contact_info.title') }}
+                </h3>
+                <section
+                  v-if="isLinkedToOtherAgent"
+                  class="infos-header__linked-contact"
+                >
+                  <UnnnicIcon
+                    icon="info"
+                    size="ant"
+                    scheme="fg-warning"
+                  />
+                  <p>
+                    {{
+                      $t('contact_info.linked_contact', {
+                        name: room.linked_user,
+                      })
+                    }}
+                  </p>
+                </section>
+              </section>
+              <div
+                v-if="!isLinkedToOtherAgent && !isViewMode && !isHistory"
+                class="sync-contact"
+              >
+                <UnnnicSwitch
+                  v-model="isLinkedUser"
+                  size="small"
+                  :textRight="
+                    isLinkedUser
+                      ? $t('contact_info.switch_disassociate_contact')
+                      : $t('contact_info.switch_associate_contact')
+                  "
+                  @update:model-value="addContactToAgent"
+                />
+                <UnnnicToolTip
+                  enabled
+                  :text="$t('contact_info.switch_tooltip')"
+                  side="left"
+                >
+                  <UnnnicIconSvg
+                    icon="info"
+                    scheme="fg-base"
+                    size="sm"
+                  />
+                </UnnnicToolTip>
+              </div>
+            </section>
+            <section class="infos-contact">
+              <p
+                v-if="room?.contact.status === 'online'"
+                class="infos-contact__item-value"
+              >
+                {{ $t('status.online') }}
+              </p>
+              <p
+                v-if="lastMessageFromContact?.created_on"
+                class="infos-contact__item-last-contact"
+              >
+                {{
+                  $t('last_message_time.date', {
+                    date: moment(lastMessageFromContact?.created_on).fromNow(),
+                  })
+                }}
+              </p>
+              <section class="infos-contact__item">
+                <section class="infos-contact__item-content">
+                  <p class="infos-contact__item-title">{{ $t('name') }}:</p>
+                  <p class="infos-contact__item-value">
+                    {{ (closedRoom || room).contact.name }}
+                  </p>
+                </section>
+                <CopyValueButton :value="(closedRoom || room).contact.name" />
+              </section>
+              <section class="infos-contact__item">
+                <section class="infos-contact__item-content">
+                  <p class="infos-contact__item-title">
+                    {{ contactNumber?.plataform || $t('URN') }}:
+                  </p>
+                  <p class="infos-contact__item-value">
+                    {{ contactNumber?.contactNum }}
+                  </p>
+                </section>
+                <CopyValueButton :value="contactNumber?.contactNum" />
+              </section>
+
+              <Transition name="expand-with-fade">
+                <section
+                  v-if="hasCustomFields && openCustomFields"
+                  class="custom-fields-container"
+                >
+                  <CustomField
+                    v-for="(value, key) in computedCustomFields"
+                    :key="key"
+                    :title="key"
+                    :description="value"
+                    :isEditable="!isHistory && room.can_edit_custom_fields"
+                    :isCurrent="isCurrentCustomField(key)"
+                    :value="currentCustomField?.[key]"
+                    @update-current-custom-field="updateCurrentCustomField"
+                    @save-value="saveCurrentCustomFieldValue"
+                  />
+                </section>
+              </Transition>
+
               <section
-                v-if="isLinkedToOtherAgent"
-                class="infos-header__linked-contact"
+                v-if="hasCustomFields"
+                class="infos-contact__slide"
               >
                 <UnnnicIcon
-                  icon="info"
-                  size="ant"
-                  scheme="fg-warning"
-                />
-                <p>
-                  {{
-                    $t('contact_info.linked_contact', {
-                      name: room.linked_user,
-                    })
-                  }}
-                </p>
-              </section>
-            </section>
-            <div
-              v-if="!isLinkedToOtherAgent && !isViewMode && !isHistory"
-              class="sync-contact"
-            >
-              <UnnnicSwitch
-                v-model="isLinkedUser"
-                size="small"
-                :textRight="
-                  isLinkedUser
-                    ? $t('contact_info.switch_disassociate_contact')
-                    : $t('contact_info.switch_associate_contact')
-                "
-                @update:model-value="addContactToAgent"
-              />
-              <UnnnicToolTip
-                enabled
-                :text="$t('contact_info.switch_tooltip')"
-                side="left"
-              >
-                <UnnnicIconSvg
-                  icon="info"
-                  scheme="fg-base"
-                  size="sm"
-                />
-              </UnnnicToolTip>
-            </div>
-          </section>
-          <section class="infos-contact">
-            <p
-              v-if="room?.contact.status === 'online'"
-              class="infos-contact__item-value"
-            >
-              {{ $t('status.online') }}
-            </p>
-            <p
-              v-if="lastMessageFromContact?.created_on"
-              class="infos-contact__item-last-contact"
-            >
-              {{
-                $t('last_message_time.date', {
-                  date: moment(lastMessageFromContact?.created_on).fromNow(),
-                })
-              }}
-            </p>
-            <section class="infos-contact__item">
-              <section class="infos-contact__item-content">
-                <p class="infos-contact__item-title">{{ $t('name') }}:</p>
-                <p class="infos-contact__item-value">
-                  {{ (closedRoom || room).contact.name }}
-                </p>
-              </section>
-              <CopyValueButton :value="(closedRoom || room).contact.name" />
-            </section>
-            <section class="infos-contact__item">
-              <section class="infos-contact__item-content">
-                <p class="infos-contact__item-title">
-                  {{ contactNumber?.plataform || $t('URN') }}:
-                </p>
-                <p class="infos-contact__item-value">
-                  {{ contactNumber?.contactNum }}
-                </p>
-              </section>
-              <CopyValueButton :value="contactNumber?.contactNum" />
-            </section>
-
-            <Transition name="expand-with-fade">
-              <section
-                v-if="hasCustomFields && openCustomFields"
-                class="custom-fields-container"
-              >
-                <CustomField
-                  v-for="(value, key) in computedCustomFields"
-                  :key="key"
-                  :title="key"
-                  :description="value"
-                  :isEditable="!isHistory && room.can_edit_custom_fields"
-                  :isCurrent="isCurrentCustomField(key)"
-                  :value="currentCustomField?.[key]"
-                  @update-current-custom-field="updateCurrentCustomField"
-                  @save-value="saveCurrentCustomFieldValue"
+                  :icon="openCustomFields ? 'expand_less' : 'expand_more'"
+                  clickable
+                  @click="openCustomFields = !openCustomFields"
                 />
               </section>
-            </Transition>
-
-            <section
-              v-if="hasCustomFields"
-              class="infos-contact__slide"
-            >
-              <UnnnicIcon
-                :icon="openCustomFields ? 'expand_less' : 'expand_more'"
-                clickable
-                @click="openCustomFields = !openCustomFields"
-              />
             </section>
-          </section>
-        </AsideSlotTemplateSection>
+          </AsideSlotTemplateSection>
 
-        <AboutSupport
-          :closedRoom="closedRoom"
-          :isHistory="isHistory"
-          :isViewMode="isViewMode"
-        />
-
-        <AsideSlotTemplateSection class="contact-info__section">
-          <ContactMedia
-            :room="room"
-            :history="isHistory"
-            :contactInfo="(closedRoom || room).contact"
-            @fullscreen="openFullScreen"
-            @loaded-medias="isLoading = false"
+          <AboutSupport
+            :closedRoom="closedRoom"
+            :isHistory="isHistory"
+            :isViewMode="isViewMode"
           />
-        </AsideSlotTemplateSection>
-      </section>
 
-      <FullscreenPreview
-        v-if="isFullscreen && currentMedia"
-        :downloadMediaUrl="currentMedia?.url"
-        :downloadMediaName="currentMedia?.message"
-        :mediaCurrent="currentMediaIndex"
-        :mediaTotal="images.length"
-        @close="isFullscreen = false"
-        @next="nextMedia"
-        @previous="previousMedia"
-      >
-        <VideoPreview
-          v-if="currentMedia.content_type.includes('mp4')"
-          :src="currentMedia.url"
-          @keypress.enter="() => {}"
-          @click.stop="() => {}"
-        />
-        <img
-          v-else
-          :src="currentMedia.url"
-          :alt="currentMedia.url"
-          @keypress.enter="() => {}"
-          @click.stop="() => {}"
-        />
-      </FullscreenPreview>
-    </AsideSlotTemplate>
+          <AsideSlotTemplateSection class="contact-info__section">
+            <ContactMedia
+              :room="room"
+              :history="isHistory"
+              :contactInfo="(closedRoom || room).contact"
+              @fullscreen="openFullScreen"
+              @loaded-medias="isLoading = false"
+            />
+          </AsideSlotTemplateSection>
+        </section>
+
+        <FullscreenPreview
+          v-if="isFullscreen && currentMedia"
+          :downloadMediaUrl="currentMedia?.url"
+          :downloadMediaName="currentMedia?.message"
+          :mediaCurrent="currentMediaIndex"
+          :mediaTotal="images.length"
+          @close="isFullscreen = false"
+          @next="nextMedia"
+          @previous="previousMedia"
+        >
+          <VideoPreview
+            v-if="currentMedia.content_type.includes('mp4')"
+            :src="currentMedia.url"
+            @keypress.enter="() => {}"
+            @click.stop="() => {}"
+          />
+          <img
+            v-else
+            :src="currentMedia.url"
+            :alt="currentMedia.url"
+            @keypress.enter="() => {}"
+            @click.stop="() => {}"
+          />
+        </FullscreenPreview>
+      </AsideSlotTemplate>
+    </template>
   </div>
 </template>
 
@@ -219,11 +281,14 @@ import ContactMedia from './Media.vue';
 import VideoPreview from '../MediaMessage/Previews/Video.vue';
 import FullscreenPreview from '../MediaMessage/Previews/Fullscreen.vue';
 import AboutSupport from './AboutSupport.vue';
+import ContactInfoRedesign from './Redesign/index.vue';
 
 import moment from 'moment';
 import { parseUrn } from '@/utils/room';
 
 import i18n from '@/plugins/i18n';
+import { useFeatureFlag } from '@/store/modules/featureFlag';
+import { useAssistedSalesFeatureFlag } from '@/composables/useAssistedSalesFeatureFlag';
 
 export default {
   name: 'ContactInfo',
@@ -238,6 +303,7 @@ export default {
     FullscreenPreview,
     VideoPreview,
     AboutSupport,
+    ContactInfoRedesign,
   },
   props: {
     closedRoom: {
@@ -282,6 +348,11 @@ export default {
       activeRoomSummary: 'activeRoomSummary',
       isLoadingActiveRoomSummary: 'isLoadingActiveRoomSummary',
     }),
+    ...mapState(useFeatureFlag, ['featureFlags']),
+
+    isAssistedSalesEnabled() {
+      return useAssistedSalesFeatureFlag(this.featureFlags);
+    },
 
     hasCustomFields() {
       return Object.keys(this.computedCustomFields).length > 0;
@@ -325,6 +396,16 @@ export default {
         return messages.findLast((message) => message.contact);
       }
       return '';
+    },
+
+    lastMessageText() {
+      if (!this.lastMessageFromContact?.created_on) {
+        return '';
+      }
+
+      return this.$t('last_message_time.date', {
+        date: moment(this.lastMessageFromContact.created_on).fromNow(),
+      });
     },
 
     contactNumber() {
@@ -464,6 +545,11 @@ export default {
       } else {
         this.removeLinkedContact();
       }
+    },
+
+    handleLinkedUserUpdate(value) {
+      this.isLinkedUser = value;
+      this.addContactToAgent();
     },
 
     verifyLinkedUser() {

--- a/src/composables/__tests__/useAssistedSalesFeatureFlag.spec.ts
+++ b/src/composables/__tests__/useAssistedSalesFeatureFlag.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ASSISTED_SALES_FEATURE_FLAG,
+  useAssistedSalesFeatureFlag,
+} from '../useAssistedSalesFeatureFlag';
+
+describe('useAssistedSalesFeatureFlag', () => {
+  it('exports the assisted sales feature flag name', () => {
+    expect(ASSISTED_SALES_FEATURE_FLAG).toBe('weniChatsAssistedSales');
+  });
+
+  it('returns true when the flag is active', () => {
+    expect(
+      useAssistedSalesFeatureFlag({
+        active_features: ['weniChatsAssistedSales'],
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when the flag is not active', () => {
+    expect(
+      useAssistedSalesFeatureFlag({
+        active_features: ['weniChatsMessageDictation'],
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when feature flags are missing', () => {
+    expect(useAssistedSalesFeatureFlag(null)).toBe(false);
+    expect(useAssistedSalesFeatureFlag(undefined)).toBe(false);
+    expect(useAssistedSalesFeatureFlag({})).toBe(false);
+  });
+});

--- a/src/composables/useAssistedSalesFeatureFlag.ts
+++ b/src/composables/useAssistedSalesFeatureFlag.ts
@@ -1,0 +1,11 @@
+export const ASSISTED_SALES_FEATURE_FLAG = 'weniChatsAssistedSales';
+
+type FeatureFlags = {
+  active_features?: string[];
+};
+
+export function useAssistedSalesFeatureFlag(
+  featureFlags?: FeatureFlags | null,
+): boolean {
+  return !!featureFlags?.active_features?.includes(ASSISTED_SALES_FEATURE_FLAG);
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -819,6 +819,10 @@
     "switch_tooltip": "Enable if you want the contact always to be directly assigned to you",
     "alert_linked": "Linked contact",
     "alert_detached": "Unlinked contact",
+    "header": {
+      "desk_copilot": "Desk Copilot",
+      "information": "Information"
+    },
     "linked_contact": "Contact linked to representative {name}",
     "see_contact_history": "View history",
     "no_contact_history": "No history",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -821,6 +821,10 @@
     "switch_tooltip": "Activa si deseas que el contacto siempre se te asigne directamente",
     "alert_linked": "Contacto vinculado",
     "alert_detached": "Contacto desvinculado",
+    "header": {
+      "desk_copilot": "Desk Copilot",
+      "information": "Información"
+    },
     "linked_contact": "Contacto vinculado al representante {name}",
     "see_contact_history": "Ver historial",
     "no_contact_history": "Sin historial",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -824,6 +824,10 @@
     "switch_tooltip": "Ative se quiser que o contato seja sempre atribuído diretamente a você",
     "alert_linked": "Contato vinculado",
     "alert_detached": "Contato desvinculado",
+    "header": {
+      "desk_copilot": "Desk Copilot",
+      "information": "Informações"
+    },
     "linked_contact": "Contato vinculado ao atendente {name}",
     "see_contact_history": "Ver histórico",
     "no_contact_history": "Sem histórico",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -789,6 +789,10 @@
     "switch_tooltip": "Activează dacă vrei ca contactul să-ți fie întotdeauna atribuit direct ție",
     "alert_linked": "Contact asociat",
     "alert_detached": "Contact neasociat",
+    "header": {
+      "desk_copilot": "Desk Copilot",
+      "information": "Informații"
+    },
     "linked_contact": "Contact asociat reprezentantului {name}",
     "see_contact_history": "Vezi istoric",
     "no_contact_history": "Fără istoric",


### PR DESCRIPTION
### Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Tests
- [ ] Chore
- [x] Locales

### Why
A redesigned Contact Info panel is needed behind a feature flag (`weniChatsAssistedSales`) to support an upcoming Assisted Sales experience. The new layout introduces a segmented header with a placeholder for Desk Copilot, dedicated cards for contact and support information, a notes tab alongside the existing media tabs, and individual note cards with inline delete support.

### What Changed
- Added a `useAssistedSalesFeatureFlag` composable that checks whether the `weniChatsAssistedSales` feature flag is active.
- Created a `ContactInfoRedesign` component tree under `ContactInfo/Redesign/` with the following sub-components:
  - **`Header`** — segmented control with "Desk Copilot" (disabled) and "Information" tabs, plus refresh and close action buttons.
  - **`AboutContactCard`** — displays contact name, URN/platform, online status, last message time, custom fields with expand/collapse, and a link/unlink switch.
  - **`AboutSupportCard`** — displays tags (with searchable dropdown and infinite scroll), protocol, CSAT info, and a start-discussion button.
  - **`MediaTabs`** — wraps the existing media/docs/audio tab content and adds a new **`NotesTabContent`** tab.
  - **`NoteCard`** — renders a single internal note with agent name, truncated text, and a delete action gated to the note's owner.
  - **`NotesTabContent`** — loads and lists internal notes for the active room, emitting a scroll-to event on click.
- Updated `ContactInfo/index.vue` to conditionally render `ContactInfoRedesign` when the flag is enabled, preserving the legacy layout otherwise. Added a `lastMessageText` computed property and a `handleLinkedUserUpdate` method to bridge the redesign's events.
- Added locale keys for `contact_info.header.desk_copilot` and `contact_info.header.information` in English, Spanish, Portuguese, and Romanian.
- Added unit tests for `AboutContactCard`, `Header`, `NoteCard`, `NotesTabContent`, `useAssistedSalesFeatureFlag`, and a feature-flag branching test for `ContactInfo`.

### Diagram

```mermaid
flowchart TD
    CI[ContactInfo/index.vue] -->|flag enabled| CIR[ContactInfoRedesign]
    CI -->|flag disabled| Legacy[AsideSlotTemplate legacy]

    CIR --> H[Header]
    CIR --> ACC[AboutContactCard]
    CIR --> ASC[AboutSupportCard]
    CIR --> MT[MediaTabs]

    MT --> NTC[NotesTabContent]
    MT --> MediasContent
    MT --> DocumentsContent
    MT --> AudiosContent

    NTC --> NC[NoteCard]
```