### PR TITLE
Add and update translations from PR#971

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -341,7 +341,7 @@
         "tooltip": "Each message will display the name of the representative who answered",
         "switch_active": "Display the representative name in messages",
         "switch_disabled": "Display the representative name in messages",
-        "hint": "Each message exchanged will have the name of the representative who is answering.",
+        "hint": "Each exchanged message will have the name of the representative who is answering.",
         "switch_label": "Use signature"
       },
       "csat": {
@@ -359,7 +359,7 @@
           "custom": "Custom flows",
           "default": "Default CSAT survey (recommended)",
           "label": "Survey type",
-          "tooltip": "Choose between the default CSAT survey and a custom flow already configured in the Flows module."
+          "tooltip": "Choose between the default CSAT survey and a custom flow previously configured in the Flows module."
         }
       },
       "automatic_message": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -341,36 +341,25 @@
         "tooltip": "Cada mensaje mostrará el nombre del representante que respondió",
         "switch_active": "Mostrar el nombre del representante en los mensajes",
         "switch_disabled": "Mostrar el nombre del representante en los mensajes",
-        "hint": "Cada mensaje enviado mostrará el nombre del representante que está respondiendo.",
-        "switch_label": "Usar firma"
+        "hint": "Cada mensaje intercambiado tendrá el nombre del representante que está respondiendo.",
+        "switch_label": "Utilizar firma"
       },
       "csat": {
         "custom": {
           "flow_disclaimer": "El flujo seleccionado debe usar una calificación de satisfacción de 1 a 5 para garantizar resultados correctos en la encuesta."
         },
-        "label": "Enviar automáticamente una encuesta de satisfacción después de finalizar el chat de soporte en Live Desk",
         "hint": "Si un flujo activo en el módulo Flujos está configurado para disparar una encuesta tras finalizar el soporte, esta configuración podría entrar en conflicto y afectar la entrega de la encuesta.",
+        "label": "Enviar automáticamente una encuesta de satisfacción después de finalizar el chat de soporte en Live Desk",
+        "confirm_modal": {
+          "content_1": "Si un flujo activo en el módulo Flujos está configurado para disparar una encuesta tras finalizar el soporte, esta configuración podría entrar en conflicto y afectar la entrega de la encuesta.",
+          "content_2": "¿Deseas continuar de todas formas?"
+        },
         "section_title": "Encuesta de satisfacción",
         "type": {
           "custom": "Flujos personalizados",
           "default": "Encuesta CSAT predeterminada (recomendado)",
           "label": "Tipo de encuesta",
           "tooltip": "Elige entre la encuesta CSAT predeterminada o un flujo personalizado ya configurado en el módulo Flujos."
-        },
-        "confirm_modal": {
-          "content_1": "Si un flujo activo en el módulo Flujos está configurado para disparar una encuesta tras finalizar el soporte, esta configuración podría entrar en conflicto y afectar la entrega de la encuesta.",
-          "content_2": "¿Deseas continuar de todas formas?"
-        }
-      },
-      "automated_message": {
-        "title": "Mensajes automatizados",
-        "switch_when_waiting_label": "Enviar mensaje automático a los contactos en espera",
-        "switch_when_start_label": "Enviar mensaje automático al iniciar el soporte",
-        "hint_when_waiting": "Se envía un mensaje automático a los contactos que están en la cola esperando soporte humano.",
-        "hint_when_start": "Se envía un mensaje automático cuando un chat se asigna a un representante. En el chat, el mensaje aparece como enviado por el representante asignado.",
-        "field": {
-          "title": "Mensaje automático",
-          "placeholder": "Ejemplo: ¡Hola! ¿Cómo puedo ayudarte hoy?"
         }
       },
       "automatic_message": {
@@ -386,7 +375,18 @@
         "switch_active": "Exigir tag al finalizar el chat de soporte",
         "switch_disabled": "Exigir tag al finalizar el chat de soporte",
         "tooltip": "Agrega al menos una tag para activar",
-        "switch_label": "Exigir etiquetas al final del soporte humano"
+        "switch_label": "Exigir tags al finalizar el soporte humano"
+      },
+      "automated_message": {
+        "title": "Mensajes automatizados",
+        "switch_when_waiting_label": "Enviar mensaje automático a los contactos en espera",
+        "switch_when_start_label": "Enviar mensaje automático al iniciar el soporte",
+        "hint_when_waiting": "Se envía automáticamente un mensaje a los contactos mientras están en la cola esperando soporte humano.",
+        "hint_when_start": "Se envía automáticamente un mensaje cuando un chat se asigna a un representante. El mensaje aparecerá como si lo hubiera enviado el representante asignado.",
+        "field": {
+          "title": "Mensaje automático",
+          "placeholder": "Ejemplo: ¡Hola! ¿Cómo puedo ayudarte hoy?"
+        }
       }
     }
   },
