### PR TITLE
feat: add `hide_desk_copilot_tab` project config to hide Desk Copilot tab for representatives

### DIFF
--- a/src/components/chats/ContactInfo/Redesign/Header.vue
+++ b/src/components/chats/ContactInfo/Redesign/Header.vue
@@ -10,6 +10,7 @@
     >
       <UnnnicSegmentedControlList>
         <UnnnicSegmentedControlTrigger
+          v-if="showDeskCopilotTab"
           value="desk_copilot"
           data-testid="segmented-desk-copilot"
         >
@@ -59,12 +60,14 @@ withDefaults(
     showRefresh?: boolean;
     showClose?: boolean;
     isRefreshDisabled?: boolean;
+    showDeskCopilotTab?: boolean;
   }>(),
   {
     modelValue: 'desk_copilot',
     showRefresh: true,
     showClose: true,
     isRefreshDisabled: false,
+    showDeskCopilotTab: true,
   },
 );
 

--- a/src/components/chats/ContactInfo/Redesign/Header.vue
+++ b/src/components/chats/ContactInfo/Redesign/Header.vue
@@ -1,6 +1,9 @@
 <template>
   <header
     class="contact-info-redesign-header"
+    :class="{
+      'contact-info-redesign-header--compact': !showDeskCopilotTab,
+    }"
     data-testid="contact-info-redesign-header"
   >
     <UnnnicSegmentedControl
@@ -82,6 +85,7 @@ const emit = defineEmits<{
 .contact-info-redesign-header {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: $unnnic-space-2;
   padding: $unnnic-space-2;
   min-height: var(--chats-column-header-height, 57px);
@@ -90,6 +94,15 @@ const emit = defineEmits<{
   &__segmented {
     flex: 1;
     min-width: 0;
+  }
+
+  &--compact &__segmented {
+    flex: 0 0 auto;
+    min-width: unset;
+
+    :deep(.unnnic-segmented-control-trigger) {
+      width: auto;
+    }
   }
 
   &__actions {

--- a/src/components/chats/ContactInfo/Redesign/__tests__/Header.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/__tests__/Header.spec.js
@@ -119,4 +119,18 @@ describe('ContactInfoRedesignHeader', () => {
     expect(wrapper.find('[data-testid="refresh-button"]').exists()).toBe(false);
     expect(wrapper.find('[data-testid="close-button"]').exists()).toBe(false);
   });
+
+  it('hides the desk copilot tab when showDeskCopilotTab is false', () => {
+    wrapper = createWrapper({
+      showDeskCopilotTab: false,
+      modelValue: 'information',
+    });
+
+    expect(
+      wrapper.find('[data-testid="segmented-desk-copilot"]').exists(),
+    ).toBe(false);
+    expect(wrapper.find('[data-testid="segmented-information"]').exists()).toBe(
+      true,
+    );
+  });
 });

--- a/src/components/chats/ContactInfo/Redesign/__tests__/Header.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/__tests__/Header.spec.js
@@ -133,4 +133,27 @@ describe('ContactInfoRedesignHeader', () => {
       true,
     );
   });
+
+  it('keeps the information tab compact on the left when desk copilot is hidden', () => {
+    wrapper = createWrapper({
+      showDeskCopilotTab: false,
+      modelValue: 'information',
+    });
+
+    expect(
+      wrapper
+        .find('[data-testid="contact-info-redesign-header"]')
+        .classes(),
+    ).toContain('contact-info-redesign-header--compact');
+  });
+
+  it('does not use the compact header when both tabs are visible', () => {
+    wrapper = createWrapper();
+
+    expect(
+      wrapper
+        .find('[data-testid="contact-info-redesign-header"]')
+        .classes(),
+    ).not.toContain('contact-info-redesign-header--compact');
+  });
 });

--- a/src/components/chats/ContactInfo/Redesign/__tests__/index.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/__tests__/index.spec.js
@@ -8,9 +8,11 @@ import {
   vi,
 } from 'vitest';
 import { mount, config } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
 import ContactInfoRedesign from '../index.vue';
 import { moduleStorage } from '@/utils/storage';
 import i18n from '@/plugins/i18n';
