### PR TITLE
[ENGAGE-9309] Add block_link_contact_agents configuration option

### DIFF
--- a/src/components/chats/ChatContact.vue
+++ b/src/components/chats/ChatContact.vue
@@ -163,7 +163,7 @@
             :scheme="schemePin"
           />
         </button>
-        <UnnnicTooltip
+        <UnnnicToolTip
           v-else-if="newMessageIndicator"
           class="chats-contact__infos__new-message-indicator-tooltip"
           :enabled="!!newMessageIndicatorTooltip"
@@ -174,7 +174,7 @@
             class="chats-contact__infos__new-message-indicator"
             data-testid="new-message-indicator"
           />
-        </UnnnicTooltip>
+        </UnnnicToolTip>
         <p
           v-else-if="(unreadMessages && !selected) || forceShowUnreadMessages"
           class="chats-contact__infos__unread-messages"

--- a/src/components/chats/ContactInfo/index.vue
+++ b/src/components/chats/ContactInfo/index.vue
@@ -55,7 +55,12 @@
               </section>
             </section>
             <div
-              v-if="!isLinkedToOtherAgent && !isViewMode && !isHistory"
+              v-if="
+                !isLinkedToOtherAgent &&
+                !isViewMode &&
+                !isHistory &&
+                !isLinkContactBlocked
+              "
               class="sync-contact"
             >
               <UnnnicSwitch
@@ -202,6 +207,7 @@ import isMobile from 'is-mobile';
 import { mapActions, mapState } from 'pinia';
 import { useRooms } from '@/store/modules/chats/rooms';
 import { useRoomMessages } from '@/store/modules/chats/roomMessages';
+import { useConfig } from '@/store/modules/config';
 
 import AsideSlotTemplate from '@/components/layouts/chats/AsideSlotTemplate/index.vue';
 import AsideSlotTemplateSection from '@/components/layouts/chats/AsideSlotTemplate/Section.vue';
@@ -282,6 +288,11 @@ export default {
       activeRoomSummary: 'activeRoomSummary',
       isLoadingActiveRoomSummary: 'isLoadingActiveRoomSummary',
     }),
+    ...mapState(useConfig, ['project']),
+
+    isLinkContactBlocked() {
+      return !!this.project?.config?.block_link_contact_agents;
+    },
 
     hasCustomFields() {
       return Object.keys(this.computedCustomFields).length > 0;

--- a/src/components/chats/Message/index.vue
+++ b/src/components/chats/Message/index.vue
@@ -109,7 +109,7 @@
         "
         class="unnnic-chats-message__tooltip"
       >
-        <UnnnicTooltip
+        <UnnnicToolTip
           enabled
           size="right"
           :text="$t('reply')"
@@ -123,7 +123,7 @@
             data-testid="reply-icon"
             @click.stop="$emit('reply')"
           />
-        </UnnnicTooltip>
+        </UnnnicToolTip>
       </section>
       <section
         v-else

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1140,6 +1140,10 @@
         "switch_label": "Allow interactions only for online representatives",
         "hint": "If this option is enabled, representatives that are offline or on break won't be able to respond to chats in progress"
       },
+      "block_link_contact_agents": {
+        "switch_label": "Block representatives from linking contacts",
+        "hint": "If this option is enabled, representatives won't be able to link contacts to themselves"
+      },
       "bulk_transfer": {
         "tooltip": "This function allows representatives to transfer different contacts at once",
         "switch_active": "Transfer chats in bulk to another queue or representative",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1140,6 +1140,10 @@
         "switch_label": "Permitir interacciones solo para representantes online",
         "hint": "Si esta opción está activa, los representantes offline o en pausa no podrán responder a chats en curso."
       },
+      "block_link_contact_agents": {
+        "switch_label": "Bloquear la vinculación de contactos por los representantes",
+        "hint": "Si esta opción está activa, los representantes no podrán vincular contactos a ellos"
+      },
       "bulk_transfer": {
         "tooltip": "Esta función permite a los representantes transferir diferentes contactos a la vez",
         "switch_active": "Transferir chats en masa a otra cola o representante",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -1140,6 +1140,10 @@
         "switch_label": "Permitir interações apenas para atendentes online",
         "hint": "Se essa opção estiver ativada, atendentes offline ou em pausa não poderão responder a chats em andamento."
       },
