### PR TITLE
feat: add disconnect Copilot Project modal and service method

### DIFF
--- a/src/composables/__tests__/useCopilotProject.spec.ts
+++ b/src/composables/__tests__/useCopilotProject.spec.ts
@@ -14,6 +14,7 @@ vi.mock('@/services/api/resources/chats/copilotProject', () => ({
     create: vi.fn(),
     update: vi.fn(),
     listExistingProjects: vi.fn(),
+    remove: vi.fn(),
   },
 }));
 
@@ -141,5 +142,35 @@ describe('useCopilotProject', () => {
       'network',
     );
     expect(project.value).toBeNull();
+  });
+
+  it('clears the linked project after a successful disconnect', async () => {
+    CopilotProjectService.remove.mockResolvedValue();
+
+    const {
+      setLinkedProject,
+      disconnectLinkedProject,
+      linkedProject: project,
+    } = useCopilotProject();
+    setLinkedProject(linkedProject);
+
+    await disconnectLinkedProject();
+
+    expect(CopilotProjectService.remove).toHaveBeenCalledWith('copilot-uuid');
+    expect(project.value).toBeNull();
+  });
+
+  it('keeps the linked project when disconnect fails', async () => {
+    CopilotProjectService.remove.mockRejectedValue(new Error('network'));
+
+    const {
+      setLinkedProject,
+      disconnectLinkedProject,
+      linkedProject: project,
+    } = useCopilotProject();
+    setLinkedProject(linkedProject);
+
+    await expect(disconnectLinkedProject()).rejects.toThrow('network');
+    expect(project.value).toEqual(linkedProject);
   });
 });

--- a/src/composables/useCopilotProject.ts
+++ b/src/composables/useCopilotProject.ts
@@ -80,6 +80,17 @@ export function useCopilotProject() {
     return updatedProject;
   }
 
+  async function disconnectLinkedProject() {
+    const copilotProjectUuid = linkedProject.value?.uuid;
+
+    if (!copilotProjectUuid) {
+      throw new Error('Missing copilot project uuid');
+    }
+
+    await CopilotProjectService.remove(copilotProjectUuid);
+    linkedProject.value = null;
+  }
+
   const isLinked = computed(() => !!linkedProject.value);
   const showNewBadge = computed(() => !linkedProject.value);
 
@@ -92,5 +103,6 @@ export function useCopilotProject() {
     setLinkedProject,
     createProject,
     changeLinkedProject,
+    disconnectLinkedProject,
   };
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1151,7 +1151,15 @@
         "created_on": "Created on",
         "description": "This project is used exclusively to manage the AI agents for the Desk Copilot. It is accessible only through this section.",
         "open": "Open",