+import { useConfig } from '@/store/modules/config';
 
 vi.mock('@/utils/storage', () => ({
   moduleStorage: {
@@ -31,9 +33,21 @@ afterAll(() => {
   }
 });
 
-const createWrapper = () =>
+const createWrapper = ({ hideDeskCopilotTab = false } = {}) =>
   mount(ContactInfoRedesign, {
     global: {
+      plugins: [
+        createTestingPinia({
+          createSpy: vi.fn,
+          initialState: {
+            config: {
+              project: {
+                config: { hide_desk_copilot_tab: hideDeskCopilotTab },
+              },
+            },
+          },
+        }),
+      ],
       mocks: {
         $t: (key) => key,
       },
@@ -51,6 +65,7 @@ const createWrapper = () =>
             'showRefresh',
             'showClose',
             'isRefreshDisabled',
+            'showDeskCopilotTab',
           ],
         },
         DeskCopilotTab: {
@@ -103,6 +118,39 @@ describe('ContactInfoRedesign', () => {
     expect(moduleStorage.setItem).toHaveBeenCalledWith(
       'contactInfoActiveTab',
       'information',
+    );
+  });
+
+  it('opens the information tab when hide_desk_copilot_tab is enabled', () => {
+    moduleStorage.getItem.mockReturnValue('desk_copilot');
+    wrapper = createWrapper({ hideDeskCopilotTab: true });
+
+    expect(wrapper.find('[data-testid="desk-copilot"]').exists()).toBe(false);
+    expect(wrapper.findComponent({ name: 'AboutContactCard' }).exists()).toBe(
+      true,
+    );
+    expect(wrapper.vm.activeTab).toBe('information');
+    expect(
+      wrapper
+        .findComponent({ name: 'ContactInfoRedesignHeader' })
+        .props('showDeskCopilotTab'),
+    ).toBe(false);
+  });
+
+  it('switches to information when hide_desk_copilot_tab is enabled at runtime', async () => {
+    moduleStorage.getItem.mockReturnValue('desk_copilot');
+    wrapper = createWrapper();
+
+    expect(wrapper.find('[data-testid="desk-copilot"]').exists()).toBe(true);
+
+    const configStore = useConfig();
+    configStore.project.config.hide_desk_copilot_tab = true;
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.activeTab).toBe('information');
+    expect(wrapper.find('[data-testid="desk-copilot"]').exists()).toBe(false);
+    expect(wrapper.findComponent({ name: 'AboutContactCard' }).exists()).toBe(
+      true,
     );
   });
 });

--- a/src/components/chats/ContactInfo/Redesign/index.vue
+++ b/src/components/chats/ContactInfo/Redesign/index.vue
@@ -9,6 +9,7 @@
         :showRefresh="!isHistory"
         :showClose="!isHistory"
         :isRefreshDisabled="isRefreshDisabled"
+        :showDeskCopilotTab="showDeskCopilotTab"
         @refresh="emit('refresh')"
         @close="emit('close')"
       />
@@ -67,7 +68,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
+import { storeToRefs } from 'pinia';
 import AsideSlotTemplate from '@/components/layouts/chats/AsideSlotTemplate/index.vue';
 import ContactInfoRedesignHeader, { type ContactInfoTab } from './Header.vue';
 import AboutContactCard from './AboutContactCard.vue';
@@ -75,21 +77,42 @@ import AboutSupportCard from './AboutSupportCard.vue';
 import MediaTabs from './MediaTabs.vue';
 import DeskCopilotTab from './DeskCopilot/index.vue';
 import { moduleStorage } from '@/utils/storage';
+import { useConfig } from '@/store/modules/config';
 
 defineOptions({
   name: 'ContactInfoRedesign',
 });
 
+const { project } = storeToRefs(useConfig());
+
+const showDeskCopilotTab = computed(
+  () => !project.value?.config?.hide_desk_copilot_tab,
+);
+
 const CONTACT_INFO_ACTIVE_TAB_KEY = 'contactInfoActiveTab';
-const DEFAULT_TAB: ContactInfoTab = 'desk_copilot';
-const VALID_TABS = new Set<ContactInfoTab>(['desk_copilot', 'information']);
+const DESK_COPILOT_TAB: ContactInfoTab = 'desk_copilot';
+const INFORMATION_TAB: ContactInfoTab = 'information';
+const VALID_TABS = new Set<ContactInfoTab>([DESK_COPILOT_TAB, INFORMATION_TAB]);
+
+function getDefaultTab(): ContactInfoTab {
+  return showDeskCopilotTab.value ? DESK_COPILOT_TAB : INFORMATION_TAB;
+}
 
 function getPersistedTab(): ContactInfoTab {
   const storedTab = moduleStorage.getItem(
     CONTACT_INFO_ACTIVE_TAB_KEY,
-    DEFAULT_TAB,
+    getDefaultTab(),
   );
-  return VALID_TABS.has(storedTab) ? storedTab : DEFAULT_TAB;
+
+  if (!VALID_TABS.has(storedTab)) {
+    return getDefaultTab();
+  }
+
+  if (storedTab === DESK_COPILOT_TAB && !showDeskCopilotTab.value) {
+    return INFORMATION_TAB;
+  }
+
+  return storedTab;
 }
 
 type CustomFields = Record<string, string>;
@@ -171,6 +194,12 @@ const activeTab = ref<ContactInfoTab>(getPersistedTab());
 
 watch(activeTab, (tab) => {
   moduleStorage.setItem(CONTACT_INFO_ACTIVE_TAB_KEY, tab);
+});
+
+watch(showDeskCopilotTab, (visible) => {
+  if (!visible && activeTab.value === DESK_COPILOT_TAB) {
+    activeTab.value = INFORMATION_TAB;
+  }
 });
 
 const handleFullscreen = (url: string, images: MediaItem[]) => {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1219,6 +1219,10 @@
         "switch_active": "Block chat transfers to offline representatives",
         "switch_inactive": "Block chat transfers to offline representatives"
       },
+      "hide_desk_copilot_tab": {
+        "hint": "When enabled, representatives only see the Information tab in the contact panel",
+        "switch_label": "Hide Desk Copilot tab"
+      },
       "hide_moderators_from_transfer": {
         "hint": "When enabled, only users assigned to the queue as representatives are shown. Moderators are only displayed if they are also assigned to the queue as representatives. When disabled, all users, including moderators, are shown.",
         "switch_label": "Hide moderator profiles when transferring chats"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1219,6 +1219,10 @@
         "switch_active": "Bloquear transferencias de chats a representantes offline",
         "switch_inactive": "Bloquear transferencias de chats a representantes offline"
       },
+      "hide_desk_copilot_tab": {
+        "hint": "Si esta opción está activa, los representantes solo ven la pestaña de información en el panel del contacto",
+        "switch_label": "Ocultar pestaña Desk Copilot"
+      },
       "hide_moderators_from_transfer": {
         "hint": "Si se activa esta opción, solo se muestran los usuarios asignados a la cola como representantes. Los moderadores solo se muestran si también están asignados a la cola como representantes. Cuando está desactivada se muestran todos los usuarios, incluidos los moderadores.",
         "switch_label": "Ocultar los perfiles de moderadores al transferir chats"

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -1219,6 +1219,10 @@
         "switch_active": "Bloquear a transferência de chats para atendentes offline",
         "switch_inactive": "Bloquear a transferência de chats para atendentes offline"
       },
+      "hide_desk_copilot_tab": {
+        "hint": "Quando ativada, os atendentes veem apenas a aba de informações no painel do contato",
+        "switch_label": "Ocultar aba Desk Copilot"
+      },
       "hide_moderators_from_transfer": {
         "hint": "Quando ativado, somente os usuários atribuídos à fila como atendentes são exibidos. Os moderadores aparecem apenas se também estiverem atribuídos à fila como atendentes. Quando desativado, todos os usuários são exibidos, inclusive os moderadores.",
         "switch_label": "Ocultar perfis de moderadores ao transferir chats"

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -1194,6 +1194,10 @@
         "switch_active": "Blochează transferul chaturilor către reprezentanți offline",
         "switch_inactive": "Blochează transferul chaturilor către reprezentanți offline"
       },
+      "hide_desk_copilot_tab": {
+        "hint": "Când este activată, reprezentanții văd doar fila Informații în panoul contactului",
+        "switch_label": "Ascunde fila Desk Copilot"
+      },
       "hide_moderators_from_transfer": {
         "hint": "Când este activată, sunt afișați doar utilizatorii atribuiți cozii ca reprezentanți. Moderatorii sunt afișați doar dacă sunt și ei atribuiți cozii ca reprezentanți. Când este dezactivată, sunt afișați toți utilizatorii, inclusiv moderatorii.",
         "switch_label": "Ascunde profilurile moderatorilor la transferul chaturilor"

--- a/src/views/Settings/SettingsProjectOptions/__tests__/SettingsProjectOptions.spec.js
+++ b/src/views/Settings/SettingsProjectOptions/__tests__/SettingsProjectOptions.spec.js
@@ -9,6 +9,7 @@ import Project from '@/services/api/resources/settings/project';
 
 import { useCompositionI18nInThisSpecFile } from '@/utils/test/compositionI18nVitest';
 import agentBuilder from '@/services/api/resources/settings/agentBuilder';
+import { ASSISTED_SALES_FEATURE_FLAG } from '@/composables/useAssistedSalesFeatureFlag';
 
 vi.mock('@/services/api/resources/settings/project', () => ({
   default: {
@@ -37,11 +38,13 @@ const defaultConfig = {
   can_use_queue_prioritization: false,
   can_see_waiting_rooms_count: true,
   can_use_name_sector_in_rooms: false,
+  hide_desk_copilot_tab: false,
 };
 
 const createWrapper = ({
   storeOverrides = {},
   projectConfig = {},
+  activeFeatures = [],
 } = {}) => {
   return mount(SettingsProjectOptions, {
     global: {
@@ -61,6 +64,9 @@ const createWrapper = ({
                 project_permission_role: 1,
               },
               ...storeOverrides.profile,
+            },
+            featureFlag: {
+              featureFlags: { active_features: activeFeatures },
             },
           },
         }),
@@ -215,6 +221,52 @@ describe('SettingsProjectOptions.vue', () => {
           'config_chats.project_configs.hide_moderators_from_transfer.hint',
         ),
       );
+    });
+
+    it('should hide hide_desk_copilot_tab when assisted sales is disabled', () => {
+      wrapper = createWrapper();
+
+      const item = wrapper.vm.optionsItems.find(
+        (option) => option.key === 'hide_desk_copilot_tab',
+      );
+
+      expect(item).toBeUndefined();
+    });
+
+    it('should include hide_desk_copilot_tab when assisted sales is enabled', () => {
+      wrapper = createWrapper({
+        activeFeatures: [ASSISTED_SALES_FEATURE_FLAG],
+      });
+
+      const item = wrapper.vm.optionsItems.find(
+        (option) => option.key === 'hide_desk_copilot_tab',
+      );
+
+      expect(item).toBeTruthy();
+      expect(item.type).toBe('flag');
+      expect(item.name).toBe(
+        wrapper.vm.$t(
+          'config_chats.project_configs.hide_desk_copilot_tab.switch_label',
+        ),
+      );
+      expect(item.hint).toBe(
+        wrapper.vm.$t(
+          'config_chats.project_configs.hide_desk_copilot_tab.hint',
+        ),
+      );
+    });
+
+    it('should hide hide_desk_copilot_tab on secondary project even with assisted sales enabled', () => {
+      wrapper = createWrapper({
+        projectConfig: { its_principal: false },
+        activeFeatures: [ASSISTED_SALES_FEATURE_FLAG],
+      });
+
+      const item = wrapper.vm.optionsItems.find(
+        (option) => option.key === 'hide_desk_copilot_tab',
+      );
+
+      expect(item).toBeUndefined();
     });
 
     it('should have prompt config on flag-prompt items', async () => {
@@ -559,6 +611,21 @@ describe('SettingsProjectOptions.vue', () => {
       );
     });
 
+    it('should persist hide_desk_copilot_tab when the toggle changes', async () => {
+      wrapper = createWrapper({
+        activeFeatures: [ASSISTED_SALES_FEATURE_FLAG],
+      });
+
+      wrapper.vm.projectConfig.hide_desk_copilot_tab = true;
+      await wrapper.vm.$nextTick();
+
+      expect(Project.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hide_desk_copilot_tab: true,
+        }),
+      );
+    });
+
     it('should load config from project store', () => {
       expect(wrapper.vm.projectConfig.can_use_bulk_transfer).toBe(false);
     });
@@ -612,5 +679,4 @@ describe('SettingsProjectOptions.vue', () => {
       );
     });
   });
-
 });