@@ -425,9 +425,6 @@
   "addition_date": "Fecha de registro",
   "in_queues": "en cola",
   "in_progress": "En curso",
-  "waiting": "Esperando",
-  "sent_flows": "Flujos enviados",
-  "discussion": "Discusiones",
   "in_progress_tooltip": "Número de chats atendidos por un representante actualmente",
   "in_progress_tooltip_filtered": "Número de chats atendidos por un representante",
   "closed": "Cerrados",
@@ -503,6 +500,7 @@
       "transfer_to_queue": "{agent} transferido a la cola {queue}",
       "transfer_from_queue_to_queue": "Transferido de la cola {queue1} a la cola {queue2}",
       "transfer_from_queue_to_agent": "Transferido de la cola {queue} a {agent}",
+      "transfer_from_queue_to_agent_by_other": "{requestedBy} transfirió el chat de la cola {queue} a {agent}",
       "pick_of_queue": "{agent} se asignó el chat de la cola {queue}",
       "pick_of_agent": "{manager} se asignó el chat de {agent}",
       "edit_custom_field": "campo personalizado editado",
@@ -512,7 +510,6 @@
       "automatic_transfer_from_queue": "Sala asignada a {agent}",
       "see_all_internal_notes": "<b style='color: white;'>Ver observación interna</b>",
       "chat_ended_by": "Chat finalizado por {agent}",
-      "transfer_from_queue_to_agent_by_other": "{requestedBy} transfirió el chat de la cola {queue} a {agent}",
       "transfer_from_queue_to_queue_by_other": "{requestedBy} transfirió el chat de la cola {queue1} a la cola {queue2}",
       "transfer_to_agent_by_other": "{requestedBy} transfirió el chat de {agent1} a {agent2}",
       "transfer_to_queue_by_other": "{requestedBy} transfirió el chat de {agent} a la cola {queue}",
@@ -598,11 +595,11 @@
     "your_chat_assumed": "Este chat se lo ha asignado otro representante",
     "your_chat_assumed_description": "El chat con {contact} se lo ha asignado {representative}",
     "closed_chats": {
+      "contact_history": "Historial del contacto",
       "general_history": "Historial general",
       "history": "Historial",
       "history_description": "Historial de todos los registros de chat de soporte del proyecto {projectName}",
-      "project_history": "Historial del proyecto",
-      "contact_history": "Historial del contacto"
+      "project_history": "Historial del proyecto"
     },
     "assigned_queues": "Colas asignadas",
     "select_queues": "Seleccionar colas",
@@ -630,6 +627,7 @@
       "assume_chat_confirmation": "Si confirmas, este chat se transferirá de {viewedAgent} a ti"
     }
   },
+  "select": "Seleccionar",
   "history": "Historial",
   "close_view": "Cerrar vista",
   "logout": "Cerrar sesión",
@@ -1027,6 +1025,7 @@
     "delete_description": "¿Realmente deseas eliminar el mensaje rápido {shortcut}?",
     "shortcut_tooltip": "Escribe /{shortcut} para usarlo",
     "new": "Nuevo mensaje rápido",
+    "description_new": "Mensaje rápido en el departamento {sector}",
     "add": "Agregar mensaje rápido",
     "edit": "Editar mensaje rápido",
     "available_shortcuts": "Atajos disponibles",
@@ -1036,14 +1035,13 @@
     "message_field_placeholder": "Ejemplo: Hola, ¿cómo estás? ¿En qué puedo ayudarte hoy?",
     "successfully_added": "Mensaje rápido agregado",
     "successfully_updated": "Mensaje rápido actualizado",