-        "popover_change_option": "Change"
+        "popover_change_option": "Change",
+        "popover_disconnect_option": "Disconnect"
+      },
+      "disconnect_modal": {
+        "confirm": "Disconnect",
+        "description": "This project will lose access to Desk Copilot feature until a Copilot Project is reconnected. The Copilot Project itself and its other connections will not be affected.",
+        "error": "Unable to disconnect the Copilot Project.",
+        "success": "The Copilot Project has been disconnected!",
+        "title": "Disconnect Copilot Project"
       },
       "empty_state": {
         "create_button": "Create Copilot Project",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1151,7 +1151,15 @@
         "created_on": "Creado el",
         "description": "Este proyecto se usa exclusivamente para gestionar los agentes de IA de Desk Copilot. Solo es accesible desde esta sección.",
         "open": "Abrir",
-        "popover_change_option": "Cambiar"
+        "popover_change_option": "Cambiar",
+        "popover_disconnect_option": "Desconectar"
+      },
+      "disconnect_modal": {
+        "confirm": "Desconectar",
+        "description": "Este proyecto perderá el acceso a Desk Copilot hasta que se reconecte un proyecto Copilot. El proyecto Copilot y las demás conexiones no se verán afectados.",
+        "error": "No se pudo desconectar el proyecto Copilot",
+        "success": "Proyecto Copilot desconectado con éxito",
+        "title": "Desconectar proyecto Copilot"
       },
       "empty_state": {
         "create_button": "Crear proyecto Copilot",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -1151,7 +1151,15 @@
         "created_on": "Criado em",
         "description": "Este projeto é usado exclusivamente para gerenciar os agentes de IA do Desk Copilot. O acesso é feito apenas por esta seção.",
         "open": "Abrir",
-        "popover_change_option": "Alterar"
+        "popover_change_option": "Alterar",
+        "popover_disconnect_option": "Desconectar"
+      },
+      "disconnect_modal": {
+        "confirm": "Desconectar",
+        "description": "Este projeto perderá o acesso ao Desk Copilot até que um projeto Copilot seja reconectado. O projeto Copilot e as outras conexões não serão afetados.",
+        "error": "Não foi possível desconectar o projeto Copilot",
+        "success": "Projeto Copilot desconectado com sucesso",
+        "title": "Desconectar projeto Copilot"
       },
       "empty_state": {
         "create_button": "Criar projeto Copilot",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -1130,7 +1130,15 @@
         "created_on": "Creat pe",
         "description": "Acest proiect este folosit exclusiv pentru a gestiona agenții IA pentru Desk Copilot. Este accesibil doar din această secțiune.",
         "open": "Deschide",
-        "popover_change_option": "Schimbă"
+        "popover_change_option": "Schimbă",
+        "popover_disconnect_option": "Deconectează"
+      },
+      "disconnect_modal": {
+        "confirm": "Deconectează",
+        "description": "Acest proiect va pierde accesul la Desk Copilot până când un proiect Copilot este reconectat. Proiectul Copilot și celelalte conexiuni nu vor fi afectate.",
+        "error": "Nu s-a putut deconecta proiectul Copilot",
+        "success": "Proiect Copilot deconectat cu succes",
+        "title": "Deconectează proiectul Copilot"
       },
       "empty_state": {
         "create_button": "Creează proiect Copilot",

--- a/src/services/api/resources/chats/__tests__/copilotProject.spec.ts
+++ b/src/services/api/resources/chats/__tests__/copilotProject.spec.ts
@@ -10,6 +10,7 @@ vi.mock('@/services/api/http', () => ({
     get: vi.fn(),
     post: vi.fn(),
     put: vi.fn(),
+    delete: vi.fn(),
   },
 }));
 
@@ -201,6 +202,18 @@ describe('copilotProject service', () => {
       await expect(
         CopilotProjectService.update('desk-uuid', 'copilot-uuid-2'),
       ).rejects.toThrow('Invalid copilot project response');
+    });
+  });
+
+  describe('remove', () => {
+    it('deletes the copilot project link by copilot uuid', async () => {
+      http.delete.mockResolvedValue({ status: 200 });
+
+      await CopilotProjectService.remove('copilot-uuid');
+
+      expect(http.delete).toHaveBeenCalledWith(
+        '/project/copilot/remove/copilot-uuid',
+      );
     });
   });
 });

--- a/src/services/api/resources/chats/copilotProject.ts
+++ b/src/services/api/resources/chats/copilotProject.ts
@@ -28,7 +28,7 @@ type CopilotProjectResponse = {
   connect_by?: string;
 };
 
-const IS_MOCKED = true;
+const IS_MOCKED = false;
 
 const MOCKED_COPILOT_PROJECT: CopilotProject = {
   name: 'Desk Copilot',

--- a/src/services/api/resources/chats/copilotProject.ts
+++ b/src/services/api/resources/chats/copilotProject.ts
@@ -28,7 +28,7 @@ type CopilotProjectResponse = {
   connect_by?: string;
 };
 
-const IS_MOCKED = false;
+const IS_MOCKED = true;
 
 const MOCKED_COPILOT_PROJECT: CopilotProject = {
   name: 'Desk Copilot',
@@ -161,5 +161,13 @@ export default {
     }
 
     return project;
+  },
+
+  async remove(copilotProjectUuid: string): Promise<void> {
+    if (IS_MOCKED) {
+      return;
+    }
+
+    await http.delete(`/project/copilot/remove/${copilotProjectUuid}`);
   },
 };

--- a/src/views/Settings/DeskCopilot/ConnectedProjectCard.vue
+++ b/src/views/Settings/DeskCopilot/ConnectedProjectCard.vue
@@ -46,7 +46,6 @@
           @click="openProject"
         />
         <UnnnicPopover
-          v-if="hasMultipleProjects"
           :open="openPopover"
           data-testid="desk-copilot-more-popover"
           @update:open="openPopover = $event"
@@ -59,14 +58,30 @@
               data-testid="desk-copilot-more-button"
             />
           </UnnnicPopoverTrigger>