--- a/src/views/Settings/SettingsProjectOptions/index.vue
+++ b/src/views/Settings/SettingsProjectOptions/index.vue
@@ -74,7 +74,9 @@
 import { mapState, mapWritableState } from 'pinia';
 
 import { useConfig } from '@/store/modules/config';
+import { useFeatureFlag } from '@/store/modules/featureFlag';
 import { useProfile } from '@/store/modules/profile';
+import { useAssistedSalesFeatureFlag } from '@/composables/useAssistedSalesFeatureFlag';
 
 import Project from '@/services/api/resources/settings/project';
 import agentBuilder from '@/services/api/resources/settings/agentBuilder';
@@ -108,6 +110,7 @@ export default {
         can_use_name_sector_in_rooms: false,
         restrict_offline_agents: false,
         block_link_contact_agents: false,
+        hide_desk_copilot_tab: false,
       },
       hasAgentBuilder: false,
       aiTransferConfig: {
@@ -123,11 +126,16 @@ export default {
   computed: {
     ...mapWritableState(useConfig, ['project']),
     ...mapState(useConfig, ['isSecondaryProject', 'isMainGroupsProject']),
+    ...mapState(useFeatureFlag, ['featureFlags']),
     ...mapState(useProfile, ['me']),
 
     isUserManager() {
       const ROLE_MANAGER = 1;
       return this.me.project_permission_role === ROLE_MANAGER;
+    },
+
+    isAssistedSalesEnabled() {
+      return useAssistedSalesFeatureFlag(this.featureFlags);
     },
 
     configAiTransferTranslation() {
@@ -231,6 +239,17 @@ export default {
           ),
         },
         {
+          key: 'hide_desk_copilot_tab',
+          type: 'flag',
+          visible: !this.isSecondaryProject && this.isAssistedSalesEnabled,
+          name: this.$t(
+            'config_chats.project_configs.hide_desk_copilot_tab.switch_label',
+          ),
+          hint: this.$t(
+            'config_chats.project_configs.hide_desk_copilot_tab.hint',
+          ),
+        },
+        {
           key: 'can_use_bulk_transfer',
           type: 'flag',
           visible: !this.isSecondaryProject,
@@ -318,6 +337,10 @@ export default {
               newProject.config.can_see_waiting_rooms_count === undefined
                 ? true
                 : newProject.config.can_see_waiting_rooms_count,
+            hide_desk_copilot_tab:
+              newProject.config.hide_desk_copilot_tab === undefined
+                ? false
+                : newProject.config.hide_desk_copilot_tab,
           };
           this.projectConfig = config;
         }
@@ -405,6 +428,7 @@ export default {
         can_use_name_sector_in_rooms,
         restrict_offline_agents,
         block_link_contact_agents,
+        hide_desk_copilot_tab,
       } = this.projectConfig;
 
       await Project.update({
@@ -420,6 +444,7 @@ export default {
         can_use_name_sector_in_rooms,
         restrict_offline_agents,
         block_link_contact_agents,
+        hide_desk_copilot_tab,
       });
 
       this.project.config = {


### PR DESCRIPTION
### Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Tests
- [ ] Chore
- [x] Locales

### Why
Some projects using the Assisted Sales feature may not want representatives to access the Desk Copilot tab in the contact panel. A project-level configuration option is needed to allow managers to hide this tab, forcing representatives to use only the Information tab.

### What Changed
- Added a `hide_desk_copilot_tab` project configuration flag that, when enabled, hides the Desk Copilot tab from the contact info panel and redirects representatives to the Information tab.
- The `hide_desk_copilot_tab` setting is only visible in project options when the Assisted Sales feature flag is active and the project is a principal (non-secondary) project.
- If a representative had the Desk Copilot tab previously selected (persisted in storage) and the flag is enabled at runtime, the active tab automatically switches to Information.
- The `ContactInfoRedesignHeader` component accepts a `showDeskCopilotTab` prop to conditionally render the Desk Copilot tab trigger.
- Localization strings for the new setting were added in English, Spanish, Portuguese, and Romanian.

### Diagram

```mermaid
flowchart TD
    A[Project Config: hide_desk_copilot_tab] -->|false| B[Show Desk Copilot Tab]
    A -->|true| C[Hide Desk Copilot Tab]
    C --> D[Force activeTab = 'information']
    E[Persisted Tab = 'desk_copilot'] -->|hide_desk_copilot_tab enabled| D
    F[Runtime flag change] -->|activeTab === 'desk_copilot'| D
    G[Assisted Sales Feature Flag] -->|disabled| H[Hide setting from Project Options]
    G -->|enabled + principal project| I[Show setting in Project Options]
```