### PR TITLE
feat: add Copilot Project picker modal for selecting and changing linked projects

### DIFF
--- a/src/composables/__tests__/useCopilotProject.spec.ts
+++ b/src/composables/__tests__/useCopilotProject.spec.ts
@@ -12,6 +12,8 @@ vi.mock('@/services/api/resources/chats/copilotProject', () => ({
   default: {
     getLinkedProject: vi.fn(),
     create: vi.fn(),
+    update: vi.fn(),
+    listExistingProjects: vi.fn(),
   },
 }));
 
@@ -35,6 +37,7 @@ describe('useCopilotProject', () => {
       uuid: 'desk-uuid',
       name: 'Sales 123',
       config: {},
+      org: 'org-uuid',
     };
   });
 
@@ -111,5 +114,32 @@ describe('useCopilotProject', () => {
 
     expect(project.value).toEqual(linkedProject);
     expect(showNewBadge.value).toBe(false);
+  });
+
+  it('changes the linked project', async () => {
+    const updatedProject = { ...linkedProject, uuid: 'copilot-uuid-2' };
+    CopilotProjectService.update.mockResolvedValue(updatedProject);
+
+    const { changeLinkedProject, linkedProject: project } = useCopilotProject();
+
+    const result = await changeLinkedProject('copilot-uuid-2');
+
+    expect(CopilotProjectService.update).toHaveBeenCalledWith(
+      'desk-uuid',
+      'copilot-uuid-2',
+    );
+    expect(result).toEqual(updatedProject);
+    expect(project.value).toEqual(updatedProject);
+  });
+
+  it('rethrows when changing the linked project fails', async () => {
+    CopilotProjectService.update.mockRejectedValue(new Error('network'));
+
+    const { changeLinkedProject, linkedProject: project } = useCopilotProject();
+
+    await expect(changeLinkedProject('copilot-uuid-2')).rejects.toThrow(
+      'network',
+    );
+    expect(project.value).toBeNull();
   });
 });

--- a/src/composables/__tests__/useCopilotProject.spec.ts
+++ b/src/composables/__tests__/useCopilotProject.spec.ts
@@ -19,11 +19,11 @@ vi.mock('@/services/api/resources/chats/copilotProject', () => ({
 
 const linkedProject = {
   name: 'Sales 123',
-  assigned_agents: 3,
-  created_on: '2026-07-30T00:00:00Z',
-  connected_on: '2026-07-30T00:00:00Z',
+  assignedAgents: 3,
+  createdOn: '2026-07-30T00:00:00Z',
+  connectedOn: '2026-07-30T00:00:00Z',
   uuid: 'copilot-uuid',
-  connected_by: 'edu',
+  connectedBy: 'edu',
 };
 
 describe('useCopilotProject', () => {

--- a/src/composables/__tests__/useCopilotProjectsList.spec.ts
+++ b/src/composables/__tests__/useCopilotProjectsList.spec.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+
+import { useConfig } from '@/store/modules/config';
+import CopilotProjectService from '@/services/api/resources/chats/copilotProject';
+import {
+  resetCopilotProjectsListState,
+  useCopilotProjectsList,
+} from '../useCopilotProjectsList';
+
+vi.mock('@/services/api/resources/chats/copilotProject', () => ({
+  default: {
+    listExistingProjects: vi.fn(),
+  },
+}));
+
+const existingProjects = [
+  {
+    name: 'Sales 123',
+    assigned_agents: 3,
+    uuid: 'copilot-uuid',
+    project_uuid: 'desk-uuid',
+  },
+  {
+    name: 'Sales 456',
+    assigned_agents: 1,
+    uuid: 'copilot-uuid-2',
+    project_uuid: 'desk-uuid-2',
+  },
+];
+
+describe('useCopilotProjectsList', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    resetCopilotProjectsListState();
+    vi.clearAllMocks();
+
+    const configStore = useConfig();
+    configStore.project = {
+      uuid: 'desk-uuid',
+      name: 'Sales 123',
+      config: {},
+      org: 'org-uuid',
+    };
+  });
+
+  it('starts without projects', () => {
+    const { projects, hasMultipleProjects } = useCopilotProjectsList();
+
+    expect(projects.value).toEqual([]);
+    expect(hasMultipleProjects.value).toBe(false);
+  });
+
+  it('loads existing projects and detects multiple items', async () => {
+    CopilotProjectService.listExistingProjects.mockResolvedValue(
+      existingProjects,
+    );
+
+    const { fetchProjects, projects, hasMultipleProjects } =
+      useCopilotProjectsList();
+
+    await fetchProjects(true);
+
+    expect(CopilotProjectService.listExistingProjects).toHaveBeenCalledWith(
+      'org-uuid',
+    );
+    expect(projects.value).toEqual(existingProjects);
+    expect(hasMultipleProjects.value).toBe(true);
+  });
+
+  it('keeps hasMultipleProjects false for a single project', async () => {
+    CopilotProjectService.listExistingProjects.mockResolvedValue([
+      existingProjects[0],
+    ]);
+
+    const { fetchProjects, hasMultipleProjects } = useCopilotProjectsList();
+
+    await fetchProjects(true);
+
+    expect(hasMultipleProjects.value).toBe(false);
+  });
+
+  it('treats a request error as an empty list', async () => {
+    CopilotProjectService.listExistingProjects.mockRejectedValue(
+      new Error('network'),
+    );
+
+    const { fetchProjects, projects, isLoading } = useCopilotProjectsList();
+
+    await fetchProjects(true);
+
+    expect(projects.value).toEqual([]);
+    expect(isLoading.value).toBe(false);
+  });
+
+  it('clears the list when the org uuid is missing', async () => {
+    const configStore = useConfig();
+    configStore.project = {
+      uuid: 'desk-uuid',
+      name: 'Sales 123',
+      config: {},
+    };
+
+    const { fetchProjects, projects } = useCopilotProjectsList();
+
+    await fetchProjects(true);
+
+    expect(CopilotProjectService.listExistingProjects).not.toHaveBeenCalled();
+    expect(projects.value).toEqual([]);
+  });
+});

--- a/src/composables/__tests__/useCopilotProjectsList.spec.ts
+++ b/src/composables/__tests__/useCopilotProjectsList.spec.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 
 import { useConfig } from '@/store/modules/config';
-import CopilotProjectService from '@/services/api/resources/chats/copilotProject';
+import CopilotProjectService, {
+  type CopilotProjectSummary,
+} from '@/services/api/resources/chats/copilotProject';
 import {
   resetCopilotProjectsListState,
   useCopilotProjectsList,
@@ -17,15 +19,15 @@ vi.mock('@/services/api/resources/chats/copilotProject', () => ({
 const existingProjects = [
   {
     name: 'Sales 123',
-    assigned_agents: 3,
+    assignedAgents: 3,
     uuid: 'copilot-uuid',
-    project_uuid: 'desk-uuid',
+    projectUuid: 'desk-uuid',
   },
   {
     name: 'Sales 456',
-    assigned_agents: 1,
+    assignedAgents: 1,
     uuid: 'copilot-uuid-2',
-    project_uuid: 'desk-uuid-2',
+    projectUuid: 'desk-uuid-2',
   },
 ];
 
@@ -107,5 +109,39 @@ describe('useCopilotProjectsList', () => {
 
     expect(CopilotProjectService.listExistingProjects).not.toHaveBeenCalled();
     expect(projects.value).toEqual([]);
+  });
+
+  it('ignores stale results when fetchProjects is forced while in flight', async () => {
+    let resolveFirst: (value: CopilotProjectSummary[]) => void = () => {};
+    CopilotProjectService.listExistingProjects
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockResolvedValueOnce(existingProjects);
+
+    const { fetchProjects, projects, isLoading } = useCopilotProjectsList();
+
+    const firstFetch = fetchProjects();
+    const secondFetch = fetchProjects(true);
+
+    await secondFetch;
+
+    expect(projects.value).toEqual(existingProjects);
+    expect(isLoading.value).toBe(false);
+
+    resolveFirst([
+      {
+        name: 'stale',
+        assignedAgents: 0,
+        uuid: 'stale-uuid',
+      },
+    ]);
+    await firstFetch;
+
+    expect(projects.value).toEqual(existingProjects);
+    expect(isLoading.value).toBe(false);
   });
 });

--- a/src/composables/useCopilotProject.ts
+++ b/src/composables/useCopilotProject.ts
@@ -50,6 +50,36 @@ export function useCopilotProject() {
     linkedProject.value = projectValue;
   }
 
+  async function createProject(name: string) {
+    const projectUuid = project.value?.uuid;
+
+    if (!projectUuid) {
+      throw new Error('Missing project uuid');
+    }
+
+    const createdProject = await CopilotProjectService.create(
+      name,
+      projectUuid,
+    );
+    linkedProject.value = createdProject;
+    return createdProject;
+  }
+
+  async function changeLinkedProject(newCopilotProjectUuid: string) {
+    const projectUuid = project.value?.uuid;
+
+    if (!projectUuid) {
+      throw new Error('Missing project uuid');
+    }
+
+    const updatedProject = await CopilotProjectService.update(
+      projectUuid,
+      newCopilotProjectUuid,
+    );
+    linkedProject.value = updatedProject;
+    return updatedProject;
+  }
+
   const isLinked = computed(() => !!linkedProject.value);
   const showNewBadge = computed(() => !linkedProject.value);
 
@@ -60,5 +90,7 @@ export function useCopilotProject() {
     showNewBadge,
     fetchLinkedProject,
     setLinkedProject,
+    createProject,
+    changeLinkedProject,
   };
 }

--- a/src/composables/useCopilotProjectsList.ts
+++ b/src/composables/useCopilotProjectsList.ts
@@ -1,0 +1,57 @@
+import { computed, ref } from 'vue';
+import { storeToRefs } from 'pinia';
+
+import { useConfig } from '@/store/modules/config';
+import CopilotProjectService, {
+  type CopilotProjectSummary,
+} from '@/services/api/resources/chats/copilotProject';
+
+const projects = ref<CopilotProjectSummary[]>([]);
+const isLoading = ref(false);
+let fetchPromise: Promise<void> | null = null;
+
+export function resetCopilotProjectsListState() {
+  projects.value = [];
+  isLoading.value = false;
+  fetchPromise = null;
+}
+
+export function useCopilotProjectsList() {
+  const { project } = storeToRefs(useConfig());
+
+  async function fetchProjects(force = false) {
+    const orgUuid = project.value?.org;
+
+    if (!orgUuid) {
+      projects.value = [];
+      return;
+    }
+
+    if (fetchPromise !== null && !force) {
+      return fetchPromise;
+    }
+
+    isLoading.value = true;
+    fetchPromise = (async () => {
+      try {
+        projects.value =
+          await CopilotProjectService.listExistingProjects(orgUuid);
+      } catch {
+        projects.value = [];
+      } finally {
+        isLoading.value = false;
+      }
+    })();
+
+    return fetchPromise;
+  }
+
+  const hasMultipleProjects = computed(() => projects.value.length > 1);
+
+  return {
+    projects,
+    isLoading,
+    hasMultipleProjects,
+    fetchProjects,
+  };
+}

--- a/src/composables/useCopilotProjectsList.ts
+++ b/src/composables/useCopilotProjectsList.ts
@@ -9,11 +9,13 @@ import CopilotProjectService, {
 const projects = ref<CopilotProjectSummary[]>([]);
 const isLoading = ref(false);
 let fetchPromise: Promise<void> | null = null;
+let fetchGeneration = 0;
 
 export function resetCopilotProjectsListState() {
   projects.value = [];
   isLoading.value = false;
   fetchPromise = null;
+  fetchGeneration = 0;
 }
 
 export function useCopilotProjectsList() {
@@ -31,15 +33,24 @@ export function useCopilotProjectsList() {
       return fetchPromise;
     }
 
+    const generation = ++fetchGeneration;
     isLoading.value = true;
     fetchPromise = (async () => {
       try {
-        projects.value =
+        const result =
           await CopilotProjectService.listExistingProjects(orgUuid);
+
+        if (generation !== fetchGeneration) return;
+
+        projects.value = result;
       } catch {
+        if (generation !== fetchGeneration) return;
+
         projects.value = [];
       } finally {
-        isLoading.value = false;
+        if (generation === fetchGeneration) {
+          isLoading.value = false;
+        }
       }
     })();
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1150,11 +1150,13 @@
         "connected_to": "Connected to",
         "created_on": "Created on",
         "description": "This project is used exclusively to manage the AI agents for the Desk Copilot. It is accessible only through this section.",
-        "open": "Open"
+        "open": "Open",
+        "popover_change_option": "Change"
       },
       "empty_state": {
         "create_button": "Create Copilot Project",
         "description": "To enable Desk Copilot, connect this project to a Copilot Project where your AI Agents are managed",
+        "select_button": "Select Copilot Project",
         "title": "No Copilot Project connected"
       },
       "enable_title": "Enable Desk Copilot",
@@ -1185,7 +1187,19 @@
         "success": "Copilot project created and connected successfully",
         "title": "Create Copilot Project"
       },
-      "new_badge": "New"
+      "new_badge": "New",
+      "picker_modal": {
+        "assigned_agents_tag": "{count, plural, one {{count} assigned agent} other {{count} assigned agents}}",
+        "change_button": "Change",
+        "change_error": "Unable to change the Copilot Project.",
+        "change_success": "The Copilot Project has been changed!",
+        "change_title": "Change Copilot Project",
+        "connect_button": "Connect",
+        "connect_error": "Error connecting to copilot project.",
+        "connect_success": "Copilot project connected!",
+        "search_placeholder": "Search by name",
+        "select_title": "Select Existing Copilot Project"
+      }
     },
     "changes_saved": "Changes saved successfully",
     "changes_not_saved": "Error saving changes. Try again.",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1150,11 +1150,13 @@
         "connected_to": "Conectado el",
         "created_on": "Creado el",
         "description": "Este proyecto se usa exclusivamente para gestionar los agentes de IA de Desk Copilot. Solo es accesible desde esta sección.",
-        "open": "Abrir"
+        "open": "Abrir",
+        "popover_change_option": "Cambiar"
       },
       "empty_state": {
         "create_button": "Crear proyecto Copilot",
         "description": "Para activar Desk Copilot, conecta este proyecto a un proyecto Copilot donde se gestionan tus agentes de IA",
+        "select_button": "Seleccionar proyecto Copilot",
         "title": "Ningún proyecto Copilot conectado"
       },
       "enable_title": "Activar Desk Copilot",
@@ -1185,7 +1187,19 @@
         "success": "Proyecto Copilot creado y conectado con éxito",
         "title": "Crear proyecto Copilot"
       },
