### PR TITLE
feat: add Desk Copilot tab with summary, disclaimer, and copilot connection service

### DIFF
--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/Disclaimer.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/Disclaimer.vue
@@ -11,8 +11,11 @@
       />
 
       <section class="desk-copilot-disclaimer__text">
-        <h3 class="desk-copilot-disclaimer__title">
-          {{ $t('contact_info.desk_copilot.disclaimer.title') }}
+        <h3
+          class="desk-copilot-disclaimer__title"
+          data-testid="desk-copilot-disclaimer-title"
+        >
+          {{ $t(titleKey) }}
         </h3>
         <p class="desk-copilot-disclaimer__description">
           {{ $t('contact_info.desk_copilot.disclaimer.description') }}
@@ -59,16 +62,24 @@ defineOptions({
 
 const props = withDefaults(
   defineProps<{
+    hasSummary?: boolean;
     isHistory?: boolean;
     isViewMode?: boolean;
   }>(),
   {
+    hasSummary: false,
     isHistory: false,
     isViewMode: false,
   },
 );
 
 const { me } = storeToRefs(useProfile());
+
+const titleKey = computed(() =>
+  props.hasSummary
+    ? 'contact_info.desk_copilot.disclaimer.title'
+    : 'contact_info.desk_copilot.disclaimer.title_without_summary',
+);
 
 const disclaimerItems = [
   'contact_info.desk_copilot.disclaimer.items.product_recommendations',

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/Disclaimer.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/Disclaimer.vue
@@ -1,0 +1,147 @@
+<template>
+  <section
+    class="desk-copilot-disclaimer"
+    data-testid="desk-copilot-disclaimer"
+  >
+    <section class="desk-copilot-disclaimer__content">
+      <UnnnicIcon
+        icon="info"
+        size="sm"
+        scheme="fg-info"
+      />
+
+      <section class="desk-copilot-disclaimer__text">
+        <h3 class="desk-copilot-disclaimer__title">
+          {{ $t('contact_info.desk_copilot.disclaimer.title') }}
+        </h3>
+        <p class="desk-copilot-disclaimer__description">
+          {{ $t('contact_info.desk_copilot.disclaimer.description') }}
+        </p>
+        <ul class="desk-copilot-disclaimer__items">
+          <li
+            v-for="item in disclaimerItems"
+            :key="item"
+            class="desk-copilot-disclaimer__item"
+          >
+            <UnnnicIcon
+              icon="check_small"
+              size="xs"
+              scheme="fg-emphasized"
+            />
+            <span>{{ $t(item) }}</span>
+          </li>
+        </ul>
+      </section>
+    </section>
+
+    <UnnnicButton
+      v-if="showEnableButton"
+      type="tertiary"
+      size="small"
+      data-testid="desk-copilot-enable-button"
+      @click="handleEnable"
+    >
+      {{ $t('contact_info.desk_copilot.disclaimer.enable_button') }}
+    </UnnnicButton>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { storeToRefs } from 'pinia';
+import { useProfile } from '@/store/modules/profile';
+import { isUserAdmin } from '@/utils/permissions';
+import { emitToHost } from '@/utils/hostBridge';
+
+defineOptions({
+  name: 'DeskCopilotDisclaimer',
+});
+
+const props = withDefaults(
+  defineProps<{
+    isHistory?: boolean;
+    isViewMode?: boolean;
+  }>(),
+  {
+    isHistory: false,
+    isViewMode: false,
+  },
+);
+
+const { me } = storeToRefs(useProfile());
+
+const disclaimerItems = [
+  'contact_info.desk_copilot.disclaimer.items.product_recommendations',
+  'contact_info.desk_copilot.disclaimer.items.catalog_search',
+  'contact_info.desk_copilot.disclaimer.items.sales_arguments',
+  'contact_info.desk_copilot.disclaimer.items.next_best_actions',
+] as const;
+
+const showEnableButton = computed(
+  () =>
+    isUserAdmin(me.value?.project_permission_role) &&
+    !props.isHistory &&
+    !props.isViewMode,
+);
+
+function handleEnable() {
+  // Placeholder path until Connect wires the Live Desk settings route
+  emitToHost('redirect', { path: 'chats:settings/live-desk' });
+}
+</script>
+
+<style lang="scss" scoped>
+.desk-copilot-disclaimer {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: $unnnic-space-2;
+  padding: $unnnic-space-4;
+  background-color: $unnnic-color-bg-info;
+  border: 1px solid $unnnic-color-border-info;
+  border-radius: $unnnic-radius-2;
+  flex-shrink: 0;
+  width: 100%;
+
+  &__content {
+    display: flex;
+    align-items: flex-start;
+    gap: $unnnic-space-2;
+    width: 100%;
+  }
+
+  &__text {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-1;
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__title {
+    font: $unnnic-font-action;
+    color: $unnnic-color-fg-emphasized;
+  }
+
+  &__description,
+  &__item {
+    font: $unnnic-font-caption-2;
+    color: $unnnic-color-fg-emphasized;
+  }
+
+  &__items {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-1;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  &__item {
+    display: flex;
+    align-items: flex-start;
+    gap: $unnnic-space-1;
+  }
+}
+</style>

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/SummaryMessage.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/SummaryMessage.vue
@@ -1,0 +1,344 @@
+<template>
+  <section
+    class="desk-copilot-summary"
+    data-testid="desk-copilot-summary"
+  >
+    <UnnnicIcon
+      class="desk-copilot-summary__icon"
+      icon="bi:stars"
+      size="sm"
+      scheme="fg-emphasized"
+    />
+
+    <section class="desk-copilot-summary__body">
+      <h3 class="desk-copilot-summary__title">
+        {{ $t('contact_info.desk_copilot.summary_title') }}
+      </h3>
+
+      <section
+        class="desk-copilot-summary__bubble"
+        data-testid="desk-copilot-summary-bubble"
+      >
+        <section
+          v-if="isLoadingActiveRoomSummary"
+          class="desk-copilot-summary__generate-text"
+          data-testid="desk-copilot-summary-loading"
+        >
+          <span>{{ $t('chats.summary.reading_and_summarizing') }}</span>
+          <span
+            v-for="dot of 3"
+            :key="dot"
+            data-testid="desk-copilot-summary-generating-dot"
+            class="desk-copilot-summary__dot"
+          />
+        </section>
+        <p
+          v-else
+          class="desk-copilot-summary__text"
+          :class="{ 'is-typing': isTyping }"
+          data-testid="desk-copilot-summary-text"
+        >
+          {{ animatedText }}
+        </p>
+      </section>
+
+      <section
+        v-if="showActions"
+        class="desk-copilot-summary__actions"
+        data-testid="desk-copilot-summary-actions"
+      >
+        <CopyValueButton
+          :value="summaryText"
+          copyTooltipKey="contact_info.desk_copilot.copy_summary"
+        />
+        <template v-if="canSendFeedback">
+          <UnnnicToolTip
+            enabled
+            :text="$t('chats.summary.feedback.positive')"
+            side="left"
+          >
+            <UnnnicIcon
+              icon="thumb_up"
+              :filled="feedbackLiked === true"
+              size="ant"
+              clickable
+              scheme="fg-base"
+              data-testid="desk-copilot-summary-thumb-up"
+              @click="handleThumbUp"
+            />
+          </UnnnicToolTip>
+          <UnnnicToolTip
+            enabled
+            :text="$t('chats.summary.feedback.negative')"
+            side="left"
+          >
+            <UnnnicIcon
+              icon="thumb_down"
+              :filled="feedbackLiked === false"
+              size="ant"
+              clickable
+              scheme="fg-base"
+              data-testid="desk-copilot-summary-thumb-down"
+              @click="handleThumbDown"
+            />
+          </UnnnicToolTip>
+        </template>
+      </section>
+    </section>
+
+    <FeedbackModal
+      v-if="showFeedbackModal && activeRoom?.uuid"
+      :hasFeedback="hasFeedback"
+      :roomUuid="activeRoom.uuid"
+      @close="handleCloseFeedbackModal"
+    />
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onUnmounted, ref, watch } from 'vue';
+import { storeToRefs } from 'pinia';
+import { useRooms } from '@/store/modules/chats/rooms';
+import { useProfile } from '@/store/modules/profile';
+import CopyValueButton from '@/components/chats/ContactInfo/CopyValueButton.vue';
+import FeedbackModal from '@/layouts/ChatsLayout/components/ChatSummary/FeedbackModal.vue';
+import Room from '@/services/api/resources/chats/room';
+
+defineOptions({
+  name: 'DeskCopilotSummaryMessage',
+});
+
+const roomsStore = useRooms();
+const { activeRoom, isLoadingActiveRoomSummary, roomsSummary } =
+  storeToRefs(roomsStore);
+const { me } = storeToRefs(useProfile());
+
+const emptySummary = {
+  feedback: { liked: null as boolean | null },
+  summary: '',
+  status: '',
+};
+
+const activeRoomSummary = computed(() => {
+  const roomUuid = activeRoom.value?.uuid;
+  if (!roomUuid) return emptySummary;
+
+  return roomsSummary.value[roomUuid] || emptySummary;
+});
+
+const animatedText = ref('');
+const isTyping = ref(false);
+const showFeedbackModal = ref(false);
+const hasFeedback = ref(false);
+const skipAnimation = ref(!!activeRoomSummary.value.summary);
+
+let animationAbortController: AbortController | null = null;
+let currentAnimationId = 0;
+
+const summaryText = computed(() => activeRoomSummary.value.summary || '');
+
+const feedbackLiked = computed(
+  () => activeRoomSummary.value.feedback?.liked ?? null,
+);
+
+const canSendFeedback = computed(
+  () =>
+    me.value?.email === activeRoom.value?.user?.email &&
+    activeRoomSummary.value.status === 'DONE',
+);
+
+const showActions = computed(
+  () => !isLoadingActiveRoomSummary.value && !!summaryText.value,
+);
+
+async function typeWriter(text: string, speed: number) {
+  if (animationAbortController) {
+    animationAbortController.abort();
+  }
+
+  animationAbortController = new AbortController();
+  const animationId = ++currentAnimationId;
+
+  isTyping.value = true;
+  animatedText.value = '';
+
+  try {
+    for (const char of text) {
+      if (animationAbortController.signal.aborted) {
+        return;
+      }
+
+      if (currentAnimationId !== animationId) {
+        return;
+      }
+
+      await new Promise<void>((resolve, reject) => {
+        const timeoutId = setTimeout(() => {
+          animatedText.value += char;
+          resolve();
+        }, speed);
+
+        animationAbortController?.signal.addEventListener(
+          'abort',
+          () => {
+            clearTimeout(timeoutId);
+            reject(new Error('Animation cancelled'));
+          },
+          { once: true },
+        );
+      });
+    }
+  } catch (error) {
+    if ((error as Error).message !== 'Animation cancelled') {
+      console.error(error);
+    }
+  } finally {
+    isTyping.value = false;
+  }
+}
+
+watch(
+  summaryText,
+  async (newValue, oldValue) => {
+    if (isTyping.value && newValue === oldValue) {
+      return;
+    }
+
+    if (newValue && !skipAnimation.value) {
+      await typeWriter(newValue, 10);
+      skipAnimation.value = true;
+      return;
+    }
+
+    animatedText.value = newValue || '';
+  },
+  { immediate: true },
+);
+
+function handleThumbUp() {
+  const roomUuid = activeRoom.value?.uuid;
+  if (!roomUuid) return;
+
+  if (!activeRoomSummary.value.feedback) {
+    activeRoomSummary.value.feedback = { liked: true };
+  } else {
+    activeRoomSummary.value.feedback.liked = true;
+  }
+  Room.sendSummaryFeedback({
+    roomUuid,
+    liked: true,
+    text: '',
+    tags: [],
+  });
+}
+
+function handleThumbDown() {
+  if (!activeRoomSummary.value.feedback) {
+    activeRoomSummary.value.feedback = { liked: false };
+  } else {
+    activeRoomSummary.value.feedback.liked = false;
+  }
+  hasFeedback.value = true;
+  showFeedbackModal.value = true;
+}
+
+function handleCloseFeedbackModal() {
+  showFeedbackModal.value = false;
+  hasFeedback.value = false;
+}
+
+onUnmounted(() => {
+  if (animationAbortController) {
+    animationAbortController.abort();
+  }
+  animatedText.value = '';
+});
+</script>
+
+<style lang="scss" scoped>
+.desk-copilot-summary {
+  display: flex;
+  align-items: flex-start;
+  gap: $unnnic-space-2;
+  width: 100%;
+
+  &__icon {
+    flex-shrink: 0;
+  }
+
+  &__body {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-2;
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__title {
+    font: $unnnic-font-emphasis;
+    color: $unnnic-color-fg-emphasized;
+  }
+
+  &__bubble {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    padding: $unnnic-space-3 $unnnic-space-4;
+    border: 1px solid $unnnic-color-border-base;
+    border-radius: $unnnic-radius-2;
+  }
+
+  &__text {
+    font: $unnnic-font-body;
+    color: $unnnic-color-fg-base;
+    overflow-wrap: anywhere;
+
+    &.is-typing {
+      padding-right: $unnnic-space-6;
+    }
+  }
+
+  &__generate-text {
+    color: $unnnic-color-fg-base;
+    font: $unnnic-font-body;
+
+    @keyframes wave {
+      0%,
+      60%,
+      100% {
+        transform: initial;
+      }
+
+      30% {
+        transform: translateY(-3px);
+      }
+    }
+
+    .desk-copilot-summary__dot {
+      display: inline-block;
+      width: 2px;
+      height: 2px;
+      border-radius: 50%;
+      margin-right: 2px;
+      background-color: $unnnic-color-fg-base;
+      animation: wave 1.5s linear infinite;
+
+      &:nth-child(2) {
+        animation-delay: 0.9s;
+      }
+
+      &:nth-child(3) {
+        animation-delay: 1.2s;
+      }
+    }
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: $unnnic-space-2;
+    width: 100%;
+  }
+}
+</style>

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/__tests__/Disclaimer.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/__tests__/Disclaimer.spec.js
@@ -73,7 +73,7 @@ describe('DeskCopilotDisclaimer', () => {
       wrapper.find('[data-testid="desk-copilot-disclaimer"]').exists(),
     ).toBe(true);
     expect(wrapper.text()).toContain(
-      'contact_info.desk_copilot.disclaimer.title',
+      'contact_info.desk_copilot.disclaimer.title_without_summary',
     );
     expect(wrapper.text()).toContain(
       'contact_info.desk_copilot.disclaimer.description',
@@ -81,6 +81,22 @@ describe('DeskCopilotDisclaimer', () => {
     expect(wrapper.text()).toContain(
       'contact_info.desk_copilot.disclaimer.items.product_recommendations',
     );
+  });
+
+  it('keeps the summary title when the project uses chats summary', () => {
+    wrapper = createWrapper({ props: { hasSummary: true } });
+
+    expect(
+      wrapper.find('[data-testid="desk-copilot-disclaimer-title"]').text(),
+    ).toBe('contact_info.desk_copilot.disclaimer.title');
+  });
+
+  it('uses the title without summary when chats summary is disabled', () => {
+    wrapper = createWrapper({ props: { hasSummary: false } });
+
+    expect(
+      wrapper.find('[data-testid="desk-copilot-disclaimer-title"]').text(),
+    ).toBe('contact_info.desk_copilot.disclaimer.title_without_summary');
   });
 
   it('shows the enable button for admin users', () => {

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/__tests__/Disclaimer.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/__tests__/Disclaimer.spec.js
@@ -1,0 +1,124 @@
+import {
+  describe,
+  it,
+  expect,
+  afterEach,
+  beforeAll,
+  afterAll,
+  vi,
+} from 'vitest';
+import { mount, config } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
+import Disclaimer from '../Disclaimer.vue';
+import i18n from '@/plugins/i18n';
+import { emitToHost } from '@/utils/hostBridge';
+
+vi.mock('@/utils/hostBridge', () => ({
+  emitToHost: vi.fn(),
+}));
+
+beforeAll(() => {
+  config.global.plugins = (config.global.plugins || []).filter(
+    (plugin) => plugin !== i18n,
+  );
+});
+
+afterAll(() => {
+  if (config.global.plugins && !config.global.plugins.includes(i18n)) {
+    config.global.plugins.push(i18n);
+  }
+});
+
+const createWrapper = ({ projectPermissionRole = 1, props = {} } = {}) =>
+  mount(Disclaimer, {
+    props,
+    global: {
+      plugins: [
+        createTestingPinia({
+          createSpy: vi.fn,
+          initialState: {
+            profile: {
+              me: { project_permission_role: projectPermissionRole },
+            },
+          },
+        }),
+      ],
+      mocks: {
+        $t: (key) => key,
+      },
+      stubs: {
+        UnnnicIcon: true,
+        UnnnicButton: {
+          name: 'UnnnicButton',
+          template:
+            '<button class="unnnic-button" :data-testid="$attrs[\'data-testid\']" @click="$emit(\'click\')"><slot /></button>',
+          inheritAttrs: false,
+        },
+      },
+    },
+  });
+
+describe('DeskCopilotDisclaimer', () => {
+  let wrapper;
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  it('renders title, description and checklist items', () => {
+    wrapper = createWrapper();
+
+    expect(
+      wrapper.find('[data-testid="desk-copilot-disclaimer"]').exists(),
+    ).toBe(true);
+    expect(wrapper.text()).toContain(
+      'contact_info.desk_copilot.disclaimer.title',
+    );
+    expect(wrapper.text()).toContain(
+      'contact_info.desk_copilot.disclaimer.description',
+    );
+    expect(wrapper.text()).toContain(
+      'contact_info.desk_copilot.disclaimer.items.product_recommendations',
+    );
+  });
+
+  it('shows the enable button for admin users', () => {
+    wrapper = createWrapper({ projectPermissionRole: 1 });
+
+    expect(
+      wrapper.find('[data-testid="desk-copilot-enable-button"]').exists(),
+    ).toBe(true);
+  });
+
+  it('hides the enable button for agent users', () => {
+    wrapper = createWrapper({ projectPermissionRole: 2 });
+
+    expect(
+      wrapper.find('[data-testid="desk-copilot-enable-button"]').exists(),
+    ).toBe(false);
+  });
+
+  it('hides the enable button in history or view mode', () => {
+    wrapper = createWrapper({
+      projectPermissionRole: 1,
+      props: { isHistory: true },
+    });
+
+    expect(
+      wrapper.find('[data-testid="desk-copilot-enable-button"]').exists(),
+    ).toBe(false);
+  });
+
+  it('redirects to live desk settings when enable is clicked', async () => {
+    wrapper = createWrapper({ projectPermissionRole: 1 });
+
+    await wrapper
+      .find('[data-testid="desk-copilot-enable-button"]')
+      .trigger('click');
+
+    expect(emitToHost).toHaveBeenCalledWith('redirect', {
+      path: 'chats:settings/live-desk',
+    });
+  });
+});

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/__tests__/SummaryMessage.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/__tests__/SummaryMessage.spec.js
@@ -1,0 +1,164 @@
+import {
+  describe,
+  it,
+  expect,
+  afterEach,
+  beforeAll,
+  afterAll,
+  vi,
+} from 'vitest';
+import { mount, config } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import SummaryMessage from '../SummaryMessage.vue';
+import { useRooms } from '@/store/modules/chats/rooms';
+import { useProfile } from '@/store/modules/profile';
+import Room from '@/services/api/resources/chats/room';
+import i18n from '@/plugins/i18n';
+
+vi.mock('@/services/api/resources/chats/room', () => ({
+  default: {
+    sendSummaryFeedback: vi.fn(),
+  },
+}));
+
+beforeAll(() => {
+  config.global.plugins = (config.global.plugins || []).filter(
+    (plugin) => plugin !== i18n,
+  );
+});
+
+afterAll(() => {
+  if (config.global.plugins && !config.global.plugins.includes(i18n)) {
+    config.global.plugins.push(i18n);
+  }
+});
+
+const createWrapper = ({
+  summary = 'The customer needs bathroom materials',
+  status = 'DONE',
+  isLoading = false,
+  userEmail = 'agent@weni.ai',
+  meEmail = 'agent@weni.ai',
+} = {}) => {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+
+  const roomsStore = useRooms();
+  roomsStore.$patch({
+    activeRoom: {
+      uuid: 'room-1',
+      ended_at: null,
+      user: { email: userEmail },
+    },
+    roomsSummary: {
+      'room-1': {
+        summary,
+        feedback: { liked: null },
+        status,
+      },
+    },
+    isLoadingActiveRoomSummary: isLoading,
+  });
+
+  const profileStore = useProfile();
+  profileStore.$patch({
+    me: { email: meEmail },
+  });
+
+  return mount(SummaryMessage, {
+    global: {
+      plugins: [pinia],
+      mocks: {
+        $t: (key) => key,
+      },
+      stubs: {
+        UnnnicIcon: {
+          name: 'UnnnicIcon',
+          template:
+            '<button class="unnnic-icon" :data-testid="$attrs[\'data-testid\']" @click="$emit(\'click\')" />',
+          inheritAttrs: false,
+        },
+        UnnnicToolTip: {
+          name: 'UnnnicToolTip',
+          template: '<div><slot /></div>',
+        },
+        CopyValueButton: {
+          name: 'CopyValueButton',
+          template: '<button data-testid="copy-summary" />',
+          props: ['value', 'copyTooltipKey'],
+        },
+        FeedbackModal: true,
+      },
+    },
+  });
+};
+
+describe('DeskCopilotSummaryMessage', () => {
+  let wrapper;
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  it('renders the summary title and text', () => {
+    wrapper = createWrapper();
+
+    expect(wrapper.find('[data-testid="desk-copilot-summary"]').exists()).toBe(
+      true,
+    );
+    expect(wrapper.text()).toContain('contact_info.desk_copilot.summary_title');
+    expect(
+      wrapper.find('[data-testid="desk-copilot-summary-text"]').text(),
+    ).toBe('The customer needs bathroom materials');
+  });
+
+  it('shows loading dots while the summary is generating', () => {
+    wrapper = createWrapper({ summary: '', isLoading: true });
+
+    expect(
+      wrapper.find('[data-testid="desk-copilot-summary-loading"]').exists(),
+    ).toBe(true);
+    expect(
+      wrapper.findAll('[data-testid="desk-copilot-summary-generating-dot"]')
+        .length,
+    ).toBe(3);
+  });
+
+  it('shows feedback actions for the room owner when summary is done', () => {
+    wrapper = createWrapper();
+
+    expect(
+      wrapper.find('[data-testid="desk-copilot-summary-actions"]').exists(),
+    ).toBe(true);
+    expect(
+      wrapper.find('[data-testid="desk-copilot-summary-thumb-up"]').exists(),
+    ).toBe(true);
+    expect(
+      wrapper.find('[data-testid="desk-copilot-summary-thumb-down"]').exists(),
+    ).toBe(true);
+  });
+
+  it('hides feedback thumbs when the user is not the room owner', () => {
+    wrapper = createWrapper({ meEmail: 'other@weni.ai' });
+
+    expect(
+      wrapper.find('[data-testid="desk-copilot-summary-thumb-up"]').exists(),
+    ).toBe(false);
+  });
+
+  it('sends positive feedback on thumb up', async () => {
+    wrapper = createWrapper();
+
+    await wrapper
+      .find('[data-testid="desk-copilot-summary-thumb-up"]')
+      .trigger('click');
+
+    expect(Room.sendSummaryFeedback).toHaveBeenCalledWith({
+      roomUuid: 'room-1',
+      liked: true,
+      text: '',
+      tags: [],
+    });
+  });
+});

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/__tests__/index.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/__tests__/index.spec.js
@@ -31,7 +31,7 @@ afterAll(() => {
   }
 });
 
-const createWrapper = (props = {}) =>
+const createWrapper = (props = {}, piniaState = {}) =>
   mount(DeskCopilotTab, {
     props,
     global: {
@@ -47,6 +47,10 @@ const createWrapper = (props = {}) =>
             profile: {
               me: { project_permission_role: 1 },
             },
+            config: {
+              project: { config: { has_chats_summary: true } },
+            },
+            ...piniaState,
           },
         }),
       ],
@@ -115,6 +119,27 @@ describe('DeskCopilotTab', () => {
     expect(wrapper.find('[data-testid="desk-copilot-summary"]').exists()).toBe(
       true,
     );
+  });
+
+  it('hides the summary when has_chats_summary is disabled', async () => {
+    Copilot.listConnections.mockResolvedValue([]);
+    wrapper = createWrapper(
+      {},
+      {
+        config: {
+          project: { config: { has_chats_summary: false } },
+        },
+      },
+    );
+
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="desk-copilot-summary"]').exists()).toBe(
+      false,
+    );
+    expect(
+      wrapper.find('[data-testid="desk-copilot-disclaimer"]').exists(),
+    ).toBe(true);
   });
 
   it('emits loaded on mount so the contact drawer can leave the skeleton', async () => {

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/__tests__/index.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/__tests__/index.spec.js
@@ -117,6 +117,15 @@ describe('DeskCopilotTab', () => {
     );
   });
 
+  it('emits loaded on mount so the contact drawer can leave the skeleton', async () => {
+    Copilot.listConnections.mockResolvedValue([]);
+    wrapper = createWrapper();
+
+    await flushPromises();
+
+    expect(wrapper.emitted('loaded')).toBeTruthy();
+  });
+
   it('shows the disclaimer when the connections request fails', async () => {
     Copilot.listConnections.mockRejectedValue(new Error('Not found'));
     wrapper = createWrapper();

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/__tests__/index.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/__tests__/index.spec.js
@@ -1,0 +1,130 @@
+import {
+  describe,
+  it,
+  expect,
+  afterEach,
+  beforeAll,
+  afterAll,
+  vi,
+} from 'vitest';
+import { mount, config, flushPromises } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
+import DeskCopilotTab from '../index.vue';
+import Copilot from '@/services/api/resources/chats/copilot';
+import i18n from '@/plugins/i18n';
+
+vi.mock('@/services/api/resources/chats/copilot', () => ({
+  default: {
+    listConnections: vi.fn(),
+  },
+}));
+
+beforeAll(() => {
+  config.global.plugins = (config.global.plugins || []).filter(
+    (plugin) => plugin !== i18n,
+  );
+});
+
+afterAll(() => {
+  if (config.global.plugins && !config.global.plugins.includes(i18n)) {
+    config.global.plugins.push(i18n);
+  }
+});
+
+const createWrapper = (props = {}) =>
+  mount(DeskCopilotTab, {
+    props,
+    global: {
+      plugins: [
+        createTestingPinia({
+          createSpy: vi.fn,
+          initialState: {
+            rooms: {
+              activeRoom: { uuid: 'room-1' },
+              roomsSummary: {},
+              isLoadingActiveRoomSummary: false,
+            },
+            profile: {
+              me: { project_permission_role: 1 },
+            },
+          },
+        }),
+      ],
+      mocks: {
+        $t: (key) => key,
+      },
+      stubs: {
+        DeskCopilotSummaryMessage: {
+          name: 'DeskCopilotSummaryMessage',
+          template: '<div data-testid="desk-copilot-summary" />',
+        },
+        SummaryMessage: {
+          name: 'DeskCopilotSummaryMessage',
+          template: '<div data-testid="desk-copilot-summary" />',
+        },
+        DeskCopilotDisclaimer: {
+          name: 'DeskCopilotDisclaimer',
+          template: '<div data-testid="desk-copilot-disclaimer" />',
+          props: ['isHistory', 'isViewMode'],
+        },
+        Disclaimer: {
+          name: 'DeskCopilotDisclaimer',
+          template: '<div data-testid="desk-copilot-disclaimer" />',
+          props: ['isHistory', 'isViewMode'],
+        },
+      },
+    },
+  });
+
+describe('DeskCopilotTab', () => {
+  let wrapper;
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  it('renders the summary and disclaimer when there are no connections', async () => {
+    Copilot.listConnections.mockResolvedValue([]);
+    wrapper = createWrapper();
+
+    await flushPromises();
+
+    expect(Copilot.listConnections).toHaveBeenCalledWith({
+      isPrincipal: false,
+    });
+    expect(wrapper.find('[data-testid="desk-copilot-summary"]').exists()).toBe(
+      true,
+    );
+    expect(
+      wrapper.find('[data-testid="desk-copilot-disclaimer"]').exists(),
+    ).toBe(true);
+  });
+
+  it('hides the disclaimer when the project has copilot connections', async () => {
+    Copilot.listConnections.mockResolvedValue([
+      { conection: { socketUrl: 'wss://example.com' } },
+    ]);
+    wrapper = createWrapper();
+
+    await flushPromises();
+
+    expect(
+      wrapper.find('[data-testid="desk-copilot-disclaimer"]').exists(),
+    ).toBe(false);
+    expect(wrapper.find('[data-testid="desk-copilot-summary"]').exists()).toBe(
+      true,
+    );
+  });
+
+  it('shows the disclaimer when the connections request fails', async () => {
+    Copilot.listConnections.mockRejectedValue(new Error('Not found'));
+    wrapper = createWrapper();
+
+    await flushPromises();
+
+    expect(
+      wrapper.find('[data-testid="desk-copilot-disclaimer"]').exists(),
+    ).toBe(true);
+  });
+});

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/__tests__/index.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/__tests__/index.spec.js
@@ -69,12 +69,12 @@ const createWrapper = (props = {}, piniaState = {}) =>
         DeskCopilotDisclaimer: {
           name: 'DeskCopilotDisclaimer',
           template: '<div data-testid="desk-copilot-disclaimer" />',
-          props: ['isHistory', 'isViewMode'],
+          props: ['hasSummary', 'isHistory', 'isViewMode'],
         },
         Disclaimer: {
           name: 'DeskCopilotDisclaimer',
           template: '<div data-testid="desk-copilot-disclaimer" />',
-          props: ['isHistory', 'isViewMode'],
+          props: ['hasSummary', 'isHistory', 'isViewMode'],
         },
       },
     },

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/index.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/index.vue
@@ -7,7 +7,7 @@
       class="desk-copilot__chat"
       data-testid="desk-copilot-chat"
     >
-      <SummaryMessage />
+      <SummaryMessage v-if="enableRoomSummary" />
     </section>
 
     <Disclaimer
@@ -19,10 +19,12 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
+import { computed, onMounted, ref } from 'vue';
+import { storeToRefs } from 'pinia';
 import SummaryMessage from './SummaryMessage.vue';
 import Disclaimer from './Disclaimer.vue';
 import Copilot from '@/services/api/resources/chats/copilot';
+import { useConfig } from '@/store/modules/config';
 
 defineOptions({
   name: 'DeskCopilotTab',
@@ -42,6 +44,12 @@ withDefaults(
 const emit = defineEmits<{
   loaded: [];
 }>();
+
+const { project } = storeToRefs(useConfig());
+
+const enableRoomSummary = computed(
+  () => !!project.value?.config?.has_chats_summary,
+);
 
 const isConfigured = ref(false);
 const isLoadingConnection = ref(true);

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/index.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/index.vue
@@ -39,6 +39,10 @@ withDefaults(
   },
 );
 
+const emit = defineEmits<{
+  loaded: [];
+}>();
+
 const isConfigured = ref(false);
 const isLoadingConnection = ref(true);
 
@@ -55,6 +59,7 @@ async function loadConnectionStatus() {
 }
 
 onMounted(() => {
+  emit('loaded');
   loadConnectionStatus();
 });
 </script>

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/index.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/index.vue
@@ -1,0 +1,81 @@
+<template>
+  <section
+    class="desk-copilot"
+    data-testid="desk-copilot"
+  >
+    <section
+      class="desk-copilot__chat"
+      data-testid="desk-copilot-chat"
+    >
+      <SummaryMessage />
+    </section>
+
+    <Disclaimer
+      v-if="!isLoadingConnection && !isConfigured"
+      :isHistory="isHistory"
+      :isViewMode="isViewMode"
+    />
+  </section>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import SummaryMessage from './SummaryMessage.vue';
+import Disclaimer from './Disclaimer.vue';
+import Copilot from '@/services/api/resources/chats/copilot';
+
+defineOptions({
+  name: 'DeskCopilotTab',
+});
+
+withDefaults(
+  defineProps<{
+    isHistory?: boolean;
+    isViewMode?: boolean;
+  }>(),
+  {
+    isHistory: false,
+    isViewMode: false,
+  },
+);
+
+const isConfigured = ref(false);
+const isLoadingConnection = ref(true);
+
+async function loadConnectionStatus() {
+  isLoadingConnection.value = true;
+  try {
+    const connections = await Copilot.listConnections({ isPrincipal: false });
+    isConfigured.value = Array.isArray(connections) && connections.length > 0;
+  } catch {
+    isConfigured.value = false;
+  } finally {
+    isLoadingConnection.value = false;
+  }
+}
+
+onMounted(() => {
+  loadConnectionStatus();
+});
+</script>
+
+<style lang="scss" scoped>
+.desk-copilot {
+  display: flex;
+  flex-direction: column;
+  gap: $unnnic-space-3;
+  padding: $unnnic-space-2;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+
+  &__chat {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-3;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden auto;
+  }
+}
+</style>

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/index.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/index.vue
@@ -12,6 +12,7 @@
 
     <Disclaimer
       v-if="!isLoadingConnection && !isConfigured"
+      :hasSummary="enableRoomSummary"
       :isHistory="isHistory"
       :isViewMode="isViewMode"
     />

--- a/src/components/chats/ContactInfo/Redesign/Header.vue
+++ b/src/components/chats/ContactInfo/Redesign/Header.vue
@@ -5,12 +5,12 @@
   >
     <UnnnicSegmentedControl
       class="contact-info-redesign-header__segmented"
-      defaultValue="information"
+      :modelValue="modelValue"
+      @update:model-value="emit('update:modelValue', $event)"
     >
       <UnnnicSegmentedControlList>
         <UnnnicSegmentedControlTrigger
           value="desk_copilot"
-          disabled
           data-testid="segmented-desk-copilot"
         >
           {{ $t('contact_info.header.desk_copilot') }}
@@ -47,17 +47,21 @@
 </template>
 
 <script setup lang="ts">
+export type ContactInfoTab = 'desk_copilot' | 'information';
+
 defineOptions({
   name: 'ContactInfoRedesignHeader',
 });
 
 withDefaults(
   defineProps<{
+    modelValue?: ContactInfoTab;
     showRefresh?: boolean;
     showClose?: boolean;
     isRefreshDisabled?: boolean;
   }>(),
   {
+    modelValue: 'desk_copilot',
     showRefresh: true,
     showClose: true,
     isRefreshDisabled: false,
@@ -65,6 +69,7 @@ withDefaults(
 );
 
 const emit = defineEmits<{
+  'update:modelValue': [value: ContactInfoTab];
   refresh: [];
   close: [];
 }>();

--- a/src/components/chats/ContactInfo/Redesign/__tests__/Header.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/__tests__/Header.spec.js
@@ -17,7 +17,10 @@ afterAll(() => {
 
 const createWrapper = (props = {}) =>
   mount(Header, {
-    props,
+    props: {
+      modelValue: 'desk_copilot',
+      ...props,
+    },
     global: {
       mocks: {
         $t: (key) => key,
@@ -26,6 +29,8 @@ const createWrapper = (props = {}) =>
         UnnnicSegmentedControl: {
           name: 'UnnnicSegmentedControl',
           template: '<div class="unnnic-segmented-control"><slot /></div>',
+          props: ['modelValue', 'defaultValue'],
+          emits: ['update:modelValue'],
         },
         UnnnicSegmentedControlList: {
           name: 'UnnnicSegmentedControlList',
@@ -56,7 +61,7 @@ describe('ContactInfoRedesignHeader', () => {
     wrapper?.unmount();
   });
 
-  it('renders segmented control with desk copilot disabled and information active', () => {
+  it('renders segmented control with desk copilot enabled', () => {
     wrapper = createWrapper();
 
     expect(
@@ -69,10 +74,19 @@ describe('ContactInfoRedesignHeader', () => {
       wrapper
         .find('[data-testid="segmented-desk-copilot"]')
         .attributes('disabled'),
-    ).toBeDefined();
+    ).toBeUndefined();
     expect(wrapper.find('[data-testid="segmented-information"]').exists()).toBe(
       true,
     );
+  });
+
+  it('emits update:modelValue when the segmented control changes', async () => {
+    wrapper = createWrapper({ modelValue: 'desk_copilot' });
+
+    const segmented = wrapper.findComponent({ name: 'UnnnicTabs' });
+    await segmented.vm.$emit('update:modelValue', 'information');
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([['information']]);
   });
 
   it('emits refresh and close events', async () => {

--- a/src/components/chats/ContactInfo/Redesign/__tests__/Header.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/__tests__/Header.spec.js
@@ -15,6 +15,26 @@ afterAll(() => {
   }
 });
 
+const segmentedControlStub = {
+  name: 'UnnnicSegmentedControl',
+  template: '<div class="unnnic-segmented-control"><slot /></div>',
+  props: ['modelValue', 'defaultValue'],
+  emits: ['update:modelValue'],
+};
+
+const segmentedControlListStub = {
+  name: 'UnnnicSegmentedControlList',
+  template: '<div class="unnnic-segmented-control-list"><slot /></div>',
+};
+
+const segmentedControlTriggerStub = {
+  name: 'UnnnicSegmentedControlTrigger',
+  template:
+    '<button class="unnnic-segmented-control-trigger" :disabled="disabled" :data-testid="$attrs[\'data-testid\']"><slot /></button>',
+  props: ['value', 'disabled'],
+  inheritAttrs: false,
+};
+
 const createWrapper = (props = {}) =>
   mount(Header, {
     props: {
@@ -26,23 +46,13 @@ const createWrapper = (props = {}) =>
         $t: (key) => key,
       },
       stubs: {
-        UnnnicSegmentedControl: {
-          name: 'UnnnicSegmentedControl',
-          template: '<div class="unnnic-segmented-control"><slot /></div>',
-          props: ['modelValue', 'defaultValue'],
-          emits: ['update:modelValue'],
-        },
-        UnnnicSegmentedControlList: {
-          name: 'UnnnicSegmentedControlList',
-          template: '<div class="unnnic-segmented-control-list"><slot /></div>',
-        },
-        UnnnicSegmentedControlTrigger: {
-          name: 'UnnnicSegmentedControlTrigger',
-          template:
-            '<button class="unnnic-segmented-control-trigger" :disabled="disabled" :data-testid="$attrs[\'data-testid\']"><slot /></button>',
-          props: ['value', 'disabled'],
-          inheritAttrs: false,
-        },
+        // UnnnicSegmentedControl is an alias of Tabs.vue (name: UnnnicTabs)
+        UnnnicTabs: segmentedControlStub,
+        UnnnicSegmentedControl: segmentedControlStub,
+        SegmentedControlList: segmentedControlListStub,
+        UnnnicSegmentedControlList: segmentedControlListStub,
+        SegmentedControlTrigger: segmentedControlTriggerStub,
+        UnnnicSegmentedControlTrigger: segmentedControlTriggerStub,
         UnnnicButton: {
           name: 'UnnnicButton',
           template:
@@ -83,7 +93,8 @@ describe('ContactInfoRedesignHeader', () => {
   it('emits update:modelValue when the segmented control changes', async () => {
     wrapper = createWrapper({ modelValue: 'desk_copilot' });
 
-    const segmented = wrapper.findComponent({ name: 'UnnnicTabs' });
+    const segmented = wrapper.findComponent({ name: 'UnnnicSegmentedControl' });
+    expect(segmented.exists()).toBe(true);
     await segmented.vm.$emit('update:modelValue', 'information');
 
     expect(wrapper.emitted('update:modelValue')).toEqual([['information']]);

--- a/src/components/chats/ContactInfo/Redesign/__tests__/index.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/__tests__/index.spec.js
@@ -1,0 +1,108 @@
+import {
+  describe,
+  it,
+  expect,
+  afterEach,
+  beforeAll,
+  afterAll,
+  vi,
+} from 'vitest';
+import { mount, config } from '@vue/test-utils';
+import ContactInfoRedesign from '../index.vue';
+import { moduleStorage } from '@/utils/storage';
+import i18n from '@/plugins/i18n';
+
+vi.mock('@/utils/storage', () => ({
+  moduleStorage: {
+    getItem: vi.fn(() => 'desk_copilot'),
+    setItem: vi.fn(),
+  },
+}));
+
+beforeAll(() => {
+  config.global.plugins = (config.global.plugins || []).filter(
+    (plugin) => plugin !== i18n,
+  );
+});
+
+afterAll(() => {
+  if (config.global.plugins && !config.global.plugins.includes(i18n)) {
+    config.global.plugins.push(i18n);
+  }
+});
+
+const createWrapper = () =>
+  mount(ContactInfoRedesign, {
+    global: {
+      mocks: {
+        $t: (key) => key,
+      },
+      stubs: {
+        AsideSlotTemplate: {
+          name: 'AsideSlotTemplate',
+          template:
+            '<div data-testid="contact-info-redesign"><slot name="header" /><slot /></div>',
+        },
+        ContactInfoRedesignHeader: {
+          name: 'ContactInfoRedesignHeader',
+          template: '<div data-testid="contact-info-redesign-header" />',
+          props: [
+            'modelValue',
+            'showRefresh',
+            'showClose',
+            'isRefreshDisabled',
+          ],
+        },
+        DeskCopilotTab: {
+          name: 'DeskCopilotTab',
+          template: '<div data-testid="desk-copilot" />',
+          props: ['isHistory', 'isViewMode'],
+        },
+        AboutContactCard: true,
+        AboutSupportCard: true,
+        MediaTabs: true,
+      },
+    },
+  });
+
+describe('ContactInfoRedesign', () => {
+  let wrapper;
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  it('opens the desk copilot tab by default', () => {
+    moduleStorage.getItem.mockReturnValue('desk_copilot');
+    wrapper = createWrapper();
+
+    expect(wrapper.find('[data-testid="desk-copilot"]').exists()).toBe(true);
+    expect(wrapper.findComponent({ name: 'AboutContactCard' }).exists()).toBe(
+      false,
+    );
+  });
+
+  it('renders information content when the persisted tab is information', () => {
+    moduleStorage.getItem.mockReturnValue('information');
+    wrapper = createWrapper();
+
+    expect(wrapper.find('[data-testid="desk-copilot"]').exists()).toBe(false);
+    expect(wrapper.findComponent({ name: 'AboutContactCard' }).exists()).toBe(
+      true,
+    );
+  });
+
+  it('persists tab changes in moduleStorage', async () => {
+    moduleStorage.getItem.mockReturnValue('desk_copilot');
+    wrapper = createWrapper();
+
+    wrapper.vm.activeTab = 'information';
+    await wrapper.vm.$nextTick();
+
+    expect(moduleStorage.setItem).toHaveBeenCalledWith(
+      'contactInfoActiveTab',
+      'information',
+    );
+  });
+});

--- a/src/components/chats/ContactInfo/Redesign/index.vue
+++ b/src/components/chats/ContactInfo/Redesign/index.vue
@@ -5,6 +5,7 @@
   >
     <template #header>
       <ContactInfoRedesignHeader
+        v-model="activeTab"
         :showRefresh="!isHistory"
         :showClose="!isHistory"
         :isRefreshDisabled="isRefreshDisabled"
@@ -13,7 +14,16 @@
       />
     </template>
 
-    <section class="contact-info-redesign__scrollable">
+    <DeskCopilotTab
+      v-if="activeTab === 'desk_copilot'"
+      :isHistory="isHistory"
+      :isViewMode="isViewMode"
+    />
+
+    <section
+      v-else
+      class="contact-info-redesign__scrollable"
+    >
       <AboutContactCard
         :contactName="contactName"
         :contactNumber="contactNumber"
@@ -56,15 +66,30 @@
 </template>
 
 <script setup lang="ts">
+import { ref, watch } from 'vue';
 import AsideSlotTemplate from '@/components/layouts/chats/AsideSlotTemplate/index.vue';
-import ContactInfoRedesignHeader from './Header.vue';
+import ContactInfoRedesignHeader, { type ContactInfoTab } from './Header.vue';
 import AboutContactCard from './AboutContactCard.vue';
 import AboutSupportCard from './AboutSupportCard.vue';
 import MediaTabs from './MediaTabs.vue';
+import DeskCopilotTab from './DeskCopilot/index.vue';
+import { moduleStorage } from '@/utils/storage';
 
 defineOptions({
   name: 'ContactInfoRedesign',
 });
+
+const CONTACT_INFO_ACTIVE_TAB_KEY = 'contactInfoActiveTab';
+const DEFAULT_TAB: ContactInfoTab = 'desk_copilot';
+const VALID_TABS = new Set<ContactInfoTab>(['desk_copilot', 'information']);
+
+function getPersistedTab(): ContactInfoTab {
+  const storedTab = moduleStorage.getItem(
+    CONTACT_INFO_ACTIVE_TAB_KEY,
+    DEFAULT_TAB,
+  );
+  return VALID_TABS.has(storedTab) ? storedTab : DEFAULT_TAB;
+}
 
 type CustomFields = Record<string, string>;
 
@@ -140,6 +165,12 @@ const emit = defineEmits<{
   fullscreen: [url: string, images: MediaItem[]];
   'loaded-medias': [];
 }>();
+
+const activeTab = ref<ContactInfoTab>(getPersistedTab());
+
+watch(activeTab, (tab) => {
+  moduleStorage.setItem(CONTACT_INFO_ACTIVE_TAB_KEY, tab);
+});
 
 const handleFullscreen = (url: string, images: MediaItem[]) => {
   emit('fullscreen', url, images);

--- a/src/components/chats/ContactInfo/Redesign/index.vue
+++ b/src/components/chats/ContactInfo/Redesign/index.vue
@@ -18,6 +18,7 @@
       v-if="activeTab === 'desk_copilot'"
       :isHistory="isHistory"
       :isViewMode="isViewMode"
+      @loaded="emit('loaded-medias')"
     />
 
     <section

--- a/src/components/chats/chat/RoomMessages.vue
+++ b/src/components/chats/chat/RoomMessages.vue
@@ -41,6 +41,8 @@ import { mapActions, mapState, mapWritableState } from 'pinia';
 import { useRooms } from '@/store/modules/chats/rooms';
 import { useRoomMessages } from '@/store/modules/chats/roomMessages';
 import { useConfig } from '@/store/modules/config';
+import { useFeatureFlag } from '@/store/modules/featureFlag';
+import { useAssistedSalesFeatureFlag } from '@/composables/useAssistedSalesFeatureFlag';
 
 import ChatMessages from '@/components/chats/chat/ChatMessages/index.vue';
 import ChatSummary from '@/layouts/ChatsLayout/components/ChatSummary/index.vue';
@@ -108,6 +110,11 @@ export default {
     ...mapState(useConfig, {
       enableRoomSummary: (store) => store.project?.config?.has_chats_summary,
     }),
+    ...mapState(useFeatureFlag, ['featureFlags']),
+
+    isAssistedSalesEnabled() {
+      return useAssistedSalesFeatureFlag(this.featureFlags);
+    },
 
     messagesReady() {
       return (
@@ -119,7 +126,8 @@ export default {
         this.messagesReady &&
         this.openChatSummary &&
         this.showRoomSummary &&
-        this.enableRoomSummary
+        this.enableRoomSummary &&
+        !this.isAssistedSalesEnabled
       );
     },
     hasArchivedContent() {

--- a/src/components/chats/chat/__tests__/RoomMessages.spec.js
+++ b/src/components/chats/chat/__tests__/RoomMessages.spec.js
@@ -6,6 +6,8 @@ import RoomMessages from '../RoomMessages.vue';
 import { useRooms } from '@/store/modules/chats/rooms';
 import { useRoomMessages } from '@/store/modules/chats/roomMessages';
 import { useConfig } from '@/store/modules/config';
+import { useFeatureFlag } from '@/store/modules/featureFlag';
+import { ASSISTED_SALES_FEATURE_FLAG } from '@/composables/useAssistedSalesFeatureFlag';
 import RoomService from '@/services/api/resources/chats/room';
 import RoomNotes from '@/services/api/resources/chats/roomNotes';
 import i18n from '@/plugins/i18n';
@@ -79,6 +81,7 @@ const createWrapper = (props = {}, piniaState = {}) => {
   const roomsStore = useRooms();
   const roomMessagesStore = useRoomMessages();
   const configStore = useConfig();
+  const featureFlagStore = useFeatureFlag();
 
   roomsStore.$patch({
     activeRoom: mockRoom,
@@ -100,6 +103,9 @@ const createWrapper = (props = {}, piniaState = {}) => {
   roomMessagesStore.addRoomMessageSorted = vi.fn();
 
   configStore.project = { config: { has_chats_summary: false } };
+  featureFlagStore.$patch({
+    featureFlags: { active_features: [] },
+  });
 
   if (piniaState.rooms) {
     roomsStore.$patch(piniaState.rooms);
@@ -116,6 +122,9 @@ const createWrapper = (props = {}, piniaState = {}) => {
   }
   if (piniaState.config) {
     Object.assign(configStore, piniaState.config);
+  }
+  if (piniaState.featureFlag) {
+    featureFlagStore.$patch(piniaState.featureFlag);
   }
 
   return mount(RoomMessages, {
@@ -285,6 +294,42 @@ describe('RoomMessages.vue', () => {
       const chatSummary = wrapper.findComponent({ name: 'ChatSummary' });
       expect(chatSummary.exists()).toBe(true);
       expect(chatSummary.props('showSummary')).toBe(true);
+    });
+
+    it('does not render ChatSummary when assisted sales flag is enabled', async () => {
+      RoomNotes.getInternalNotes.mockResolvedValue({ results: [] });
+      RoomService.getSummary.mockResolvedValue({
+        status: 'DONE',
+        summary: 'Resumo',
+        feedback: null,
+      });
+
+      const wrapper = createWrapper(
+        { showRoomSummary: true },
+        {
+          config: {
+            project: { config: { has_chats_summary: true } },
+          },
+          rooms: {
+            openActiveRoomSummary: true,
+            roomsSummary: {
+              [mockRoom.uuid]: { summary: 'Summary', feedback: null },
+            },
+          },
+          featureFlag: {
+            featureFlags: {
+              active_features: [ASSISTED_SALES_FEATURE_FLAG],
+            },
+          },
+        },
+      );
+
+      await flushPromises();
+      wrapper.vm.isLoadingMessages = false;
+      wrapper.vm.silentLoadingMessages = true;
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('[data-testid="chat-summary"]').exists()).toBe(false);
     });
   });
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -845,6 +845,21 @@
         "1": "😡 Very dissatisfied",
         "no_response": "No response"
       }
+    },
+    "desk_copilot": {
+      "copy_summary": "Copy summary",
+      "disclaimer": {
+        "description": "Desk Copilot can help you with:",
+        "enable_button": "Enable Desk Copilot",
+        "items": {
+          "catalog_search": "Catalog search",
+          "next_best_actions": "Next best actions",
+          "product_recommendations": "Product recommendations",
+          "sales_arguments": "Sales arguments"
+        },
+        "title": "Go beyond conversation summaries"
+      },
+      "summary_title": "Summary of this conversation"
     }
   },
   "discussions": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -857,7 +857,8 @@
           "product_recommendations": "Product recommendations",
           "sales_arguments": "Sales arguments"
         },
-        "title": "Go beyond conversation summaries"
+        "title": "Go beyond conversation summaries",
+        "title_without_summary": "Unlock your full potential with Desk Copilot"
       },
       "summary_title": "Summary of this conversation"
     }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -859,7 +859,8 @@
           "product_recommendations": "Recomendaciones de productos",
           "sales_arguments": "Argumentos de venta"
         },
-        "title": "Ve más allá de los resúmenes de conversación"
+        "title": "Ve más allá de los resúmenes de conversación",
+        "title_without_summary": "Desbloquea todo tu potencial con Desk Copilot"
       },
       "summary_title": "Resumen de esta conversación"
     }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -847,6 +847,21 @@
         "1": "😡 Muy insatisfecho",
         "no_response": "Sin respuesta"
       }
+    },
+    "desk_copilot": {
+      "copy_summary": "Copiar resumen",
+      "disclaimer": {
+        "description": "Desk Copilot puede ayudarte con:",
+        "enable_button": "Activar Desk Copilot",
+        "items": {
+          "catalog_search": "Búsqueda en el catálogo",
+          "next_best_actions": "Próximas mejores acciones",
+          "product_recommendations": "Recomendaciones de productos",
+          "sales_arguments": "Argumentos de venta"
+        },
+        "title": "Ve más allá de los resúmenes de conversación"
+      },
+      "summary_title": "Resumen de esta conversación"
     }
   },
   "discussions": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -850,6 +850,21 @@
         "1": "😡 Muito insatisfeito",
         "no_response": "Sem resposta"
       }
+    },
+    "desk_copilot": {
+      "copy_summary": "Copiar resumo",
+      "disclaimer": {
+        "description": "O Desk Copilot pode ajudar você com:",
+        "enable_button": "Ativar Desk Copilot",
+        "items": {
+          "catalog_search": "Busca no catálogo",
+          "next_best_actions": "Próximas melhores ações",
+          "product_recommendations": "Recomendações de produtos",
+          "sales_arguments": "Argumentos de venda"
+        },
+        "title": "Vá além dos resumos de conversa"
+      },
+      "summary_title": "Resumo desta conversa"
     }
   },
   "discussions": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -862,7 +862,8 @@
           "product_recommendations": "Recomendações de produtos",
           "sales_arguments": "Argumentos de venda"
         },
-        "title": "Vá além dos resumos de conversa"
+        "title": "Vá além dos resumos de conversa",
+        "title_without_summary": "Desbloqueie todo o seu potencial com o Desk Copilot"
       },
       "summary_title": "Resumo desta conversa"
     }

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -815,6 +815,21 @@
         "1": "😡 Foarte nemulțumit",
         "no_response": "Fără răspuns"
       }
+    },
+    "desk_copilot": {
+      "copy_summary": "Copiază rezumatul",
+      "disclaimer": {
+        "description": "Desk Copilot te poate ajuta cu:",
+        "enable_button": "Activează Desk Copilot",
+        "items": {
+          "catalog_search": "Căutare în catalog",
+          "next_best_actions": "Următoarele acțiuni recomandate",
+          "product_recommendations": "Recomandări de produse",
+          "sales_arguments": "Argumente de vânzare"
+        },
+        "title": "Mergi dincolo de rezumatele conversațiilor"
+      },
+      "summary_title": "Rezumatul acestei conversații"
     }
   },
   "discussions": {

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -827,7 +827,8 @@
           "product_recommendations": "Recomandări de produse",
           "sales_arguments": "Argumente de vânzare"
         },
-        "title": "Mergi dincolo de rezumatele conversațiilor"
+        "title": "Mergi dincolo de rezumatele conversațiilor",
+        "title_without_summary": "Deblochează-ți tot potențialul cu Desk Copilot"
       },
       "summary_title": "Rezumatul acestei conversații"
     }

--- a/src/services/api/resources/chats/__tests__/copilot.unit.spec.ts
+++ b/src/services/api/resources/chats/__tests__/copilot.unit.spec.ts
@@ -1,0 +1,46 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import Copilot from '../copilot';
+import http from '@/services/api/http';
+
+vi.mock('@/services/api/http', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock('@/utils/config', () => ({
+  getProject: vi.fn(() => 'mocked-project-id'),
+}));
+
+describe('Copilot service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('listConnections', () => {
+    it('requests connections with is_principal false by default', async () => {
+      const connections = [{ conection: { socketUrl: 'wss://example.com' } }];
+      vi.mocked(http.get).mockResolvedValue({ data: connections });
+
+      const result = await Copilot.listConnections();
+
+      expect(http.get).toHaveBeenCalledWith(
+        '/project/mocked-project-id/copilot/list_connections',
+        { params: { is_principal: false } },
+      );
+      expect(result).toEqual(connections);
+    });
+
+    it('forwards isPrincipal true as is_principal param', async () => {
+      vi.mocked(http.get).mockResolvedValue({ data: [] });
+
+      await Copilot.listConnections({ isPrincipal: true });
+
+      expect(http.get).toHaveBeenCalledWith(
+        '/project/mocked-project-id/copilot/list_connections',
+        { params: { is_principal: true } },
+      );
+    });
+  });
+});

--- a/src/services/api/resources/chats/__tests__/copilot.unit.spec.ts
+++ b/src/services/api/resources/chats/__tests__/copilot.unit.spec.ts
@@ -19,28 +19,18 @@ describe('Copilot service', () => {
   });
 
   describe('listConnections', () => {
-    it('requests connections with is_principal false by default', async () => {
-      const connections = [{ conection: { socketUrl: 'wss://example.com' } }];
-      vi.mocked(http.get).mockResolvedValue({ data: connections });
-
+    it('returns the mock connections without calling the API', async () => {
       const result = await Copilot.listConnections();
 
-      expect(http.get).toHaveBeenCalledWith(
-        '/project/mocked-project-id/copilot/list_connections',
-        { params: { is_principal: false } },
-      );
-      expect(result).toEqual(connections);
+      expect(http.get).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
     });
 
-    it('forwards isPrincipal true as is_principal param', async () => {
-      vi.mocked(http.get).mockResolvedValue({ data: [] });
+    it('returns the mock connections regardless of isPrincipal', async () => {
+      const result = await Copilot.listConnections({ isPrincipal: true });
 
-      await Copilot.listConnections({ isPrincipal: true });
-
-      expect(http.get).toHaveBeenCalledWith(
-        '/project/mocked-project-id/copilot/list_connections',
-        { params: { is_principal: true } },
-      );
+      expect(http.get).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
     });
   });
 });

--- a/src/services/api/resources/chats/copilot.ts
+++ b/src/services/api/resources/chats/copilot.ts
@@ -19,10 +19,18 @@ type ListConnectionsParams = {
   isPrincipal?: boolean;
 };
 
+const USE_MOCK_CONNECTIONS = true;
+
+const MOCK_CONNECTIONS: CopilotConnectionItem[] = [];
+
 export default {
   async listConnections({
     isPrincipal = false,
   }: ListConnectionsParams = {}): Promise<CopilotConnectionItem[]> {
+    if (USE_MOCK_CONNECTIONS) {
+      return MOCK_CONNECTIONS;
+    }
+
     const projectUuid = getProject();
     const response = await http.get<CopilotConnectionItem[]>(
       `/project/${projectUuid}/copilot/list_connections`,

--- a/src/services/api/resources/chats/copilot.ts
+++ b/src/services/api/resources/chats/copilot.ts
@@ -1,0 +1,33 @@
+import http from '@/services/api/http';
+import { getProject } from '@/utils/config';
+
+export type CopilotConnection = {
+  socketUrl: string;
+  channelUuid: string;
+  host: string;
+  connectOn: string;
+  storage: string;
+  callbackUrl: string;
+};
+
+export type CopilotConnectionItem = {
+  conection: CopilotConnection;
+  [key: string]: string | CopilotConnection;
+};
+
+type ListConnectionsParams = {
+  isPrincipal?: boolean;
+};
+
+export default {
+  async listConnections({
+    isPrincipal = false,
+  }: ListConnectionsParams = {}): Promise<CopilotConnectionItem[]> {
+    const projectUuid = getProject();
+    const response = await http.get<CopilotConnectionItem[]>(
+      `/project/${projectUuid}/copilot/list_connections`,
+      { params: { is_principal: isPrincipal } },
+    );
+    return response.data;
+  },
+};

--- a/src/services/api/resources/chats/room.js
+++ b/src/services/api/resources/chats/room.js
@@ -61,7 +61,14 @@ export default {
     return response.data;
   },
 
-  async sendSummaryFeedback({ roomUuid, liked, text, tags }) {
+  /**
+   * @param {object} payload
+   * @param {string} payload.roomUuid
+   * @param {boolean} payload.liked
+   * @param {string} [payload.text]
+   * @param {string[]} [payload.tags]
+   */
+  async sendSummaryFeedback({ roomUuid, liked, text = '', tags = [] }) {
     const response = await http.post(
       `/room/${roomUuid}/chats-summary/feedback/`,
       { liked, text, tags },


### PR DESCRIPTION
### Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Tests
- [ ] Chore
- [x] Locales

### Why
The Desk Copilot tab in the contact info panel was previously disabled and non-functional. This change activates it, wiring up the conversation summary display and a disclaimer that prompts admins to enable Desk Copilot when no connections are configured. It also ensures the legacy `ChatSummary` component is hidden when the Assisted Sales feature flag is active, since the summary is now surfaced inside the Copilot tab instead.

### What Changed
- Enabled the **Desk Copilot** tab in `ContactInfoRedesignHeader` and made it the default active tab. The selected tab is persisted to `moduleStorage` so it survives page reloads.
- Added `DeskCopilot/index.vue` as the tab's root, which fetches copilot connection status on mount and conditionally renders the summary and disclaimer.
- Added `SummaryMessage.vue`, which displays the active room's AI-generated conversation summary with a typewriter animation, copy button, and thumbs-up/thumbs-down feedback controls (including a feedback modal on thumbs-down).
- Added `Disclaimer.vue`, which renders an informational card listing Desk Copilot capabilities. Admin users in a live, non-read-only context see an "Enable Desk Copilot" button that redirects to the Live Desk settings route via `emitToHost`.
- Added a `Copilot` API service (`copilot.ts`) with a `listConnections` method used to determine whether the project has an active Copilot configuration.
- Suppressed the existing `ChatSummary` overlay in `RoomMessages.vue` when the Assisted Sales feature flag is enabled, preventing a duplicate summary UI.
- Added i18n strings for all new Desk Copilot UI copy in English, Spanish, Portuguese (BR), and Romanian.
- Added unit and component tests for `Disclaimer`, `SummaryMessage`, `DeskCopilotTab`, `ContactInfoRedesign`, and the `Copilot` service.

### Diagram

```mermaid
flowchart TD
    A[ContactInfoRedesign] -->|v-model activeTab| B[ContactInfoRedesignHeader]
    A -->|activeTab === desk_copilot| C[DeskCopilotTab]
    A -->|activeTab === information| D[Information Panel]

    C -->|has_chats_summary| E[SummaryMessage]
    C -->|listConnections → empty| F[Disclaimer]

    E --> G[Typewriter animation]
    E --> H[Copy / Feedback actions]
    H -->|thumbs down| I[FeedbackModal]

    F -->|admin + live mode| J[Enable button → emitToHost redirect]
```