+    "successfully_deleted": "Mensaje rápido eliminado con éxito",
+    "error_deleting": "No se pudo eliminar el mensaje rápido.",
     "error": "Error al configurar mensaje rápido",
     "no_suggestions": "No se encontraron resultados para el atajo ingresado",
     "disclaimer": "Escribe / (barra) en el campo de mensaje para ver los mensajes rápidos",
     "action_open": "Abrir mensajes rápidos (/)",
-    "action_close": "Cerrar mensajes rápidos",
-    "description_new": "Mensaje rápido en el departamento {sector}",
-    "error_deleting": "No se pudo eliminar el mensaje rápido.",
-    "successfully_deleted": "Mensaje rápido eliminado con éxito"
+    "action_close": "Cerrar mensajes rápidos"
   },
   "discard": "Descartar",
   "on_boarding": {
@@ -1096,11 +1094,11 @@
     "filter_by_group_name": "Filtrar por nombre del grupo",
     "section_sectors_subtitle": "Agrega, consulta y gestiona departamentos, colas, managers y representantes dentro de tu organización.",
     "tabs": {
+      "general": "General",
       "settings": "Configuración",
       "groups": "Grupos de proyectos",
       "sectors": "Departamentos",
-      "representatives": "Representantes",
-      "general": "General"
+      "representatives": "Representantes"
     },
     "custom_breaks": {
       "title": "Pausas personalizadas",
@@ -1116,11 +1114,11 @@
       "status_remove_success": "Status {status} removido",
       "status_error": "Error al guardar cambios. Vuelve a intentarlo.",
       "delete_modal": {
+        "title": "Eliminar pausa personalizada",
         "description_1": "¿Realmente deseas eliminar la pausa personalizada “{name}”?",
         "description_2": "Una vez eliminada, sus datos ya no aparecerán en el panel de Live Desk y no podrán recuperarse.",
-        "error": "No se pudo eliminar la pausa personalizada.",
         "success": "Pausa personalizada eliminada con éxito",
-        "title": "Eliminar pausa personalizada"
+        "error": "No se pudo eliminar la pausa personalizada."
       }
     },
     "changes_saved": "Cambios guardados con éxito",
@@ -1203,10 +1201,9 @@
     "queues": {
       "in_sector": "Cola en el departamento {sector}",
       "new": "Nueva cola",
-      "info": "Las colas son grupos de soporte dentro de un departamento. Puedes dirigir contactos desde un flujo a una cola específica.",
       "title": "Gestión de colas",
+      "info": "Las colas son grupos de soporte dentro de un departamento. Puedes dirigir contactos desde un flujo a una cola específica.",
       "hint": "Las colas son grupos de soporte dentro de un departamento. Puedes crearlas o editarlas en cualquier momento.",
-      "queue_definitions": "Configuración de la cola",
       "filter_by_name": "Filtrar por nombre de la cola",
       "add_queue": "Agregar cola",
       "delete_this_queue": "Escribe el nombre de la cola a eliminar",
@@ -1215,6 +1212,7 @@
         "title": "Configurar cola",
         "tooltip": "Las colas son grupos de atención dentro del departamento. Puedes crear nuevas colas o editarlas cuando quieras después de crear el departamento."
       },
+      "queue_definitions": "Configuración de la cola",
       "delete_or_edit": "Eliminar o editar",
       "limit_chats": {
         "title": "Límite de chats esperando soporte",
@@ -1523,7 +1521,6 @@
       "tooltip": "No respondiste a este contacto"
     }
   },
-  "select": "Seleccionar",
   "mass_message": {
     "title": "Mensaje en masa",
     "form": {
@@ -1593,5 +1590,8 @@
       "activate": "Modo de voz",
       "stop": "Detener"
     }
-  }
+  },
+  "waiting": "Esperando",
+  "sent_flows": "Flujos enviados",
+  "discussion": "Discusiones"
 }

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -341,7 +341,7 @@
         "tooltip": "Cada mensagem exibirá o nome do atendente que respondeu",
         "switch_active": "Exibir nome do atendente nas mensagens",
         "switch_disabled": "Exibir nome do atendente nas mensagens",
