### PR TITLE
fix: update redirect path for Desk Copilot settings

### DIFF
--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/Disclaimer.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/Disclaimer.vue
@@ -96,8 +96,7 @@ const showEnableButton = computed(
 );
 
 function handleEnable() {
-  // Placeholder path until Connect wires the Live Desk settings route
-  emitToHost('redirect', { path: 'chats:settings/live-desk' });
+  emitToHost('redirect', { path: 'chats-settings:?tab=desk_copilot' });
 }
 </script>
 

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/__tests__/Disclaimer.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/__tests__/Disclaimer.spec.js
@@ -134,7 +134,7 @@ describe('DeskCopilotDisclaimer', () => {
       .trigger('click');
 
     expect(emitToHost).toHaveBeenCalledWith('redirect', {
-      path: 'chats:settings/live-desk',
+      path: 'chats-settings:?tab=desk_copilot',
     });
   });
 });


### PR DESCRIPTION
### Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Tests
- [ ] Chore
- [ ] Locales

### Why
The redirect path used when enabling Desk Copilot was a placeholder pointing to an incorrect route. It needed to be updated to the correct settings route with the appropriate tab parameter.

### What Changed
The redirect path in `handleEnable` was updated from `chats:settings/live-desk` to `chats-settings:?tab=desk_copilot`, ensuring users are taken directly to the Desk Copilot tab in the settings when clicking the enable button. The corresponding test was updated to reflect the correct path.