-          <UnnnicPopoverContent size="small">
+          <UnnnicPopoverContent
+            size="small"
+            side="bottom"
+            align="end"
+          >
             <UnnnicPopoverOption
+              v-if="hasMultipleProjects"
               :label="
                 $t('config_chats.desk_copilot.connected.popover_change_option')
               "
               icon="edit_square"
               data-testid="desk-copilot-change-option"
               @click="handleChange"
+            />
+            <UnnnicPopoverOption
+              :label="
+                $t(
+                  'config_chats.desk_copilot.connected.popover_disconnect_option',
+                )
+              "
+              icon="delete"
+              scheme="fg-critical"
+              data-testid="desk-copilot-disconnect-option"
+              @click="handleDisconnect"
             />
           </UnnnicPopoverContent>
         </UnnnicPopover>
@@ -104,6 +119,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   'open-change-modal': [];
+  'open-disconnect-modal': [];
 }>();
 
 const { hasMultipleProjects } = useCopilotProjectsList();
@@ -149,6 +165,11 @@ function openProject() {
 function handleChange() {
   openPopover.value = false;
   emit('open-change-modal');
+}
+
+function handleDisconnect() {
+  openPopover.value = false;
+  emit('open-disconnect-modal');
 }
 </script>
 

--- a/src/views/Settings/DeskCopilot/DisconnectCopilotProjectModal.vue
+++ b/src/views/Settings/DeskCopilot/DisconnectCopilotProjectModal.vue
@@ -1,0 +1,117 @@
+<template>
+  <UnnnicDialog
+    v-model:open="isOpen"
+    data-testid="disconnect-copilot-project-modal"
+  >
+    <UnnnicDialogContent size="medium">
+      <UnnnicDialogHeader>
+        <UnnnicDialogTitle data-testid="disconnect-copilot-project-title">
+          {{ $t('config_chats.desk_copilot.disconnect_modal.title') }}
+        </UnnnicDialogTitle>
+        <UnnnicDialogClose
+          data-testid="disconnect-copilot-project-close"
+          @click="close"
+        />
+      </UnnnicDialogHeader>
+
+      <p
+        class="disconnect-copilot-project-modal__description"
+        data-testid="disconnect-copilot-project-description"
+      >
+        {{ $t('config_chats.desk_copilot.disconnect_modal.description') }}
+      </p>
+
+      <UnnnicDialogFooter>
+        <UnnnicButton
+          type="tertiary"
+          :text="$t('cancel')"
+          :disabled="isSaving"
+          data-testid="disconnect-copilot-project-cancel"
+          @click="close"
+        />
+        <UnnnicButton
+          type="warning"
+          :text="$t('config_chats.desk_copilot.disconnect_modal.confirm')"
+          :loading="isSaving"
+          data-testid="disconnect-copilot-project-submit"
+          @click="disconnect"
+        />
+      </UnnnicDialogFooter>
+    </UnnnicDialogContent>
+  </UnnnicDialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+
+import { useCopilotProject } from '@/composables/useCopilotProject';
+import callUnnnicAlert from '@/utils/callUnnnicAlert';
+import i18n from '@/plugins/i18n';
+
+defineOptions({
+  name: 'DisconnectCopilotProjectModal',
+});
+
+const props = defineProps<{
+  modelValue: boolean;
+}>();
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean];
+}>();
+
+const { disconnectLinkedProject } = useCopilotProject();
+const isSaving = ref(false);
+
+const isOpen = computed({
+  get: () => props.modelValue,
+  set: (value) => emit('update:modelValue', value),
+});
+
+function close() {
+  if (isSaving.value) return;
+  isOpen.value = false;
+}
+
+async function disconnect() {
+  if (isSaving.value) return;
+
+  isSaving.value = true;
+  try {
+    await disconnectLinkedProject();
+
+    callUnnnicAlert({
+      props: {
+        text: i18n.global.t(
+          'config_chats.desk_copilot.disconnect_modal.success',
+        ),
+        type: 'success',
+      },
+      seconds: 5,
+    });
+
+    isOpen.value = false;
+  } catch {
+    callUnnnicAlert({
+      props: {
+        text: i18n.global.t('config_chats.desk_copilot.disconnect_modal.error'),
+        type: 'error',
+      },
+      seconds: 5,
+    });
+  } finally {
+    isSaving.value = false;
+  }
+}
+
+defineExpose({ isSaving, isOpen, disconnect });
+</script>
+
+<style lang="scss" scoped>
+.disconnect-copilot-project-modal__description {
+  margin: 0;
+  padding: $unnnic-space-6;
+  font: $unnnic-font-body;
+  color: $unnnic-color-fg-base;
+}
+</style>