-        "hint": "Cada mensagem trocada exibirá o nome do agente que está respondendo.",
+        "hint": "Cada mensagem trocada terá o nome do atendente que está respondendo.",
         "switch_label": "Usar assinatura"
       },
       "csat": {
@@ -350,16 +350,16 @@
         },
         "hint": "Se um fluxo ativo no módulo Fluxos estiver configurado para disparar uma pesquisa após o fim do suporte, esta configuração pode conflitar com o fluxo e afetar a entrega da pesquisa.",
         "label": "Enviar automaticamente uma pesquisa de satisfação após o fim do suporte no Live Desk",
+        "confirm_modal": {
+          "content_1": "Se um fluxo ativo no módulo Fluxos estiver configurado para disparar uma pesquisa após o fim do suporte, esta configuração pode conflitar com o fluxo e afetar a entrega da pesquisa.",
+          "content_2": "Deseja continuar mesmo assim?"
+        },
         "section_title": "Pesquisa de satisfação",
         "type": {
           "custom": "Fluxos personalizados",
           "default": "Pesquisa CSAT padrão (recomendado)",
           "label": "Tipo de pesquisa",
-          "tooltip": "Escolha entre a pesquisa CSAT padrão ou um fluxo personalizado já configurado no módulo Fluxos."
-        },
-        "confirm_modal": {
-          "content_1": "Se um fluxo ativo no módulo Fluxos estiver configurado para disparar uma pesquisa após o fim do suporte, esta configuração pode conflitar com o fluxo e afetar a entrega da pesquisa.",
-          "content_2": "Deseja continuar mesmo assim?"
+          "tooltip": "Escolha entre a pesquisa CSAT padrão e um fluxo personalizado já configurado no módulo Fluxos."
         }
       },
       "automatic_message": {
@@ -378,7 +378,7 @@
         "switch_label": "Exigir tags ao final do atendimento humano"
       },
       "automated_message": {
-        "title": "Mensagens automatizadas",
+        "title": "Mensagens automáticas",
         "switch_when_waiting_label": "Enviar mensagem automática para contatos na fila de espera",
         "switch_when_start_label": "Enviar mensagem automática quando o atendimento começar",
         "hint_when_waiting": "Envia automaticamente uma mensagem para os contatos enquanto aguardam atendimento humano na fila.",
@@ -425,9 +425,6 @@
   "addition_date": "Data de cadastro",
   "in_queues": "nas filas",
   "in_progress": "Em andamento",
-  "waiting": "Aguardando",
-  "sent_flows": "Fluxos enviados",
-  "discussion": "Discussões",
   "in_progress_tooltip": "Número de chats sendo atendidos por um atendente",
   "in_progress_tooltip_filtered": "Número de chats que foram atendidos por um atendente",
   "closed": "Encerrados",
@@ -497,24 +494,24 @@
       }
     },
     "feedback": {
-      "agent_took_chat": "Ops! O chat com o contato {contact} já foi assumido por outro atendente",
-      "automatic_transfer_from_queue": "Sala atribuída a {agent}",
-      "chat_ended_by": "Chat finalizado por {agent}",
-      "discussion_created": "{agent} iniciou uma discussão na fila {queue}",
-      "discussion_joined": "{agent} entrou na discussão",
-      "edit_custom_field": "campo customizável editado",
       "forwarded_to_agent": "Contato transferido para o atendente {agent}",
       "forwarded_to_queue": "Contato transferido para a fila {queue}",
-      "pick_of_agent": "{manager} assumiu o chat de {agent}",
-      "pick_of_queue": "{agent} assumiu o chat da fila {queue}",
-      "see_all_internal_notes": "<b style='color: white;'>Ver notas internas</b>",
+      "transfer_to_agent": "{agent1} transferido para {agent2}",
+      "transfer_to_queue": "{agent} transferido para a fila {queue}",
+      "transfer_from_queue_to_queue": "Foi transferido da fila {queue1} para a fila {queue2}",
       "transfer_from_queue_to_agent": "Transferido da fila {queue} para {agent}",
       "transfer_from_queue_to_agent_by_other": "{requestedBy} transferiu o chat da fila {queue} para {agent}",
-      "transfer_from_queue_to_queue": "Foi transferido da fila {queue1} para a fila {queue2}",
+      "pick_of_queue": "{agent} assumiu o chat da fila {queue}",
+      "pick_of_agent": "{manager} assumiu o chat de {agent}",
+      "edit_custom_field": "campo customizável editado",
+      "discussion_created": "{agent} iniciou uma discussão na fila {queue}",
+      "discussion_joined": "{agent} entrou na discussão",
+      "agent_took_chat": "Ops! O chat com o contato {contact} já foi assumido por outro atendente",
+      "automatic_transfer_from_queue": "Sala atribuída a {agent}",
+      "see_all_internal_notes": "<b style='color: white;'>Ver notas internas</b>",
+      "chat_ended_by": "Chat finalizado por {agent}",
       "transfer_from_queue_to_queue_by_other": "{requestedBy} transferiu o chat da fila {queue1} para a fila {queue2}",
-      "transfer_to_agent": "{agent1} transferido para {agent2}",
       "transfer_to_agent_by_other": "{requestedBy} transferiu o chat de {agent1} para {agent2}",
-      "transfer_to_queue": "{agent} transferido para a fila {queue}",
       "transfer_to_queue_by_other": "{requestedBy} transferiu o chat de {agent} para a fila {queue}",
       "automatic_close_room": "Encerrado automaticamente por falta de interação do contato"
     },