+      "block_link_contact_agents": {
+        "switch_label": "Bloquear a vinculação de contatos pelos atendentes",
+        "hint": "Se essa opção estiver ativada, os atendentes não poderão vincular contatos a eles"
+      },
       "bulk_transfer": {
         "tooltip": "Esta função permite que os atendentes transfiram diferentes contatos de uma só vez",
         "switch_active": "Transferir chats em massa para outra fila ou atendente",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -1115,6 +1115,10 @@
         "switch_label": "Permite interacțiuni doar pentru reprezentanții online",
         "hint": "Dacă această opțiune este activată, reprezentanții care sunt offline sau în pauză nu vor putea răspunde la conversațiile în curs"
       },
+      "block_link_contact_agents": {
+        "switch_label": "Blochează asocierea contactelor de către reprezentanți",
+        "hint": "Dacă această opțiune este activată, reprezentanții nu vor putea asocia contacte la ei"
+      },
       "bulk_transfer": {
         "tooltip": "Această funcție permite reprezentanților să transfere simultan mai multe contacte",
         "switch_active": "Transferă chaturile în masă către o altă coadă sau reprezentant",

--- a/src/views/Settings/SettingsProjectOptions/__tests__/SettingsProjectOptions.spec.js
+++ b/src/views/Settings/SettingsProjectOptions/__tests__/SettingsProjectOptions.spec.js
@@ -233,6 +233,7 @@ describe('SettingsProjectOptions.vue', () => {
   describe('Groups mode (main vs secondary project)', () => {
     const otherKeys = [
       'restrict_offline_agents',
+      'block_link_contact_agents',
       'can_use_bulk_transfer',
       'filter_offline_agents',
       'filter_moderators',

--- a/src/views/Settings/SettingsProjectOptions/index.vue
+++ b/src/views/Settings/SettingsProjectOptions/index.vue
@@ -107,6 +107,7 @@ export default {
         can_see_waiting_rooms_count: true,
         can_use_name_sector_in_rooms: false,
         restrict_offline_agents: false,
+        block_link_contact_agents: false,
       },
       hasAgentBuilder: false,
       aiTransferConfig: {
@@ -216,6 +217,17 @@ export default {
           ),
           hint: this.$t(
             'config_chats.project_configs.restrict_offline_agents.hint',
+          ),
+        },
+        {
+          key: 'block_link_contact_agents',
+          type: 'flag',
+          visible: !this.isSecondaryProject,
+          name: this.$t(
+            'config_chats.project_configs.block_link_contact_agents.switch_label',
+          ),
+          hint: this.$t(
+            'config_chats.project_configs.block_link_contact_agents.hint',
           ),
         },
         {
@@ -392,6 +404,7 @@ export default {
         can_see_waiting_rooms_count,
         can_use_name_sector_in_rooms,
         restrict_offline_agents,
+        block_link_contact_agents,
       } = this.projectConfig;
 
       await Project.update({
@@ -406,6 +419,7 @@ export default {
         can_see_waiting_rooms_count,
         can_use_name_sector_in_rooms,
         restrict_offline_agents,
+        block_link_contact_agents,
       });
 
       this.project.config = {


### PR DESCRIPTION
### Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Tests
- [ ] Chore
- [x] Locales

### Why
Admins need the ability to prevent representatives from linking contacts to themselves, giving project administrators more control over contact assignment workflows.

### What Changed
- Added a new `block_link_contact_agents` project configuration flag that, when enabled, hides the contact linking toggle from representatives in the contact info panel.
- The `isLinkContactBlocked` computed property reads `project.config.block_link_contact_agents` from the config store and conditionally renders the sync-contact switch in `ContactInfo`.
- The new setting is included in the project settings save/load flow alongside existing flags.
- Added the `block_link_contact_agents` option to the project settings UI with the appropriate label and hint.
- Added localization strings for the new setting in English, Spanish, Portuguese, and Romanian.
- Fixed `UnnnicTooltip` → `UnnnicToolTip` casing in `ChatContact` and `Message` components.
- Updated tests to include `block_link_contact_agents` in the expected set of non-main-project-only config keys.