--- a/src/views/Settings/DeskCopilot/__tests__/ConnectedProjectCard.spec.js
+++ b/src/views/Settings/DeskCopilot/__tests__/ConnectedProjectCard.spec.js
@@ -83,9 +83,10 @@ const createWrapper = () =>
         },
         UnnnicPopoverOption: {
           name: 'UnnnicPopoverOption',
+          inheritAttrs: false,
           template:
-            '<button data-testid="desk-copilot-change-option" @click="$emit(\'click\')">{{ label }}</button>',
-          props: ['label', 'icon'],
+            '<button v-bind="$attrs" @click="$emit(\'click\')">{{ label }}</button>',
+          props: ['label', 'icon', 'scheme'],
         },
       },
     },
@@ -140,9 +141,12 @@ describe('DeskCopilot ConnectedProjectCard', () => {
     expect(
       wrapper.find('[data-testid="desk-copilot-change-option"]').exists(),
     ).toBe(true);
+    expect(
+      wrapper.find('[data-testid="desk-copilot-disconnect-option"]').exists(),
+    ).toBe(true);
   });
 
-  it('hides the popover when there is a single project', async () => {
+  it('hides the change option when there is a single project', async () => {
     hasMultipleProjects.value = false;
     wrapper.unmount();
     wrapper = createWrapper();
@@ -150,7 +154,13 @@ describe('DeskCopilot ConnectedProjectCard', () => {
 
     expect(
       wrapper.find('[data-testid="desk-copilot-more-popover"]').exists(),
+    ).toBe(true);
+    expect(
+      wrapper.find('[data-testid="desk-copilot-change-option"]').exists(),
     ).toBe(false);
+    expect(
+      wrapper.find('[data-testid="desk-copilot-disconnect-option"]').exists(),
+    ).toBe(true);
   });
 
   it('emits open-change-modal when change is clicked', async () => {
@@ -159,5 +169,13 @@ describe('DeskCopilot ConnectedProjectCard', () => {
       .trigger('click');
 
     expect(wrapper.emitted('open-change-modal')).toBeTruthy();
+  });
+
+  it('emits open-disconnect-modal when disconnect is clicked', async () => {
+    await wrapper
+      .find('[data-testid="desk-copilot-disconnect-option"]')
+      .trigger('click');
+
+    expect(wrapper.emitted('open-disconnect-modal')).toBeTruthy();
   });
 });

--- a/src/views/Settings/DeskCopilot/__tests__/DisconnectCopilotProjectModal.spec.js
+++ b/src/views/Settings/DeskCopilot/__tests__/DisconnectCopilotProjectModal.spec.js
@@ -1,0 +1,141 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { mount, config } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+
+import DisconnectCopilotProjectModal from '../DisconnectCopilotProjectModal.vue';
+import {
+  resetCopilotProjectState,
+  useCopilotProject,
+} from '@/composables/useCopilotProject';
+import CopilotProjectService from '@/services/api/resources/chats/copilotProject';
+import callUnnnicAlert from '@/utils/callUnnnicAlert';
+import i18n from '@/plugins/i18n';
+
+vi.mock('@/services/api/resources/chats/copilotProject', () => ({
+  default: {
+    remove: vi.fn(),
+    getLinkedProject: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    listExistingProjects: vi.fn(),
+  },
+}));
+
+vi.mock('@/utils/callUnnnicAlert', () => ({
+  default: vi.fn(),
+}));
+
+beforeAll(() => {
+  config.global.plugins = (config.global.plugins || []).filter(
+    (plugin) => plugin !== i18n,
+  );
+});
+
+afterAll(() => {
+  if (config.global.plugins && !config.global.plugins.includes(i18n)) {
+    config.global.plugins.push(i18n);
+  }
+});
+
+const linkedProject = {
+  name: 'Sales 123',
+  assignedAgents: 3,
+  createdOn: '2026-07-30T00:00:00Z',
+  connectedOn: '2026-07-30T00:00:00Z',
+  uuid: 'copilot-uuid',
+  connectedBy: 'edu',
+};
+
+const createWrapper = () =>
+  mount(DisconnectCopilotProjectModal, {
+    props: {
+      modelValue: true,
+    },
+    global: {
+      plugins: [createTestingPinia()],
+      mocks: {
+        $t: (key) => key,
+      },
+      stubs: {
+        UnnnicDialog: {
+          template: '<div><slot /></div>',
+          props: ['open'],
+        },
+        UnnnicDialogContent: {
+          template: '<div><slot /></div>',
+        },
+        UnnnicDialogHeader: {
+          template: '<div><slot /></div>',
+        },
+        UnnnicDialogTitle: {
+          template: '<div><slot /></div>',
+        },
+        UnnnicDialogClose: {
+          template:
+            '<button data-testid="dialog-close" @click="$emit(\'click\')"></button>',
+        },
+        UnnnicDialogFooter: {
+          template: '<div><slot /></div>',
+        },
+      },
+    },
+  });
+
+describe('DisconnectCopilotProjectModal', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCopilotProjectState();
+    setActivePinia(createTestingPinia());
+    const { setLinkedProject } = useCopilotProject();
+    setLinkedProject(linkedProject);
+    wrapper = createWrapper();
+  });
+
+  it('renders the disconnect title', () => {
+    expect(
+      wrapper.find('[data-testid="disconnect-copilot-project-title"]').text(),
+    ).toBe('config_chats.desk_copilot.disconnect_modal.title');
+  });
+
+  it('disconnects the project, shows a toast and closes the modal', async () => {
+    CopilotProjectService.remove.mockResolvedValue();
+
+    await wrapper.vm.disconnect();
+
+    expect(CopilotProjectService.remove).toHaveBeenCalledWith('copilot-uuid');
+    expect(callUnnnicAlert).toHaveBeenCalledWith({
+      props: {
+        text: expect.any(String),
+        type: 'success',
+      },
+      seconds: 5,
+    });
+    expect(wrapper.emitted('update:modelValue').at(-1)).toEqual([false]);
+  });
+
+  it('shows an error toast and keeps the modal open on failure', async () => {
+    CopilotProjectService.remove.mockRejectedValue(new Error('API Error'));
+
+    await wrapper.vm.disconnect();
+
+    expect(callUnnnicAlert).toHaveBeenCalledWith({
+      props: {
+        text: expect.any(String),
+        type: 'error',
+      },
+      seconds: 5,
+    });
+    expect(wrapper.emitted('update:modelValue')).toBeFalsy();
+  });
+});

--- a/src/views/Settings/DeskCopilot/__tests__/index.spec.js
+++ b/src/views/Settings/DeskCopilot/__tests__/index.spec.js
@@ -3,7 +3,10 @@ import { mount } from '@vue/test-utils';
 import { createTestingPinia } from '@pinia/testing';
 
 import DeskCopilotSettings from '../index.vue';
-import { resetCopilotProjectState } from '@/composables/useCopilotProject';
+import {
+  resetCopilotProjectState,
+  useCopilotProject,
+} from '@/composables/useCopilotProject';
 import { resetCopilotProjectsListState } from '@/composables/useCopilotProjectsList';
 import CopilotProjectService from '@/services/api/resources/chats/copilotProject';
 
@@ -13,6 +16,7 @@ vi.mock('@/services/api/resources/chats/copilotProject', () => ({
     create: vi.fn(),
     update: vi.fn(),
     listExistingProjects: vi.fn().mockResolvedValue([]),
+    remove: vi.fn(),
   },
 }));
 