@@ -814,8 +811,6 @@
     "partial_success_message": "{success, plural, one {{success} chat assumido, {failed} falhou. Tente novamente.} other {{success} chats assumidos, {failed} falharam. Tente novamente.}}",
     "error_message": "Não foi possível assumir os chats, tente novamente"
   },
-  "close_contact": "Encerrar contato",
-  "close_contact_confirmation": "Tem certeza que deseja encerrar este contato?",
   "contact_info": {
     "title": "Sobre o contato",
     "about_support": "Sobre o atendimento",
@@ -1099,11 +1094,11 @@
     "filter_by_group_name": "Filtrar por nome do grupo",
     "section_sectors_subtitle": "Adicione, visualize e gerencie setores, filas, gerentes e atendentes na sua organização.",
     "tabs": {
+      "general": "Geral",
       "settings": "Configurações",
       "groups": "Grupos do projeto",
       "sectors": "Setores",
-      "representatives": "Atendentes",
-      "general": "Geral"
+      "representatives": "Atendentes"
     },
     "custom_breaks": {
       "title": "Pausas personalizadas",
@@ -1119,11 +1114,11 @@
       "status_remove_success": "Status {status} removido",
       "status_error": "Erro ao salvar alterações. Tente novamente.",
       "delete_modal": {
+        "title": "Excluir pausa personalizada",
         "description_1": "Tem certeza de que deseja excluir a pausa personalizada “{name}”?",
         "description_2": "Depois de excluir, os dados não aparecerão mais no painel do Live Desk e não poderão ser recuperados.",
-        "error": "Não foi possível excluir a pausa personalizada.",
         "success": "Pausa personalizada excluída com sucesso",
-        "title": "Excluir pausa personalizada"
+        "error": "Não foi possível excluir a pausa personalizada."
       }
     },
     "changes_saved": "Alterações salvas com sucesso",
@@ -1206,8 +1201,8 @@
     "queues": {
       "in_sector": "Fila no setor {sector}",
       "new": "Nova fila",
-      "info": "Filas são grupos de suporte dentro de um setor. Você pode direcionar os contatos de um fluxo para uma fila específica.",
       "title": "Gestão de filas",
+      "info": "Filas são grupos de suporte dentro de um setor. Você pode direcionar os contatos de um fluxo para uma fila específica.",
       "hint": "Filas são grupos de suporte dentro de um setor. Você pode criar ou editar uma fila a qualquer momento.",
       "filter_by_name": "Filtrar por nome da fila",
       "add_queue": "Adicionar fila",
@@ -1595,5 +1590,10 @@
       "activate": "Modo de voz",
       "stop": "Desativar"
     }
-  }
+  },
+  "waiting": "Aguardando",
+  "sent_flows": "Fluxos enviados",
+  "discussion": "Discussões",
+  "close_contact": "Encerrar contato",
+  "close_contact_confirmation": "Tem certeza que deseja encerrar este contato?"
 }

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -148,6 +148,7 @@
     "inactive_close_message": "Mesaj de încheiere",
     "bulk_message": "Mesaj în masă trimis de {sender}"
   },