-      "new_badge": "Nuevo"
+      "new_badge": "Nuevo",
+      "picker_modal": {
+        "assigned_agents_tag": "{count, plural, one {{count} agente asignado} other {{count} agentes asignados}}",
+        "change_button": "Cambiar",
+        "change_error": "No se pudo cambiar el proyecto Copilot",
+        "change_success": "Proyecto Copilot cambiado con éxito",
+        "change_title": "Cambiar proyecto Copilot",
+        "connect_button": "Conectar",
+        "connect_error": "No se pudo conectar al proyecto Copilot",
+        "connect_success": "Proyecto Copilot conectado con éxito",
+        "search_placeholder": "Buscar por nombre",
+        "select_title": "Seleccionar proyecto Copilot existente"
+      }
     },
     "changes_saved": "Cambios guardados con éxito",
     "changes_not_saved": "Error al guardar cambios. Vuelve a intentarlo.",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -1150,11 +1150,13 @@
         "connected_to": "Conectado em",
         "created_on": "Criado em",
         "description": "Este projeto é usado exclusivamente para gerenciar os agentes de IA do Desk Copilot. O acesso é feito apenas por esta seção.",
-        "open": "Abrir"
+        "open": "Abrir",
+        "popover_change_option": "Alterar"
       },
       "empty_state": {
         "create_button": "Criar projeto Copilot",
         "description": "Para ativar o Desk Copilot, conecte este projeto a um projeto Copilot onde seus agentes de IA são gerenciados",
+        "select_button": "Selecionar projeto Copilot",
         "title": "Nenhum projeto Copilot conectado"
       },
       "enable_title": "Ativar Desk Copilot",
@@ -1185,7 +1187,19 @@
         "success": "Projeto Copilot criado e conectado com sucesso",
         "title": "Criar projeto Copilot"
       },
-      "new_badge": "Novo"
+      "new_badge": "Novo",
+      "picker_modal": {
+        "assigned_agents_tag": "{count, plural, one {{count} agente atribuído} other {{count} agentes atribuídos}}",
+        "change_button": "Alterar",
+        "change_error": "Não foi possível alterar o projeto Copilot",
+        "change_success": "Projeto Copilot alterado com sucesso",
+        "change_title": "Alterar projeto Copilot",
+        "connect_button": "Conectar",
+        "connect_error": "Não foi possível conectar ao projeto Copilot",
+        "connect_success": "Projeto Copilot conectado com sucesso",
+        "search_placeholder": "Buscar por nome",
+        "select_title": "Selecionar projeto Copilot existente"
+      }
     },
     "changes_saved": "Alterações salvas com sucesso",
     "changes_not_saved": "Erro ao salvar alterações. Tente novamente.",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -1129,11 +1129,13 @@
         "connected_to": "Conectat la",
         "created_on": "Creat pe",
         "description": "Acest proiect este folosit exclusiv pentru a gestiona agenții IA pentru Desk Copilot. Este accesibil doar din această secțiune.",
-        "open": "Deschide"
+        "open": "Deschide",
+        "popover_change_option": "Schimbă"
       },
       "empty_state": {
         "create_button": "Creează proiect Copilot",
         "description": "Pentru a activa Desk Copilot, conectează acest proiect la un proiect Copilot unde sunt gestionați agenții tăi IA",
+        "select_button": "Selectează proiect Copilot",
         "title": "Niciun proiect Copilot conectat"
       },
       "enable_title": "Activează Desk Copilot",
@@ -1164,7 +1166,19 @@
         "success": "Proiect Copilot creat și conectat cu succes",
         "title": "Creează proiect Copilot"
       },
-      "new_badge": "Nou"
+      "new_badge": "Nou",
+      "picker_modal": {
+        "assigned_agents_tag": "{count, plural, one {{count} agent atribuit} other {{count} agenți atribuiți}}",
+        "change_button": "Schimbă",
+        "change_error": "Nu s-a putut schimba proiectul Copilot",
+        "change_success": "Proiect Copilot schimbat cu succes",
+        "change_title": "Schimbă proiectul Copilot",
+        "connect_button": "Conectează",
+        "connect_error": "Nu s-a putut conecta la proiectul Copilot",
+        "connect_success": "Proiect Copilot conectat cu succes",
+        "search_placeholder": "Caută după nume",
+        "select_title": "Selectează proiectul Copilot existent"
+      }
     },
     "changes_saved": "Modificări salvate cu succes",
     "changes_not_saved": "Eroare la salvarea modificărilor. Încearcă din nou.",

--- a/src/services/api/resources/chats/__tests__/copilotProject.spec.ts
+++ b/src/services/api/resources/chats/__tests__/copilotProject.spec.ts
@@ -50,15 +50,15 @@ describe('copilotProject service', () => {
       expect(normalizeCopilotProject([])).toBeNull();
     });
 
-    it('normalizes connect_by into connected_by', () => {
+    it('normalizes connect_by into connectedBy', () => {
       expect(normalizeCopilotProject(linkedProjectResponse)).toEqual({
         name: 'projeto copilot teste',
-        assigned_agents: 5,
-        created_on: '2026-07-30T00:00:00Z',
-        connected_on: '2026-07-30T00:00:00Z',
+        assignedAgents: 5,
+        createdOn: '2026-07-30T00:00:00Z',
+        connectedOn: '2026-07-30T00:00:00Z',
         uuid: 'copilot-uuid',
-        project_uuid: 'desk-uuid',
-        connected_by: 'edu',
+        projectUuid: 'desk-uuid',
+        connectedBy: 'edu',
       });
     });
   });
@@ -74,9 +74,9 @@ describe('copilotProject service', () => {
         normalizeCopilotProjectSummary(existingProjectsResponse[0]),
       ).toEqual({
         name: 'projeto copilot teste',
-        assigned_agents: 5,
+        assignedAgents: 5,
         uuid: 'copilot-uuid',
-        project_uuid: 'desk-uuid',
+        projectUuid: 'desk-uuid',
       });
     });
   });