@@ -55,7 +59,7 @@ const createWrapper = () =>
         },
         ConnectedProjectCard: {
           template:
-            '<article data-testid="desk-copilot-connected-card" @click="$emit(\'open-change-modal\')" />',
+            '<article data-testid="desk-copilot-connected-card" @click="$emit(\'open-change-modal\')" @dblclick="$emit(\'open-disconnect-modal\')" />',
           props: ['linkedProject'],
         },
         CreateCopilotProjectModal: {
@@ -66,6 +70,11 @@ const createWrapper = () =>
           template:
             '<div data-testid="copilot-project-picker-modal" :data-mode="mode" :data-open="String(modelValue)" />',
           props: ['modelValue', 'mode'],
+        },
+        DisconnectCopilotProjectModal: {
+          template:
+            '<div data-testid="disconnect-copilot-project-modal" :data-open="String(modelValue)" />',
+          props: ['modelValue'],
         },
       },
     },
@@ -138,5 +147,42 @@ describe('DeskCopilotSettings', () => {
     const picker = wrapper.find('[data-testid="copilot-project-picker-modal"]');
     expect(picker.attributes('data-mode')).toBe('change');
     expect(picker.attributes('data-open')).toBe('true');
+  });
+
+  it('opens the disconnect modal from the connected card', async () => {
+    CopilotProjectService.getLinkedProject.mockResolvedValue(linkedProject);
+    const wrapper = createWrapper();
+    await wrapper.vm.$nextTick();
+    await Promise.resolve();
+    await wrapper.vm.$nextTick();
+
+    await wrapper
+      .find('[data-testid="desk-copilot-connected-card"]')
+      .trigger('dblclick');
+
+    expect(
+      wrapper
+        .find('[data-testid="disconnect-copilot-project-modal"]')
+        .attributes('data-open'),
+    ).toBe('true');
+  });
+
+  it('shows the empty state after the linked project is cleared', async () => {
+    CopilotProjectService.getLinkedProject.mockResolvedValue(linkedProject);
+    const wrapper = createWrapper();
+    await wrapper.vm.$nextTick();
+    await Promise.resolve();
+    await wrapper.vm.$nextTick();
+
+    const { setLinkedProject } = useCopilotProject();
+    setLinkedProject(null);
+    await wrapper.vm.$nextTick();
+
+    expect(
+      wrapper.find('[data-testid="desk-copilot-empty-state"]').exists(),
+    ).toBe(true);
+    expect(
+      wrapper.find('[data-testid="desk-copilot-connected-card"]').exists(),
+    ).toBe(false);
   });
 });