+  "inactive": "Inactiv",
   "inactive_room_tooltip": "{minutes, plural, one {Conversația a atins limita de inactivitate de {minutes} minut.} few {Conversația a atins limita de inactivitate de {minutes} minute.} other {Conversația a atins limita de inactivitate de {minutes} de minute.}}",
   "reply": "Răspuns",
   "chats_count": "{count, plural, one {{count} chat} few {{count} chaturi} other {{count} de chaturi}}",
@@ -276,28 +277,28 @@
     "additional_options": {
       "title": "Opțiuni suplimentare",
       "inactivity_timeout": {
+        "title": "Inactivitate conversație",
         "show": {
+          "switch_label": "Afișează alerta de inactivitate reprezentantului și notifică contactul",
+          "hint": "Alerta este afișată doar pentru chaturile în desfășurare și ia în considerare timpul de la ultimul mesaj al reprezentantului.",
           "field": {
-            "default_warning_message": "Mai ești aici? Dacă nu există niciun răspuns, această sesiune va fi închisă în curând.",
             "timeout_time_label": "Definește câte minute fără un răspuns din partea contactului ar trebui să aștepte sistemul înainte de a trimite un mesaj de inactivitate",
             "timeout_time_tooltip": "În acest moment, reprezentantul va vedea, de asemenea, chatul marcat cu o alertă de inactivitate.",
             "warning_message_label": "Mesaj de inactivitate",
-            "warning_message_tooltip": "Mesajul va apărea ca și cum ar fi fost trimis de reprezentantul atribuit."
-          },
-          "switch_label": "Afișează alerta de inactivitate reprezentantului și notifică contactul",
-          "hint": "Alerta este afișată doar pentru chaturile în desfășurare și ia în considerare timpul de la ultimul mesaj al reprezentantului."
+            "warning_message_tooltip": "Mesajul va apărea ca și cum ar fi fost trimis de reprezentantul atribuit.",
+            "default_warning_message": "Mai ești aici? Dacă nu există niciun răspuns, această sesiune va fi închisă în curând."
+          }
         },
         "close_room": {
+          "switch_label": "Închide automat chaturile inactive",
+          "hint": "Chaturile sunt închise automat dacă contactul nu trimite niciun mesaj în perioada de după trimiterea alertei.",
           "field": {
-            "default_close_room_message": "Această sesiune s-a încheiat din cauza inactivității. Poți începe o nouă conversație oricând!",
             "close_room_time_label": "Definește câte minute trebuie să aștepte sistemul pentru a încheia conversația după trimiterea mesajului de inactivitate",
             "close_room_message_label": "Mesaj de închidere",
-            "close_room_message_tooltip": "Mesajul va apărea ca și cum ar fi fost trimis de reprezentantul atribuit."
-          },
-          "switch_label": "Închide automat chaturile inactive",
-          "hint": "Chaturile sunt închise automat dacă contactul nu trimite niciun mesaj în perioada de după trimiterea alertei."
-        },
-        "title": "Inactivitate conversație"
+            "close_room_message_tooltip": "Mesajul va apărea ca și cum ar fi fost trimis de reprezentantul atribuit.",
+            "default_close_room_message": "Această sesiune s-a încheiat din cauza inactivității. Poți începe o nouă conversație oricând!"
+          }
+        }
       },
       "template_message": {
         "switch_active": "Declanșare șabloane mesaj",
@@ -309,7 +310,7 @@
         "tooltip": "Fiecare mesaj va afișa numele reprezentantului care a răspuns",
         "switch_active": "Afișează numele reprezentativ în mesaje",
         "switch_disabled": "Afișează numele reprezentativ în mesaje",
-        "hint": "Fiecare mesaj trimis va avea numele reprezentantului care răspunde.",
+        "hint": "Fiecare mesaj schimbat va avea numele reprezentantului care răspunde.",
         "switch_label": "Folosește semnătura"
       },
       "csat": {
@@ -415,10 +416,6 @@
   "interaction_time": "Timp interacțiune",
   "average_interaction_time": "Durata medie a conversației în chat",
   "chats": {
-    "audio_download": {
-      "tooltip": "Exportare",
-      "error": "Nu s-a putut exporta fișierul audio din cauza unei probleme tehnice"
-    },
     "transcription": {
       "unavailable_closed_chat": "Nu poți vizualiza transcrierile care nu au fost activate în timpul interacțiunii",
       "unavailable_exceeding_duration": "Transcrierea nu este disponibilă pentru audio mai lung de {duration} minute",
@@ -434,6 +431,10 @@
           "input_placeholder": "Împărtășește feedbackul tău aici"
         }
       }
+    },
+    "audio_download": {
+      "tooltip": "Exportare",
+      "error": "Nu s-a putut exporta fișierul audio din cauza unei probleme tehnice"
     },
     "search_messages": {
       "title": "Caută în conversație",
@@ -475,6 +476,7 @@
       "transfer_to_queue": "{agent} a transferat în coada {queue}",
       "transfer_from_queue_to_queue": "A fost transferat din coada {queue1} în coada {queue2}",
       "transfer_from_queue_to_agent": "A fost transferat din coada {queue} către {agent}",
+      "transfer_from_queue_to_agent_by_other": "{requestedBy} a transferat chatul din coada {queue} către {agent}",
       "pick_of_queue": "{agent} a preluat chatul din coada {queue}",
       "pick_of_agent": "{manager} a preluat chatul care era cu {agent}",
       "edit_custom_field": "a editat un câmp personalizat",
@@ -482,13 +484,12 @@
       "discussion_joined": "{agent} s-a alăturat discuției",
       "agent_took_chat": "Ups! Chatul cu contactul {contact} a fost deja preluat de un alt agent",
       "automatic_transfer_from_queue": "Cameră atribuită lui {agent}",
-      "automatic_close_room": "Închis automat din cauza lipsei de interacțiune din partea contactului",
       "see_all_internal_notes": "<b style='color: white;'>Vedeți notele interne</b>",
-      "transfer_to_agent_by_other": "{requestedBy} a transferat conversația lui {agent1} către {agent2}",
       "chat_ended_by": "Conversație încheiată de {agent}",
-      "transfer_from_queue_to_agent_by_other": "{requestedBy} a transferat chatul din coada {queue} către {agent}",
       "transfer_from_queue_to_queue_by_other": "{requestedBy} a transferat chatul din coada {queue1} în coada {queue2}",
-      "transfer_to_queue_by_other": "{requestedBy} a transferat chatul lui {agent} în coada {queue}"
+      "transfer_to_agent_by_other": "{requestedBy} a transferat conversația lui {agent1} către {agent2}",
+      "transfer_to_queue_by_other": "{requestedBy} a transferat chatul lui {agent} în coada {queue}",
+      "automatic_close_room": "Închis automat din cauza lipsei de interacțiune din partea contactului"
     },
     "room_list": {
       "order_by": "Sortează după:",
@@ -662,6 +663,7 @@
   "pagination": "{from} – {to} din {total}",
   "contact": "Contact",
   "unread_messages": "{count, plural, one {{count} mesaj necitit} few {{count} mesaje necitite} other {{count} de mesaje necitite}}",
+  "automatically_ended": "Închis automat",
   "unnamed_contact": "Contact fără nume",
   "unnamed_agent": "Reprezentant fără nume",
   "no_agent_assigned": "Niciun reprezentant atribuit",
@@ -1537,7 +1539,5 @@
       "activate": "Mod vocal",
       "stop": "Oprire"
     }
-  },
-  "inactive": "Inactiv",
-  "automatically_ended": "Închis automat"
+  }
 }


### PR DESCRIPTION
Add and update translations from [PR#971](https://github.com/weni-ai/chats-webapp/pull/971). Tracked in [LOC-27432](https://vtex-dev.atlassian.net/browse/LOC-27432).

Updates `sector.additional_options` strings in en, pt_br, es, and ro.