@@ -91,7 +91,7 @@ describe('copilotProject service', () => {
         '/project/copilot/linked_project/desk-uuid',
       );
       expect(result?.uuid).toBe('copilot-uuid');
-      expect(result?.connected_by).toBe('edu');
+      expect(result?.connectedBy).toBe('edu');
     });
 
     it('returns null when the API has no linked project', async () => {
@@ -114,7 +114,12 @@ describe('copilotProject service', () => {
         '/project/copilot/list_existing_projects/org-uuid',
       );
       expect(result).toHaveLength(2);
-      expect(result[0].uuid).toBe('copilot-uuid');
+      expect(result[0]).toEqual({
+        name: 'projeto copilot teste',
+        assignedAgents: 5,
+        uuid: 'copilot-uuid',
+        projectUuid: 'desk-uuid',
+      });
     });
 
     it('returns an empty list when the payload is not an array', async () => {
@@ -187,7 +192,7 @@ describe('copilotProject service', () => {
         { new_uuid: 'copilot-uuid-2' },
       );
       expect(result.uuid).toBe('copilot-uuid');
-      expect(result.connected_by).toBe('edu');
+      expect(result.connectedBy).toBe('edu');
     });
 
     it('throws when the response cannot be normalized', async () => {

--- a/src/services/api/resources/chats/__tests__/copilotProject.spec.ts
+++ b/src/services/api/resources/chats/__tests__/copilotProject.spec.ts
@@ -2,12 +2,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import http from '@/services/api/http';
 import CopilotProjectService, {
   normalizeCopilotProject,
+  normalizeCopilotProjectSummary,
 } from '../copilotProject';
 
 vi.mock('@/services/api/http', () => ({
   default: {
     get: vi.fn(),
     post: vi.fn(),
+    put: vi.fn(),
   },
 }));
 
@@ -20,6 +22,21 @@ const linkedProjectResponse = {
   project_uuid: 'desk-uuid',
   connect_by: 'edu',
 };
+
+const existingProjectsResponse = [
+  {
+    name: 'projeto copilot teste',
+    assigned_agents: 5,
+    uuid: 'copilot-uuid',
+    project_uuid: 'desk-uuid',
+  },
+  {
+    name: 'another copilot',
+    assigned_agents: 2,
+    uuid: 'copilot-uuid-2',
+    project_uuid: 'desk-uuid-2',
+  },
+];
 
 describe('copilotProject service', () => {
   beforeEach(() => {
@@ -46,6 +63,24 @@ describe('copilotProject service', () => {
     });
   });
 
+  describe('normalizeCopilotProjectSummary', () => {
+    it('returns null for empty payloads', () => {
+      expect(normalizeCopilotProjectSummary(null)).toBeNull();
+      expect(normalizeCopilotProjectSummary({})).toBeNull();
+    });
+
+    it('normalizes a summary payload', () => {
+      expect(
+        normalizeCopilotProjectSummary(existingProjectsResponse[0]),
+      ).toEqual({
+        name: 'projeto copilot teste',
+        assigned_agents: 5,
+        uuid: 'copilot-uuid',
+        project_uuid: 'desk-uuid',
+      });
+    });
+  });
+
   describe('getLinkedProject', () => {
     it('requests the linked project by uuid', async () => {
       http.get.mockResolvedValue({ data: linkedProjectResponse });
@@ -68,8 +103,43 @@ describe('copilotProject service', () => {
     });
   });
 
+  describe('listExistingProjects', () => {
+    it('requests the existing projects by org uuid', async () => {
+      http.get.mockResolvedValue({ data: existingProjectsResponse });
+
+      const result =
+        await CopilotProjectService.listExistingProjects('org-uuid');
+
+      expect(http.get).toHaveBeenCalledWith(
+        '/project/copilot/list_existing_projects/org-uuid',
+      );
+      expect(result).toHaveLength(2);
+      expect(result[0].uuid).toBe('copilot-uuid');
+    });
+
+    it('returns an empty list when the payload is not an array', async () => {
+      http.get.mockResolvedValue({ data: null });
+
+      await expect(
+        CopilotProjectService.listExistingProjects('org-uuid'),
+      ).resolves.toEqual([]);
+    });
+
+    it('skips items without a uuid', async () => {
+      http.get.mockResolvedValue({
+        data: [{ name: 'invalid' }, existingProjectsResponse[0]],
+      });
+
+      const result =
+        await CopilotProjectService.listExistingProjects('org-uuid');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].uuid).toBe('copilot-uuid');
+    });
+  });
+
   describe('create', () => {
-    it('posts the project name and returns the created project', async () => {
+    it('posts the project name and uuid and returns the created project', async () => {
       http.post.mockResolvedValue({
         data: {
           ...linkedProjectResponse,
@@ -77,10 +147,14 @@ describe('copilotProject service', () => {
         },
       });
 
-      const result = await CopilotProjectService.create('Sales 123');
+      const result = await CopilotProjectService.create(
+        'Sales 123',
+        'desk-uuid',
+      );
 
       expect(http.post).toHaveBeenCalledWith('/project/copilot/create', {
         name: 'Sales 123',
+        project: 'desk-uuid',
       });
       expect(result.name).toBe('projeto copilot teste');
     });
@@ -88,9 +162,40 @@ describe('copilotProject service', () => {
     it('throws when the response cannot be normalized', async () => {
       http.post.mockResolvedValue({ data: {} });
 
-      await expect(CopilotProjectService.create('Sales 123')).rejects.toThrow(
-        'Invalid copilot project response',
+      await expect(
+        CopilotProjectService.create('Sales 123', 'desk-uuid'),
+      ).rejects.toThrow('Invalid copilot project response');
+    });
+  });
+
+  describe('update', () => {
+    it('puts the new copilot uuid and returns the linked project', async () => {
+      http.put.mockResolvedValue({
+        data: {
+          ...linkedProjectResponse,
+          connected_by: 'edu',
+        },
+      });
+
+      const result = await CopilotProjectService.update(
+        'desk-uuid',
+        'copilot-uuid-2',
       );
+
+      expect(http.put).toHaveBeenCalledWith(
+        '/project/copilot/update/desk-uuid',
+        { new_uuid: 'copilot-uuid-2' },
+      );
+      expect(result.uuid).toBe('copilot-uuid');
+      expect(result.connected_by).toBe('edu');
+    });
+
+    it('throws when the response cannot be normalized', async () => {
+      http.put.mockResolvedValue({ data: {} });
+
+      await expect(
+        CopilotProjectService.update('desk-uuid', 'copilot-uuid-2'),
+      ).rejects.toThrow('Invalid copilot project response');
     });
   });
 });

--- a/src/services/api/resources/chats/copilotProject.ts
+++ b/src/services/api/resources/chats/copilotProject.ts
@@ -10,6 +10,13 @@ export type CopilotProject = {
   connected_by?: string;
 };
 
+export type CopilotProjectSummary = {
+  name: string;
+  assigned_agents: number;
+  uuid: string;
+  project_uuid?: string;
+};
+
 type CopilotProjectResponse = {
   name?: string;
   assigned_agents?: number;
@@ -57,6 +64,29 @@ export function normalizeCopilotProject(data: unknown): CopilotProject | null {
   };
 }
 
+export function normalizeCopilotProjectSummary(
+  data: unknown,
+): CopilotProjectSummary | null {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return null;
+  }
+
+  const project = data as CopilotProjectResponse;
+
+  if (!project.uuid) {
+    return null;
+  }
+
+  return {
+    name: String(project.name ?? ''),
+    assigned_agents: Number(project.assigned_agents ?? 0),
+    uuid: String(project.uuid),
+    project_uuid: project.project_uuid
+      ? String(project.project_uuid)
+      : undefined,
+  };
+}
+
 export default {
   async getLinkedProject(projectUuid: string): Promise<CopilotProject | null> {
     if (IS_MOCKED) {
@@ -69,14 +99,62 @@ export default {
     return normalizeCopilotProject(response.data);
   },
 
-  async create(name: string): Promise<CopilotProject> {
+  async listExistingProjects(
+    orgUuid: string,
+  ): Promise<CopilotProjectSummary[]> {
+    if (IS_MOCKED) {
+      return [
+        {
+          name: MOCKED_COPILOT_PROJECT.name,
+          assigned_agents: MOCKED_COPILOT_PROJECT.assigned_agents,
+          uuid: MOCKED_COPILOT_PROJECT.uuid,
+          project_uuid: MOCKED_COPILOT_PROJECT.project_uuid,
+        },
+      ];
+    }
+
+    const response = await http.get<CopilotProjectResponse[]>(
+      `/project/copilot/list_existing_projects/${orgUuid}`,
+    );
+
+    if (!Array.isArray(response.data)) {
+      return [];
+    }
+
+    return response.data
+      .map(normalizeCopilotProjectSummary)
+      .filter((project): project is CopilotProjectSummary => project !== null);
+  },
+
+  async create(name: string, projectUuid: string): Promise<CopilotProject> {
     const response = await http.post<CopilotProjectResponse>(
       '/project/copilot/create',
-      { name },
+      { name, project: projectUuid },
     );
     const project = IS_MOCKED
       ? MOCKED_COPILOT_PROJECT
       : normalizeCopilotProject(response.data);
+
+    if (!project) {
+      throw new Error('Invalid copilot project response');
+    }
+
+    return project;
+  },
+
+  async update(
+    currentProjectUuid: string,
+    newCopilotProjectUuid: string,
+  ): Promise<CopilotProject> {
+    if (IS_MOCKED) {
+      return MOCKED_COPILOT_PROJECT;
+    }
+
+    const response = await http.put<CopilotProjectResponse>(
+      `/project/copilot/update/${currentProjectUuid}`,
+      { new_uuid: newCopilotProjectUuid },
+    );
+    const project = normalizeCopilotProject(response.data);
 
     if (!project) {
       throw new Error('Invalid copilot project response');

--- a/src/services/api/resources/chats/copilotProject.ts
+++ b/src/services/api/resources/chats/copilotProject.ts
@@ -2,19 +2,19 @@ import http from '@/services/api/http';
 
 export type CopilotProject = {
   name: string;
-  assigned_agents: number;
-  created_on: string;
-  connected_on: string;
+  assignedAgents: number;
+  createdOn: string;
+  connectedOn: string;
   uuid: string;
-  project_uuid?: string;
-  connected_by?: string;
+  projectUuid?: string;
+  connectedBy?: string;
 };
 
 export type CopilotProjectSummary = {
   name: string;
-  assigned_agents: number;
+  assignedAgents: number;
   uuid: string;
-  project_uuid?: string;
+  projectUuid?: string;
 };
 
 type CopilotProjectResponse = {
@@ -32,12 +32,12 @@ const IS_MOCKED = false;
 
 const MOCKED_COPILOT_PROJECT: CopilotProject = {
   name: 'Desk Copilot',
-  assigned_agents: 0,
-  created_on: new Date().toISOString(),
-  connected_on: new Date().toISOString(),
+  assignedAgents: 0,
+  createdOn: new Date().toISOString(),
+  connectedOn: new Date().toISOString(),
   uuid: '1234567890',
-  project_uuid: 'project-1234567890',
-  connected_by: 'test@example.com',
+  projectUuid: 'project-1234567890',
+  connectedBy: 'test@example.com',
 };
 
 export function normalizeCopilotProject(data: unknown): CopilotProject | null {
@@ -53,14 +53,14 @@ export function normalizeCopilotProject(data: unknown): CopilotProject | null {
 
   return {
     name: String(project.name ?? ''),
-    assigned_agents: Number(project.assigned_agents ?? 0),
-    created_on: String(project.created_on ?? ''),
-    connected_on: String(project.connected_on ?? ''),
+    assignedAgents: Number(project.assigned_agents ?? 0),
+    createdOn: String(project.created_on ?? ''),
+    connectedOn: String(project.connected_on ?? ''),
     uuid: String(project.uuid),
-    project_uuid: project.project_uuid
+    projectUuid: project.project_uuid
       ? String(project.project_uuid)
       : undefined,
-    connected_by: String(project.connected_by ?? project.connect_by ?? ''),
+    connectedBy: String(project.connected_by ?? project.connect_by ?? ''),
   };
 }
 
@@ -79,9 +79,9 @@ export function normalizeCopilotProjectSummary(
 
   return {
     name: String(project.name ?? ''),
-    assigned_agents: Number(project.assigned_agents ?? 0),
+    assignedAgents: Number(project.assigned_agents ?? 0),
     uuid: String(project.uuid),
-    project_uuid: project.project_uuid
+    projectUuid: project.project_uuid
       ? String(project.project_uuid)
       : undefined,
   };
@@ -106,9 +106,9 @@ export default {
       return [
         {
           name: MOCKED_COPILOT_PROJECT.name,
-          assigned_agents: MOCKED_COPILOT_PROJECT.assigned_agents,
+          assignedAgents: MOCKED_COPILOT_PROJECT.assignedAgents,
           uuid: MOCKED_COPILOT_PROJECT.uuid,
-          project_uuid: MOCKED_COPILOT_PROJECT.project_uuid,
+          projectUuid: MOCKED_COPILOT_PROJECT.projectUuid,
         },
       ];
     }

--- a/src/views/Settings/DeskCopilot/ConnectedProjectCard.vue
+++ b/src/views/Settings/DeskCopilot/ConnectedProjectCard.vue
@@ -45,12 +45,31 @@
           data-testid="desk-copilot-open-button"
           @click="openProject"
         />
-        <UnnnicButton
-          type="tertiary"
-          size="small"
-          iconCenter="more_vert"
-          data-testid="desk-copilot-more-button"
-        />
+        <UnnnicPopover
+          v-if="hasMultipleProjects"
+          :open="openPopover"
+          data-testid="desk-copilot-more-popover"
+          @update:open="openPopover = $event"
+        >
+          <UnnnicPopoverTrigger>
+            <UnnnicButton
+              type="tertiary"
+              size="small"
+              iconCenter="more_vert"
+              data-testid="desk-copilot-more-button"
+            />
+          </UnnnicPopoverTrigger>
+          <UnnnicPopoverContent size="small">
+            <UnnnicPopoverOption
+              :label="
+                $t('config_chats.desk_copilot.connected.popover_change_option')
+              "
+              icon="edit_square"
+              data-testid="desk-copilot-change-option"
+              @click="handleChange"
+            />
+          </UnnnicPopoverContent>
+        </UnnnicPopover>
       </section>
     </section>
 
@@ -68,11 +87,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import moment from 'moment';
 
 import type { CopilotProject } from '@/services/api/resources/chats/copilotProject';
 import { buildCopilotProjectUrl } from '@/utils/copilotProject';
+import { useCopilotProjectsList } from '@/composables/useCopilotProjectsList';
 
 defineOptions({
   name: 'DeskCopilotConnectedProjectCard',
@@ -81,6 +101,13 @@ defineOptions({
 const props = defineProps<{
   linkedProject: CopilotProject;
 }>();
+
+const emit = defineEmits<{
+  'open-change-modal': [];
+}>();
+
+const { hasMultipleProjects } = useCopilotProjectsList();
+const openPopover = ref(false);
 
 function formatDate(value: string) {
   if (!value) return '–';
@@ -117,6 +144,11 @@ function openProject() {
     '_blank',
     'noopener,noreferrer',
   );
+}
+
+function handleChange() {
+  openPopover.value = false;
+  emit('open-change-modal');
 }
 </script>
 

--- a/src/views/Settings/DeskCopilot/ConnectedProjectCard.vue
+++ b/src/views/Settings/DeskCopilot/ConnectedProjectCard.vue
@@ -118,22 +118,22 @@ function formatDate(value: string) {
 const metadata = computed(() => [
   {
     labelKey: 'config_chats.desk_copilot.connected.created_on',
-    value: formatDate(props.linkedProject.created_on),
+    value: formatDate(props.linkedProject.createdOn),
     testId: 'desk-copilot-created-on',
   },
   {
     labelKey: 'config_chats.desk_copilot.connected.connected_to',
-    value: formatDate(props.linkedProject.connected_on),
+    value: formatDate(props.linkedProject.connectedOn),
     testId: 'desk-copilot-connected-on',
   },
   {
     labelKey: 'config_chats.desk_copilot.connected.connected_by',
-    value: props.linkedProject.connected_by || '–',
+    value: props.linkedProject.connectedBy || '–',
     testId: 'desk-copilot-connected-by',
   },
   {
     labelKey: 'config_chats.desk_copilot.connected.assigned_agents',
-    value: String(props.linkedProject.assigned_agents ?? '–'),
+    value: String(props.linkedProject.assignedAgents ?? '–'),
     testId: 'desk-copilot-assigned-agents',
   },
 ]);

--- a/src/views/Settings/DeskCopilot/CopilotProjectPickerModal.vue
+++ b/src/views/Settings/DeskCopilot/CopilotProjectPickerModal.vue
@@ -25,7 +25,11 @@
         />
 
         <ul
+          ref="listRef"
           class="copilot-project-picker-modal__list"
+          :class="{
+            'copilot-project-picker-modal__list--scrollable': hasOverflow,
+          }"
           data-testid="copilot-project-picker-list"
         >
           <li
@@ -82,7 +86,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
+import { computed, nextTick, ref, watch } from 'vue';
 
 import { useCopilotProject } from '@/composables/useCopilotProject';
 import { useCopilotProjectsList } from '@/composables/useCopilotProjectsList';
@@ -114,6 +118,8 @@ const { projects } = useCopilotProjectsList();
 const searchTerm = ref('');
 const selectedUuid = ref('');
 const isSaving = ref(false);
+const listRef = ref<HTMLElement | null>(null);
+const hasOverflow = ref(false);
 
 const isOpen = computed({
   get: () => props.modelValue,
@@ -154,6 +160,11 @@ const canSubmit = computed(() => {
   return true;
 });
 
+function updateListOverflow() {
+  const list = listRef.value;
+  hasOverflow.value = !!list && list.scrollHeight > list.clientHeight;
+}
+
 watch(
   () => props.modelValue,
   (isVisible) => {
@@ -163,9 +174,14 @@ watch(
     selectedUuid.value = isChangeMode.value
       ? (linkedProject.value?.uuid ?? '')
       : '';
+    nextTick(updateListOverflow);
   },
   { immediate: true },
 );
+
+watch(filteredProjects, () => {
+  nextTick(updateListOverflow);
+});
 
 function close() {
   isOpen.value = false;
@@ -243,6 +259,10 @@ defineExpose({
     margin: 0;
     padding: 0;
     list-style: none;
+
+    &--scrollable {
+      padding-right: $unnnic-space-2;
+    }
   }
 
   &__option {

--- a/src/views/Settings/DeskCopilot/CopilotProjectPickerModal.vue
+++ b/src/views/Settings/DeskCopilot/CopilotProjectPickerModal.vue
@@ -55,7 +55,7 @@
               :text="
                 $t(
                   'config_chats.desk_copilot.picker_modal.assigned_agents_tag',
-                  { count: item.assigned_agents },
+                  { count: item.assignedAgents },
                 )
               "
               type="next"

--- a/src/views/Settings/DeskCopilot/CopilotProjectPickerModal.vue
+++ b/src/views/Settings/DeskCopilot/CopilotProjectPickerModal.vue
@@ -1,0 +1,265 @@
+<template>
+  <UnnnicDialog
+    v-model:open="isOpen"
+    data-testid="copilot-project-picker-modal"
+  >
+    <UnnnicDialogContent size="medium">
+      <UnnnicDialogHeader>
+        <UnnnicDialogTitle data-testid="copilot-project-picker-title">
+          {{ $t(titleKey) }}
+        </UnnnicDialogTitle>
+        <UnnnicDialogClose
+          data-testid="copilot-project-picker-close"
+          @click="close"
+        />
+      </UnnnicDialogHeader>
+
+      <section class="copilot-project-picker-modal__body">
+        <UnnnicInput
+          v-model="searchTerm"
+          iconLeft="search-1"
+          :placeholder="
+            $t('config_chats.desk_copilot.picker_modal.search_placeholder')
+          "
+          data-testid="copilot-project-picker-search"
+        />
+
+        <ul
+          class="copilot-project-picker-modal__list"
+          data-testid="copilot-project-picker-list"
+        >
+          <li
+            v-for="item in filteredProjects"
+            :key="item.uuid"
+            class="copilot-project-picker-modal__option"
+            :class="{
+              'copilot-project-picker-modal__option--selected':
+                selectedUuid === item.uuid,
+            }"
+            :data-testid="`copilot-project-picker-option-${item.uuid}`"
+            @click="selectedUuid = item.uuid"
+          >
+            <UnnnicRadio
+              :modelValue="selectedUuid"
+              :value="item.uuid"
+              size="md"
+              @update:model-value="selectedUuid = $event"
+            >
+              {{ item.name }}
+            </UnnnicRadio>
+            <UnnnicTag
+              :text="
+                $t(
+                  'config_chats.desk_copilot.picker_modal.assigned_agents_tag',
+                  { count: item.assigned_agents },
+                )
+              "
+              type="next"
+              scheme="bg-blue-plain"
+            />
+          </li>
+        </ul>
+      </section>
+
+      <UnnnicDialogFooter>
+        <UnnnicButton
+          type="tertiary"
+          :text="$t('cancel')"
+          data-testid="copilot-project-picker-cancel"
+          @click="close"
+        />
+        <UnnnicButton
+          type="primary"
+          :text="$t(submitLabelKey)"
+          :loading="isSaving"
+          :disabled="!canSubmit"
+          data-testid="copilot-project-picker-submit"
+          @click="submit"
+        />
+      </UnnnicDialogFooter>
+    </UnnnicDialogContent>
+  </UnnnicDialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+
+import { useCopilotProject } from '@/composables/useCopilotProject';
+import { useCopilotProjectsList } from '@/composables/useCopilotProjectsList';
+import { buildCopilotProjectUrl } from '@/utils/copilotProject';
+import callUnnnicAlert from '@/utils/callUnnnicAlert';
+import i18n from '@/plugins/i18n';
+
+defineOptions({
+  name: 'CopilotProjectPickerModal',
+});
+
+const props = withDefaults(
+  defineProps<{
+    modelValue: boolean;
+    mode?: 'connect' | 'change';
+  }>(),
+  {
+    mode: 'connect',
+  },
+);
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean];
+}>();
+
+const { linkedProject, changeLinkedProject } = useCopilotProject();
+const { projects } = useCopilotProjectsList();
+
+const searchTerm = ref('');
+const selectedUuid = ref('');
+const isSaving = ref(false);
+
+const isOpen = computed({
+  get: () => props.modelValue,
+  set: (value) => emit('update:modelValue', value),
+});
+
+const isChangeMode = computed(() => props.mode === 'change');
+
+const titleKey = computed(() =>
+  isChangeMode.value
+    ? 'config_chats.desk_copilot.picker_modal.change_title'
+    : 'config_chats.desk_copilot.picker_modal.select_title',
+);
+
+const submitLabelKey = computed(() =>
+  isChangeMode.value
+    ? 'config_chats.desk_copilot.picker_modal.change_button'
+    : 'config_chats.desk_copilot.picker_modal.connect_button',
+);
+
+const filteredProjects = computed(() => {
+  const query = searchTerm.value.trim().toLowerCase();
+
+  if (!query) return projects.value;
+
+  return projects.value.filter((item) =>
+    item.name.toLowerCase().includes(query),
+  );
+});
+
+const canSubmit = computed(() => {
+  if (!selectedUuid.value || isSaving.value) return false;
+
+  if (isChangeMode.value && selectedUuid.value === linkedProject.value?.uuid) {
+    return false;
+  }
+
+  return true;
+});
+
+watch(
+  () => props.modelValue,
+  (isVisible) => {
+    if (!isVisible) return;
+
+    searchTerm.value = '';
+    selectedUuid.value = isChangeMode.value
+      ? (linkedProject.value?.uuid ?? '')
+      : '';
+  },
+  { immediate: true },
+);
+
+function close() {
+  isOpen.value = false;
+}
+
+async function submit() {
+  if (!canSubmit.value) return;
+
+  isSaving.value = true;
+  try {
+    const updatedProject = await changeLinkedProject(selectedUuid.value);
+
+    callUnnnicAlert({
+      props: {
+        text: i18n.global.t(
+          isChangeMode.value
+            ? 'config_chats.desk_copilot.picker_modal.change_success'
+            : 'config_chats.desk_copilot.picker_modal.connect_success',
+        ),
+        type: 'success',
+      },
+      seconds: 5,
+    });
+
+    if (!isChangeMode.value) {
+      window.open(
+        buildCopilotProjectUrl(updatedProject.uuid),
+        '_blank',
+        'noopener,noreferrer',
+      );
+    }
+
+    close();
+  } catch {
+    callUnnnicAlert({
+      props: {
+        text: i18n.global.t(
+          isChangeMode.value
+            ? 'config_chats.desk_copilot.picker_modal.change_error'
+            : 'config_chats.desk_copilot.picker_modal.connect_error',
+        ),
+        type: 'error',
+      },
+      seconds: 5,
+    });
+  } finally {
+    isSaving.value = false;
+  }
+}
+
+defineExpose({
+  searchTerm,
+  selectedUuid,
+  isSaving,
+  isOpen,
+  submit,
+});
+</script>
+
+<style lang="scss" scoped>
+.copilot-project-picker-modal {
+  &__body {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-4;
+    padding: $unnnic-space-6;
+  }
+
+  &__list {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-2;
+    max-height: 320px;
+    overflow-y: auto;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  &__option {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: $unnnic-space-2;
+    padding: $unnnic-space-4;
+    border: 1px solid $unnnic-color-border-base;
+    border-radius: $unnnic-radius-2;
+    background-color: $unnnic-color-bg-base;
+    cursor: pointer;
+
+    :deep(.unnnic-radio) {
+      flex: 1;
+      min-width: 0;
+    }
+  }
+}
+</style>

--- a/src/views/Settings/DeskCopilot/CreateCopilotProjectModal.vue
+++ b/src/views/Settings/DeskCopilot/CreateCopilotProjectModal.vue
@@ -99,11 +99,15 @@ function close() {
 
 async function createProject() {
   const name = projectName.value.trim();
-  if (!name) return;
+  const projectUuid = project.value?.uuid;
+  if (!name || !projectUuid) return;
 
   isSaving.value = true;
   try {
-    const createdProject = await CopilotProjectService.create(name);
+    const createdProject = await CopilotProjectService.create(
+      name,
+      projectUuid,
+    );
 
     callUnnnicAlert({
       props: {

--- a/src/views/Settings/DeskCopilot/EmptyState.vue
+++ b/src/views/Settings/DeskCopilot/EmptyState.vue
@@ -7,31 +7,41 @@
       class="desk-copilot-empty-state__title"
       data-testid="desk-copilot-empty-state-title"
     >
-      {{ $t('config_chats.desk_copilot.empty_state.title') }}
+      {{ $t("config_chats.desk_copilot.empty_state.title") }}
     </h2>
     <p
       class="desk-copilot-empty-state__description"
       data-testid="desk-copilot-empty-state-description"
     >
-      {{ $t('config_chats.desk_copilot.empty_state.description') }}
+      {{ $t("config_chats.desk_copilot.empty_state.description") }}
     </p>
-    <UnnnicButton
-      type="primary"
-      size="small"
-      :text="$t('config_chats.desk_copilot.empty_state.create_button')"
-      data-testid="desk-copilot-create-button"
-      @click="emit('open-create-modal')"
-    />
+    <section class="desk-copilot-empty-state__actions">
+      <UnnnicButton
+        type="primary"
+        size="small"
+        :text="$t('config_chats.desk_copilot.empty_state.select_button')"
+        data-testid="desk-copilot-select-button"
+        @click="emit('open-select-modal')"
+      />
+      <UnnnicButton
+        type="secondary"
+        size="small"
+        :text="$t('config_chats.desk_copilot.empty_state.create_button')"
+        data-testid="desk-copilot-create-button"
+        @click="emit('open-create-modal')"
+      />
+    </section>
   </section>
 </template>
 
 <script setup lang="ts">
 defineOptions({
-  name: 'DeskCopilotEmptyState',
+  name: "DeskCopilotEmptyState",
 });
 
 const emit = defineEmits<{
-  'open-create-modal': [];
+  "open-create-modal": [];
+  "open-select-modal": [];
 }>();
 </script>
 
@@ -59,6 +69,13 @@ const emit = defineEmits<{
     text-align: center;
     max-width: 374px;
     margin: 0;
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: $unnnic-space-3;
   }
 }
 </style>

--- a/src/views/Settings/DeskCopilot/EmptyState.vue
+++ b/src/views/Settings/DeskCopilot/EmptyState.vue
@@ -7,13 +7,13 @@
       class="desk-copilot-empty-state__title"
       data-testid="desk-copilot-empty-state-title"
     >
-      {{ $t("config_chats.desk_copilot.empty_state.title") }}
+      {{ $t('config_chats.desk_copilot.empty_state.title') }}
     </h2>
     <p
       class="desk-copilot-empty-state__description"
       data-testid="desk-copilot-empty-state-description"
     >
-      {{ $t("config_chats.desk_copilot.empty_state.description") }}
+      {{ $t('config_chats.desk_copilot.empty_state.description') }}
     </p>
     <section class="desk-copilot-empty-state__actions">
       <UnnnicButton
@@ -36,12 +36,12 @@
 
 <script setup lang="ts">
 defineOptions({
-  name: "DeskCopilotEmptyState",
+  name: 'DeskCopilotEmptyState',
 });
 
 const emit = defineEmits<{
-  "open-create-modal": [];
-  "open-select-modal": [];
+  'open-create-modal': [];
+  'open-select-modal': [];
 }>();
 </script>
 

--- a/src/views/Settings/DeskCopilot/__tests__/ConnectedProjectCard.spec.js
+++ b/src/views/Settings/DeskCopilot/__tests__/ConnectedProjectCard.spec.js
@@ -1,40 +1,103 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mount } from '@vue/test-utils';
-import moment from 'moment';
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { mount, config } from "@vue/test-utils";
+import moment from "moment";
+import { createTestingPinia } from "@pinia/testing";
+import { ref } from "vue";
 
-import ConnectedProjectCard from '../ConnectedProjectCard.vue';
+import ConnectedProjectCard from "../ConnectedProjectCard.vue";
+import i18n from "@/plugins/i18n";
+import UnnnicSystemPlugin from "@/plugins/UnnnicSystem.js";
 
-vi.mock('@/utils/copilotProject', () => ({
+const hasMultipleProjects = ref(true);
+
+vi.mock("@/utils/copilotProject", () => ({
   buildCopilotProjectUrl: vi.fn(
     (uuid) => `https://dash.stg.cloud.weni.ai/projects/${uuid}`,
   ),
 }));
 
+vi.mock("@/composables/useCopilotProjectsList", () => ({
+  useCopilotProjectsList: () => ({
+    hasMultipleProjects,
+  }),
+}));
+
+beforeAll(() => {
+  config.global.plugins = (config.global.plugins || []).filter(
+    (plugin) => plugin !== i18n && plugin !== UnnnicSystemPlugin,
+  );
+});
+
+afterAll(() => {
+  if (config.global.plugins && !config.global.plugins.includes(i18n)) {
+    config.global.plugins.push(i18n);
+  }
+  if (
+    UnnnicSystemPlugin &&
+    config.global.plugins &&
+    !config.global.plugins.includes(UnnnicSystemPlugin)
+  ) {
+    config.global.plugins.push(UnnnicSystemPlugin);
+  }
+});
+
 const linkedProject = {
-  name: 'Sales 123',
+  name: "Sales 123",
   assigned_agents: 3,
-  created_on: '2026-07-30T00:00:00Z',
-  connected_on: '2026-07-30T00:00:00Z',
-  uuid: 'copilot-uuid',
-  connected_by: 'edu',
+  created_on: "2026-07-30T00:00:00Z",
+  connected_on: "2026-07-30T00:00:00Z",
+  uuid: "copilot-uuid",
+  connected_by: "edu",
 };
 
 const createWrapper = () =>
   mount(ConnectedProjectCard, {
     props: { linkedProject },
     global: {
+      plugins: [createTestingPinia()],
       mocks: {
         $t: (key) => key,
+      },
+      stubs: {
+        UnnnicPopover: {
+          name: "UnnnicPopover",
+          template:
+            '<div data-testid="desk-copilot-more-popover"><slot /></div>',
+        },
+        UnnnicPopoverTrigger: {
+          name: "UnnnicPopoverTrigger",
+          template: "<div><slot /></div>",
+        },
+        UnnnicPopoverContent: {
+          name: "UnnnicPopoverContent",
+          template: "<div><slot /></div>",
+        },
+        UnnnicPopoverOption: {
+          name: "UnnnicPopoverOption",
+          template:
+            '<button data-testid="desk-copilot-change-option" @click="$emit(\'click\')">{{ label }}</button>',
+          props: ["label", "icon"],
+        },
       },
     },
   });
 
-describe('DeskCopilot ConnectedProjectCard', () => {
+describe("DeskCopilot ConnectedProjectCard", () => {
   let wrapper;
   const originalOpen = window.open;
 
   beforeEach(() => {
     window.open = vi.fn();
+    hasMultipleProjects.value = true;
     wrapper = createWrapper();
   });
 
@@ -43,30 +106,58 @@ describe('DeskCopilot ConnectedProjectCard', () => {
     wrapper?.unmount();
   });
 
-  it('renders the linked project details', () => {
+  it("renders the linked project details", () => {
     expect(
       wrapper.find('[data-testid="desk-copilot-connected-name"]').text(),
-    ).toBe('Sales 123');
+    ).toBe("Sales 123");
     expect(
       wrapper.find('[data-testid="desk-copilot-connected-by"]').text(),
-    ).toBe('edu');
+    ).toBe("edu");
     expect(
       wrapper.find('[data-testid="desk-copilot-assigned-agents"]').text(),
-    ).toBe('3');
+    ).toBe("3");
     expect(wrapper.find('[data-testid="desk-copilot-created-on"]').text()).toBe(
-      moment(linkedProject.created_on).format('L'),
+      moment(linkedProject.created_on).format("L"),
     );
   });
 
-  it('opens the copilot project in a new tab', async () => {
+  it("opens the copilot project in a new tab", async () => {
     await wrapper
       .find('[data-testid="desk-copilot-open-button"]')
-      .trigger('click');
+      .trigger("click");
 
     expect(window.open).toHaveBeenCalledWith(
-      'https://dash.stg.cloud.weni.ai/projects/copilot-uuid',
-      '_blank',
-      'noopener,noreferrer',
+      "https://dash.stg.cloud.weni.ai/projects/copilot-uuid",
+      "_blank",
+      "noopener,noreferrer",
     );
+  });
+
+  it("shows the change option when there are multiple projects", () => {
+    expect(
+      wrapper.find('[data-testid="desk-copilot-more-popover"]').exists(),
+    ).toBe(true);
+    expect(
+      wrapper.find('[data-testid="desk-copilot-change-option"]').exists(),
+    ).toBe(true);
+  });
+
+  it("hides the popover when there is a single project", async () => {
+    hasMultipleProjects.value = false;
+    wrapper.unmount();
+    wrapper = createWrapper();
+    await wrapper.vm.$nextTick();
+
+    expect(
+      wrapper.find('[data-testid="desk-copilot-more-popover"]').exists(),
+    ).toBe(false);
+  });
+
+  it("emits open-change-modal when change is clicked", async () => {
+    await wrapper
+      .find('[data-testid="desk-copilot-change-option"]')
+      .trigger("click");
+
+    expect(wrapper.emitted("open-change-modal")).toBeTruthy();
   });
 });

--- a/src/views/Settings/DeskCopilot/__tests__/ConnectedProjectCard.spec.js
+++ b/src/views/Settings/DeskCopilot/__tests__/ConnectedProjectCard.spec.js
@@ -7,25 +7,25 @@ import {
   afterAll,
   beforeEach,
   afterEach,
-} from "vitest";
-import { mount, config } from "@vue/test-utils";
-import moment from "moment";
-import { createTestingPinia } from "@pinia/testing";
-import { ref } from "vue";
+} from 'vitest';
+import { mount, config } from '@vue/test-utils';
+import moment from 'moment';
+import { createTestingPinia } from '@pinia/testing';
+import { ref } from 'vue';
 
-import ConnectedProjectCard from "../ConnectedProjectCard.vue";
-import i18n from "@/plugins/i18n";
-import UnnnicSystemPlugin from "@/plugins/UnnnicSystem.js";
+import ConnectedProjectCard from '../ConnectedProjectCard.vue';
+import i18n from '@/plugins/i18n';
+import UnnnicSystemPlugin from '@/plugins/UnnnicSystem.js';
 
 const hasMultipleProjects = ref(true);
 
-vi.mock("@/utils/copilotProject", () => ({
+vi.mock('@/utils/copilotProject', () => ({
   buildCopilotProjectUrl: vi.fn(
     (uuid) => `https://dash.stg.cloud.weni.ai/projects/${uuid}`,
   ),
 }));
 
-vi.mock("@/composables/useCopilotProjectsList", () => ({
+vi.mock('@/composables/useCopilotProjectsList', () => ({
   useCopilotProjectsList: () => ({
     hasMultipleProjects,
   }),
@@ -51,12 +51,12 @@ afterAll(() => {
 });
 
 const linkedProject = {
-  name: "Sales 123",
+  name: 'Sales 123',
   assigned_agents: 3,
-  created_on: "2026-07-30T00:00:00Z",
-  connected_on: "2026-07-30T00:00:00Z",
-  uuid: "copilot-uuid",
-  connected_by: "edu",
+  created_on: '2026-07-30T00:00:00Z',
+  connected_on: '2026-07-30T00:00:00Z',
+  uuid: 'copilot-uuid',
+  connected_by: 'edu',
 };
 
 const createWrapper = () =>
@@ -69,29 +69,29 @@ const createWrapper = () =>
       },
       stubs: {
         UnnnicPopover: {
-          name: "UnnnicPopover",
+          name: 'UnnnicPopover',
           template:
             '<div data-testid="desk-copilot-more-popover"><slot /></div>',
         },
         UnnnicPopoverTrigger: {
-          name: "UnnnicPopoverTrigger",
-          template: "<div><slot /></div>",
+          name: 'UnnnicPopoverTrigger',
+          template: '<div><slot /></div>',
         },
         UnnnicPopoverContent: {
-          name: "UnnnicPopoverContent",
-          template: "<div><slot /></div>",
+          name: 'UnnnicPopoverContent',
+          template: '<div><slot /></div>',
         },
         UnnnicPopoverOption: {
-          name: "UnnnicPopoverOption",
+          name: 'UnnnicPopoverOption',
           template:
             '<button data-testid="desk-copilot-change-option" @click="$emit(\'click\')">{{ label }}</button>',
-          props: ["label", "icon"],
+          props: ['label', 'icon'],
         },
       },
     },
   });
 
-describe("DeskCopilot ConnectedProjectCard", () => {
+describe('DeskCopilot ConnectedProjectCard', () => {
   let wrapper;
   const originalOpen = window.open;
 
@@ -106,34 +106,34 @@ describe("DeskCopilot ConnectedProjectCard", () => {
     wrapper?.unmount();
   });
 
-  it("renders the linked project details", () => {
+  it('renders the linked project details', () => {
     expect(
       wrapper.find('[data-testid="desk-copilot-connected-name"]').text(),
-    ).toBe("Sales 123");
+    ).toBe('Sales 123');
     expect(
       wrapper.find('[data-testid="desk-copilot-connected-by"]').text(),
-    ).toBe("edu");
+    ).toBe('edu');
     expect(
       wrapper.find('[data-testid="desk-copilot-assigned-agents"]').text(),
-    ).toBe("3");
+    ).toBe('3');
     expect(wrapper.find('[data-testid="desk-copilot-created-on"]').text()).toBe(
-      moment(linkedProject.created_on).format("L"),
+      moment(linkedProject.created_on).format('L'),
     );
   });
 
-  it("opens the copilot project in a new tab", async () => {
+  it('opens the copilot project in a new tab', async () => {
     await wrapper
       .find('[data-testid="desk-copilot-open-button"]')
-      .trigger("click");
+      .trigger('click');
 
     expect(window.open).toHaveBeenCalledWith(
-      "https://dash.stg.cloud.weni.ai/projects/copilot-uuid",
-      "_blank",
-      "noopener,noreferrer",
+      'https://dash.stg.cloud.weni.ai/projects/copilot-uuid',
+      '_blank',
+      'noopener,noreferrer',
     );
   });
 
-  it("shows the change option when there are multiple projects", () => {
+  it('shows the change option when there are multiple projects', () => {
     expect(
       wrapper.find('[data-testid="desk-copilot-more-popover"]').exists(),
     ).toBe(true);
@@ -142,7 +142,7 @@ describe("DeskCopilot ConnectedProjectCard", () => {
     ).toBe(true);
   });
 
-  it("hides the popover when there is a single project", async () => {
+  it('hides the popover when there is a single project', async () => {
     hasMultipleProjects.value = false;
     wrapper.unmount();
     wrapper = createWrapper();
@@ -153,11 +153,11 @@ describe("DeskCopilot ConnectedProjectCard", () => {
     ).toBe(false);
   });
 
-  it("emits open-change-modal when change is clicked", async () => {
+  it('emits open-change-modal when change is clicked', async () => {
     await wrapper
       .find('[data-testid="desk-copilot-change-option"]')
-      .trigger("click");
+      .trigger('click');
 
-    expect(wrapper.emitted("open-change-modal")).toBeTruthy();
+    expect(wrapper.emitted('open-change-modal')).toBeTruthy();
   });
 });

--- a/src/views/Settings/DeskCopilot/__tests__/ConnectedProjectCard.spec.js
+++ b/src/views/Settings/DeskCopilot/__tests__/ConnectedProjectCard.spec.js
@@ -52,11 +52,11 @@ afterAll(() => {
 
 const linkedProject = {
   name: 'Sales 123',
-  assigned_agents: 3,
-  created_on: '2026-07-30T00:00:00Z',
-  connected_on: '2026-07-30T00:00:00Z',
+  assignedAgents: 3,
+  createdOn: '2026-07-30T00:00:00Z',
+  connectedOn: '2026-07-30T00:00:00Z',
   uuid: 'copilot-uuid',
-  connected_by: 'edu',
+  connectedBy: 'edu',
 };
 
 const createWrapper = () =>
@@ -117,7 +117,7 @@ describe('DeskCopilot ConnectedProjectCard', () => {
       wrapper.find('[data-testid="desk-copilot-assigned-agents"]').text(),
     ).toBe('3');
     expect(wrapper.find('[data-testid="desk-copilot-created-on"]').text()).toBe(
-      moment(linkedProject.created_on).format('L'),
+      moment(linkedProject.createdOn).format('L'),
     );
   });
 

--- a/src/views/Settings/DeskCopilot/__tests__/CopilotProjectPickerModal.spec.js
+++ b/src/views/Settings/DeskCopilot/__tests__/CopilotProjectPickerModal.spec.js
@@ -60,25 +60,25 @@ afterAll(() => {
 const existingProjects = [
   {
     name: 'Sales 123',
-    assigned_agents: 3,
+    assignedAgents: 3,
     uuid: 'copilot-uuid',
-    project_uuid: 'desk-uuid',
+    projectUuid: 'desk-uuid',
   },
   {
     name: 'Sales 456',
-    assigned_agents: 1,
+    assignedAgents: 1,
     uuid: 'copilot-uuid-2',
-    project_uuid: 'desk-uuid-2',
+    projectUuid: 'desk-uuid-2',
   },
 ];
 
 const updatedProject = {
   name: 'Sales 456',
-  assigned_agents: 1,
-  created_on: '2026-07-30T00:00:00Z',
-  connected_on: '2026-07-30T00:00:00Z',
+  assignedAgents: 1,
+  createdOn: '2026-07-30T00:00:00Z',
+  connectedOn: '2026-07-30T00:00:00Z',
   uuid: 'copilot-uuid-2',
-  connected_by: 'edu',
+  connectedBy: 'edu',
 };
 
 const createWrapper = ({ mode = 'connect' } = {}) =>

--- a/src/views/Settings/DeskCopilot/__tests__/CopilotProjectPickerModal.spec.js
+++ b/src/views/Settings/DeskCopilot/__tests__/CopilotProjectPickerModal.spec.js
@@ -1,0 +1,262 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { mount, config } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
+import { ref } from 'vue';
+
+import CopilotProjectPickerModal from '../CopilotProjectPickerModal.vue';
+import { resetCopilotProjectState } from '@/composables/useCopilotProject';
+import CopilotProjectService from '@/services/api/resources/chats/copilotProject';
+import callUnnnicAlert from '@/utils/callUnnnicAlert';
+import { buildCopilotProjectUrl } from '@/utils/copilotProject';
+import i18n from '@/plugins/i18n';
+
+const projects = ref([]);
+
+vi.mock('@/services/api/resources/chats/copilotProject', () => ({
+  default: {
+    update: vi.fn(),
+    getLinkedProject: vi.fn(),
+    listExistingProjects: vi.fn(),
+    create: vi.fn(),
+  },
+}));
+
+vi.mock('@/utils/callUnnnicAlert', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('@/utils/copilotProject', () => ({
+  buildCopilotProjectUrl: vi.fn(
+    (uuid) => `https://dash.stg.cloud.weni.ai/projects/${uuid}`,
+  ),
+}));
+
+vi.mock('@/composables/useCopilotProjectsList', () => ({
+  useCopilotProjectsList: () => ({
+    projects,
+  }),
+}));
+
+beforeAll(() => {
+  config.global.plugins = (config.global.plugins || []).filter(
+    (plugin) => plugin !== i18n,
+  );
+});
+
+afterAll(() => {
+  if (config.global.plugins && !config.global.plugins.includes(i18n)) {
+    config.global.plugins.push(i18n);
+  }
+});
+
+const existingProjects = [
+  {
+    name: 'Sales 123',
+    assigned_agents: 3,
+    uuid: 'copilot-uuid',
+    project_uuid: 'desk-uuid',
+  },
+  {
+    name: 'Sales 456',
+    assigned_agents: 1,
+    uuid: 'copilot-uuid-2',
+    project_uuid: 'desk-uuid-2',
+  },
+];
+
+const updatedProject = {
+  name: 'Sales 456',
+  assigned_agents: 1,
+  created_on: '2026-07-30T00:00:00Z',
+  connected_on: '2026-07-30T00:00:00Z',
+  uuid: 'copilot-uuid-2',
+  connected_by: 'edu',
+};
+
+const createWrapper = ({ mode = 'connect' } = {}) =>
+  mount(CopilotProjectPickerModal, {
+    props: {
+      modelValue: true,
+      mode,
+    },
+    global: {
+      plugins: [
+        createTestingPinia({
+          initialState: {
+            config: {
+              project: {
+                uuid: 'desk-uuid',
+                name: 'Sales 123',
+                config: {},
+                org: 'org-uuid',
+              },
+            },
+          },
+        }),
+      ],
+      mocks: {
+        $t: (key) => key,
+      },
+      stubs: {
+        UnnnicDialog: {
+          template: '<div><slot /></div>',
+          props: ['open'],
+        },
+        UnnnicDialogContent: {
+          template: '<div><slot /></div>',
+        },
+        UnnnicDialogHeader: {
+          template: '<div><slot /></div>',
+        },
+        UnnnicDialogTitle: {
+          template:
+            '<div data-testid="copilot-project-picker-title"><slot /></div>',
+        },
+        UnnnicDialogClose: {
+          template:
+            '<button data-testid="copilot-project-picker-close" @click="$emit(\'click\')"></button>',
+        },
+        UnnnicDialogFooter: {
+          template: '<div><slot /></div>',
+        },
+        UnnnicRadio: {
+          template:
+            '<label><input type="radio" :value="value" /><slot /></label>',
+          props: ['modelValue', 'value'],
+        },
+        UnnnicTag: true,
+      },
+    },
+  });
+
+describe('CopilotProjectPickerModal', () => {
+  let wrapper;
+  const originalOpen = window.open;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCopilotProjectState();
+    window.open = vi.fn();
+    projects.value = existingProjects;
+  });
+
+  afterAll(() => {
+    window.open = originalOpen;
+  });
+
+  it('renders the connect title', () => {
+    wrapper = createWrapper({ mode: 'connect' });
+
+    expect(
+      wrapper.find('[data-testid="copilot-project-picker-title"]').text(),
+    ).toBe('config_chats.desk_copilot.picker_modal.select_title');
+  });
+
+  it('renders the change title and pre-selects the linked project', async () => {
+    const { useCopilotProject } = await import(
+      '@/composables/useCopilotProject'
+    );
+    const { setLinkedProject } = useCopilotProject();
+    setLinkedProject({
+      ...updatedProject,
+      uuid: 'copilot-uuid',
+      name: 'Sales 123',
+    });
+
+    wrapper = createWrapper({ mode: 'change' });
+    await wrapper.vm.$nextTick();
+
+    expect(
+      wrapper.find('[data-testid="copilot-project-picker-title"]').text(),
+    ).toBe('config_chats.desk_copilot.picker_modal.change_title');
+    expect(wrapper.vm.selectedUuid).toBe('copilot-uuid');
+  });
+
+  it('filters projects by name on the client', async () => {
+    wrapper = createWrapper();
+    wrapper.vm.searchTerm = '456';
+    await wrapper.vm.$nextTick();
+
+    expect(
+      wrapper
+        .find('[data-testid="copilot-project-picker-option-copilot-uuid"]')
+        .exists(),
+    ).toBe(false);
+    expect(
+      wrapper
+        .find('[data-testid="copilot-project-picker-option-copilot-uuid-2"]')
+        .exists(),
+    ).toBe(true);
+  });
+
+  it('connects a project, shows a toast and opens a new tab', async () => {
+    CopilotProjectService.update.mockResolvedValue(updatedProject);
+    wrapper = createWrapper({ mode: 'connect' });
+    wrapper.vm.selectedUuid = 'copilot-uuid-2';
+
+    await wrapper.vm.submit();
+
+    expect(CopilotProjectService.update).toHaveBeenCalledWith(
+      'desk-uuid',
+      'copilot-uuid-2',
+    );
+    expect(callUnnnicAlert).toHaveBeenCalledWith({
+      props: {
+        text: expect.any(String),
+        type: 'success',
+      },
+      seconds: 5,
+    });
+    expect(buildCopilotProjectUrl).toHaveBeenCalledWith('copilot-uuid-2');
+    expect(window.open).toHaveBeenCalledWith(
+      'https://dash.stg.cloud.weni.ai/projects/copilot-uuid-2',
+      '_blank',
+      'noopener,noreferrer',
+    );
+    expect(wrapper.emitted('update:modelValue').at(-1)).toEqual([false]);
+  });
+
+  it('changes a project without opening a new tab', async () => {
+    CopilotProjectService.update.mockResolvedValue(updatedProject);
+    wrapper = createWrapper({ mode: 'change' });
+    wrapper.vm.selectedUuid = 'copilot-uuid-2';
+
+    await wrapper.vm.submit();
+
+    expect(callUnnnicAlert).toHaveBeenCalledWith({
+      props: {
+        text: expect.any(String),
+        type: 'success',
+      },
+      seconds: 5,
+    });
+    expect(window.open).not.toHaveBeenCalled();
+    expect(wrapper.emitted('update:modelValue').at(-1)).toEqual([false]);
+  });
+
+  it('shows an error toast and keeps the modal open on failure', async () => {
+    CopilotProjectService.update.mockRejectedValue(new Error('API Error'));
+    wrapper = createWrapper({ mode: 'connect' });
+    wrapper.vm.selectedUuid = 'copilot-uuid-2';
+
+    await wrapper.vm.submit();
+
+    expect(callUnnnicAlert).toHaveBeenCalledWith({
+      props: {
+        text: expect.any(String),
+        type: 'error',
+      },
+      seconds: 5,
+    });
+    expect(window.open).not.toHaveBeenCalled();
+    expect(wrapper.emitted('update:modelValue')).toBeFalsy();
+  });
+});

--- a/src/views/Settings/DeskCopilot/__tests__/CreateCopilotProjectModal.spec.js
+++ b/src/views/Settings/DeskCopilot/__tests__/CreateCopilotProjectModal.spec.js
@@ -47,11 +47,11 @@ afterAll(() => {
 
 const createdProject = {
   name: 'Sales 123',
-  assigned_agents: 0,
-  created_on: '2026-07-30T00:00:00Z',
-  connected_on: '2026-07-30T00:00:00Z',
+  assignedAgents: 0,
+  createdOn: '2026-07-30T00:00:00Z',
+  connectedOn: '2026-07-30T00:00:00Z',
   uuid: 'copilot-uuid',
-  connected_by: 'edu',
+  connectedBy: 'edu',
 };
 
 const createWrapper = () =>

--- a/src/views/Settings/DeskCopilot/__tests__/CreateCopilotProjectModal.spec.js
+++ b/src/views/Settings/DeskCopilot/__tests__/CreateCopilotProjectModal.spec.js
@@ -125,7 +125,10 @@ describe('CreateCopilotProjectModal', () => {
 
     await wrapper.vm.createProject();
 
-    expect(CopilotProjectService.create).toHaveBeenCalledWith('Sales 123');
+    expect(CopilotProjectService.create).toHaveBeenCalledWith(
+      'Sales 123',
+      'desk-uuid',
+    );
     expect(callUnnnicAlert).toHaveBeenCalledWith({
       props: {
         text: expect.any(String),

--- a/src/views/Settings/DeskCopilot/__tests__/EmptyState.spec.js
+++ b/src/views/Settings/DeskCopilot/__tests__/EmptyState.spec.js
@@ -35,4 +35,12 @@ describe('DeskCopilot EmptyState', () => {
 
     expect(wrapper.emitted('open-create-modal')).toBeTruthy();
   });
+
+  it('emits open-select-modal when the select button is clicked', async () => {
+    await wrapper
+      .find('[data-testid="desk-copilot-select-button"]')
+      .trigger('click');
+
+    expect(wrapper.emitted('open-select-modal')).toBeTruthy();
+  });
 });

--- a/src/views/Settings/DeskCopilot/__tests__/index.spec.js
+++ b/src/views/Settings/DeskCopilot/__tests__/index.spec.js
@@ -4,12 +4,15 @@ import { createTestingPinia } from '@pinia/testing';
 
 import DeskCopilotSettings from '../index.vue';
 import { resetCopilotProjectState } from '@/composables/useCopilotProject';
+import { resetCopilotProjectsListState } from '@/composables/useCopilotProjectsList';
 import CopilotProjectService from '@/services/api/resources/chats/copilotProject';
 
 vi.mock('@/services/api/resources/chats/copilotProject', () => ({
   default: {
     getLinkedProject: vi.fn().mockResolvedValue(null),
     create: vi.fn(),
+    update: vi.fn(),
+    listExistingProjects: vi.fn().mockResolvedValue([]),
   },
 }));
 
@@ -33,6 +36,7 @@ const createWrapper = () =>
                 uuid: 'desk-uuid',
                 name: 'Sales 123',
                 config: {},
+                org: 'org-uuid',
               },
             },
           },
@@ -47,15 +51,21 @@ const createWrapper = () =>
         },
         EmptyState: {
           template:
-            '<section data-testid="desk-copilot-empty-state" @click="$emit(\'open-create-modal\')" />',
+            '<section data-testid="desk-copilot-empty-state" @click="$emit(\'open-create-modal\')" @dblclick="$emit(\'open-select-modal\')" />',
         },
         ConnectedProjectCard: {
-          template: '<article data-testid="desk-copilot-connected-card" />',
+          template:
+            '<article data-testid="desk-copilot-connected-card" @click="$emit(\'open-change-modal\')" />',
           props: ['linkedProject'],
         },
         CreateCopilotProjectModal: {
           template: '<div data-testid="create-copilot-project-modal" />',
           props: ['modelValue'],
+        },
+        CopilotProjectPickerModal: {
+          template:
+            '<div data-testid="copilot-project-picker-modal" :data-mode="mode" :data-open="String(modelValue)" />',
+          props: ['modelValue', 'mode'],
         },
       },
     },
@@ -64,6 +74,7 @@ const createWrapper = () =>
 describe('DeskCopilotSettings', () => {
   beforeEach(() => {
     resetCopilotProjectState();
+    resetCopilotProjectsListState();
     vi.clearAllMocks();
   });
 
@@ -95,5 +106,37 @@ describe('DeskCopilotSettings', () => {
     expect(
       wrapper.find('[data-testid="desk-copilot-empty-state"]').exists(),
     ).toBe(false);
+  });
+
+  it('opens the picker in connect mode from the empty state', async () => {
+    CopilotProjectService.getLinkedProject.mockResolvedValue(null);
+    const wrapper = createWrapper();
+    await wrapper.vm.$nextTick();
+    await Promise.resolve();
+    await wrapper.vm.$nextTick();
+
+    await wrapper
+      .find('[data-testid="desk-copilot-empty-state"]')
+      .trigger('dblclick');
+
+    const picker = wrapper.find('[data-testid="copilot-project-picker-modal"]');
+    expect(picker.attributes('data-mode')).toBe('connect');
+    expect(picker.attributes('data-open')).toBe('true');
+  });
+
+  it('opens the picker in change mode from the connected card', async () => {
+    CopilotProjectService.getLinkedProject.mockResolvedValue(linkedProject);
+    const wrapper = createWrapper();
+    await wrapper.vm.$nextTick();
+    await Promise.resolve();
+    await wrapper.vm.$nextTick();
+
+    await wrapper
+      .find('[data-testid="desk-copilot-connected-card"]')
+      .trigger('click');
+
+    const picker = wrapper.find('[data-testid="copilot-project-picker-modal"]');
+    expect(picker.attributes('data-mode')).toBe('change');
+    expect(picker.attributes('data-open')).toBe('true');
   });
 });

--- a/src/views/Settings/DeskCopilot/__tests__/index.spec.js
+++ b/src/views/Settings/DeskCopilot/__tests__/index.spec.js
@@ -18,11 +18,11 @@ vi.mock('@/services/api/resources/chats/copilotProject', () => ({
 
 const linkedProject = {
   name: 'Sales 123',
-  assigned_agents: 3,
-  created_on: '2026-07-30T00:00:00Z',
-  connected_on: '2026-07-30T00:00:00Z',
+  assignedAgents: 3,
+  createdOn: '2026-07-30T00:00:00Z',
+  connectedOn: '2026-07-30T00:00:00Z',
   uuid: 'copilot-uuid',
-  connected_by: 'edu',
+  connectedBy: 'edu',
 };
 
 const createWrapper = () =>

--- a/src/views/Settings/DeskCopilot/index.vue
+++ b/src/views/Settings/DeskCopilot/index.vue
@@ -16,17 +16,23 @@
       <EmptyState
         v-if="!isLoading && !linkedProject"
         @open-create-modal="showCreateModal = true"
+        @open-select-modal="openPicker('connect')"
       />
 
       <ConnectedProjectCard
         v-else-if="linkedProject"
         :linkedProject="linkedProject"
+        @open-change-modal="openPicker('change')"
       />
     </section>
 
     <CreateCopilotProjectModal
       v-model="showCreateModal"
       @created="handleCreated"
+    />
+    <CopilotProjectPickerModal
+      v-model="showPickerModal"
+      :mode="pickerMode"
     />
   </section>
 </template>
@@ -38,17 +44,29 @@ import InfoCard from './InfoCard.vue';
 import EmptyState from './EmptyState.vue';
 import ConnectedProjectCard from './ConnectedProjectCard.vue';
 import CreateCopilotProjectModal from './CreateCopilotProjectModal.vue';
+import CopilotProjectPickerModal from './CopilotProjectPickerModal.vue';
 import { useCopilotProject } from '@/composables/useCopilotProject';
+import { useCopilotProjectsList } from '@/composables/useCopilotProjectsList';
 import type { CopilotProject } from '@/services/api/resources/chats/copilotProject';
 
 defineOptions({
   name: 'DeskCopilotSettings',
 });
 
+type PickerMode = 'connect' | 'change';
+
 const { linkedProject, isLoading, fetchLinkedProject, setLinkedProject } =
   useCopilotProject();
+const { fetchProjects } = useCopilotProjectsList();
 
 const showCreateModal = ref(false);
+const showPickerModal = ref(false);
+const pickerMode = ref<PickerMode>('connect');
+
+function openPicker(mode: PickerMode) {
+  pickerMode.value = mode;
+  showPickerModal.value = true;
+}
 
 function handleCreated(project: CopilotProject) {
   setLinkedProject(project);
@@ -57,6 +75,7 @@ function handleCreated(project: CopilotProject) {
 
 onMounted(() => {
   fetchLinkedProject();
+  fetchProjects();
 });
 </script>
 


### PR DESCRIPTION
### Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Tests
- [ ] Chore
- [x] Locales

### Why
Users need a way to connect an existing Copilot Project to a Desk project, and to switch between Copilot Projects after one is already linked, without having to create a new one every time.

### What Changed
- Added a `CopilotProjectPickerModal` component that lists existing Copilot Projects with a search filter, radio selection, and an assigned-agents tag. It operates in two modes: `connect` (for the empty state) and `change` (for an already-linked project). On success it shows a toast; in connect mode it also opens the new project in a new tab.
- Added `useCopilotProjectsList` composable that fetches the list of existing Copilot Projects scoped to the current org UUID, exposes `projects`, `isLoading`, and `hasMultipleProjects`, and deduplicates in-flight requests.
- Added `changeLinkedProject` and `createProject` actions to `useCopilotProject`, backed by a new `update` API call (`PUT /project/copilot/update/:projectUuid`) and an updated `create` call that now sends the desk project UUID.
- Added `listExistingProjects` to the Copilot Project service (`GET /project/copilot/list_existing_projects/:orgUuid`) along with a `normalizeCopilotProjectSummary` helper and the `CopilotProjectSummary` type.
- The `ConnectedProjectCard` now shows a popover with a "Change" option when `hasMultipleProjects` is true, emitting `open-change-modal` to the parent.
- The `EmptyState` now renders a primary "Select Copilot Project" button alongside the existing secondary "Create Copilot Project" button, emitting `open-select-modal`.
- `DeskCopilotSettings` wires up the picker modal, fetches the projects list on mount, and routes `open-select-modal` / `open-change-modal` events to the correct picker mode.
- Locale strings for the picker modal (title, buttons, toasts, search placeholder, and a pluralized assigned-agents tag) added for EN, ES, PT-BR, and RO.

### Diagram

```mermaid
flowchart TD
    A[DeskCopilotSettings] -->|no linked project| B[EmptyState]
    A -->|linked project| C[ConnectedProjectCard]
    B -->|open-select-modal| D["openPicker('connect')"]
    C -->|open-change-modal| E["openPicker('change')"]
    D --> F[CopilotProjectPickerModal mode=connect]
    E --> G[CopilotProjectPickerModal mode=change]
    F -->|submit| H[changeLinkedProject]
    G -->|submit| H
    H --> I["PUT /project/copilot/update/:uuid"]
    A -->|onMounted| J[fetchProjects]
    J --> K["GET /project/copilot/list_existing_projects/:orgUuid"]
    K --> L[useCopilotProjectsList]
    L -->|hasMultipleProjects| C
    L -->|projects| F
    L -->|projects| G
```