--- a/src/views/Settings/DeskCopilot/index.vue
+++ b/src/views/Settings/DeskCopilot/index.vue
@@ -23,6 +23,7 @@
         v-else-if="linkedProject"
         :linkedProject="linkedProject"
         @open-change-modal="openPicker('change')"
+        @open-disconnect-modal="showDisconnectModal = true"
       />
     </section>
 
@@ -34,6 +35,7 @@
       v-model="showPickerModal"
       :mode="pickerMode"
     />
+    <DisconnectCopilotProjectModal v-model="showDisconnectModal" />
   </section>
 </template>
 
@@ -45,6 +47,7 @@ import EmptyState from './EmptyState.vue';
 import ConnectedProjectCard from './ConnectedProjectCard.vue';
 import CreateCopilotProjectModal from './CreateCopilotProjectModal.vue';
 import CopilotProjectPickerModal from './CopilotProjectPickerModal.vue';
+import DisconnectCopilotProjectModal from './DisconnectCopilotProjectModal.vue';
 import { useCopilotProject } from '@/composables/useCopilotProject';
 import { useCopilotProjectsList } from '@/composables/useCopilotProjectsList';
 import type { CopilotProject } from '@/services/api/resources/chats/copilotProject';
@@ -61,6 +64,7 @@ const { fetchProjects } = useCopilotProjectsList();
 
 const showCreateModal = ref(false);
 const showPickerModal = ref(false);
+const showDisconnectModal = ref(false);
 const pickerMode = ref<PickerMode>('connect');
 
 function openPicker(mode: PickerMode) {


### PR DESCRIPTION
### Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Tests
- [ ] Chore
- [x] Locales

### Why
Users needed a way to unlink a Copilot Project from Desk Copilot without deleting the project itself or affecting its other connections.

### What Changed
- Added a `remove` method to `CopilotProjectService` that calls `DELETE /project/copilot/remove/{uuid}`.
- Added `disconnectLinkedProject` to the `useCopilotProject` composable, which calls the service and clears the local `linkedProject` state on success.
- Added a "Disconnect" option to the `ConnectedProjectCard` popover. The popover is now always visible (not gated on `hasMultipleProjects`), while the "Change" option remains conditionally shown only when multiple projects exist.
- Created `DisconnectCopilotProjectModal.vue`, a confirmation dialog that calls `disconnectLinkedProject`, shows a success or error toast, and closes itself on success.
- Wired the new modal into `DeskCopilot/index.vue` via a `showDisconnectModal` ref and the `open-disconnect-modal` event emitted by `ConnectedProjectCard`.
- Added locale keys for the disconnect option label and all modal strings (title, description, confirm button, success toast, error toast) in English, Spanish, Portuguese (BR), and Romanian.