### PR TITLE
feat: implement media messages with text feature

### DIFF
--- a/src/components/chats/Message/index.vue
+++ b/src/components/chats/Message/index.vue
@@ -13,6 +13,7 @@
       'is-video': isVideo,
       'is-geo': isGeolocation,
       highlighted: highlighted,
+      'is-medias-group': hasMediasGroup,
     }"
     @mouseover="isHovering = true"
     @mouseleave="isHovering = false"
@@ -40,6 +41,7 @@
         'is-image': isImage,
         'is-video': isVideo,
         'is-geo': isGeolocation,
+        'is-medias-group': hasMediasGroup,
       }"
     >
       <UnnnicIcon
@@ -48,6 +50,12 @@
         icon="location_on"
         size="avatar-nano"
       />
+      <div
+        v-if="hasMediasGroup"
+        class="unnnic-chats-message__medias-group"
+      >
+        <slot name="medias" />
+      </div>
       <ChatsMessageText
         v-if="isText"
         :text="slotText"
@@ -241,10 +249,16 @@ export default {
     isMedia() {
       return !!this.mediaType;
     },
+    hasMediasGroup() {
+      return !!this.$slots.medias;
+    },
     isDocument() {
       return !!this.documentName;
     },
     isText() {
+      if (this.hasMediasGroup) {
+        return !!this.slotText;
+      }
       const validText = !this.isMedia || this.isGeolocation;
       return validText && !this.isDocument;
     },
@@ -349,6 +363,10 @@ $defaultLineHeight: $unnnic-font-size-body-gt + $unnnic-line-height-medium;
     }
   }
 
+  &.is-medias-group {
+    padding: $unnnic-space-2 $unnnic-space-3;
+  }
+
   &.is-media {
     padding: $unnnic-space-2;
   }
@@ -394,6 +412,13 @@ $defaultLineHeight: $unnnic-font-size-body-gt + $unnnic-line-height-medium;
         width: 300px;
         max-width: 300px;
       }
+    }
+
+    &.is-medias-group {
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
+      gap: $unnnic-space-2;
     }
 
     &.is-document {
@@ -454,6 +479,12 @@ $defaultLineHeight: $unnnic-font-size-body-gt + $unnnic-line-height-medium;
       align-items: center;
       gap: $unnnic-space-1;
     }
+  }
+
+  &__medias-group {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-2;
   }
 
   &__media__container {

--- a/src/components/chats/Message/index.vue
+++ b/src/components/chats/Message/index.vue
@@ -500,5 +500,9 @@ $defaultLineHeight: $unnnic-font-size-body-gt + $unnnic-line-height-medium;
   .geolocation-icon {
     align-self: center;
   }
+
+  &__time-container {
+    align-self: flex-end;
+  }
 }
 </style>

--- a/src/components/chats/MessageManager/TextBox/Actions/AttachAction.vue
+++ b/src/components/chats/MessageManager/TextBox/Actions/AttachAction.vue
@@ -16,6 +16,8 @@ import { storeToRefs } from 'pinia';
 import { useMessageManager } from '@/store/modules/chats/messageManager';
 import { useDiscussions } from '@/store/modules/chats/discussions';
 import { useAiTextImprovement } from '@/store/modules/chats/aiTextImprovement';
+import { useFeatureFlag } from '@/store/modules/featureFlag';
+import { useMediaMessagesWithTextFeatureFlag } from '@/composables/useMediaMessagesWithTextFeatureFlag';
 
 import ActionItem from './ActionItem.vue';
 
@@ -46,8 +48,12 @@ const {
 
 const { activeDiscussion } = storeToRefs(useDiscussions());
 const { isLoading: isAiLoading } = storeToRefs(useAiTextImprovement());
+const { featureFlags } = storeToRefs(useFeatureFlag());
 
 const isInDiscussion = computed(() => !!activeDiscussion.value?.uuid);
+const isMediaMessagesWithTextEnabled = computed(() =>
+  useMediaMessagesWithTextFeatureFlag(featureFlags.value),
+);
 
 const isValidInputMessage = computed(() =>
   isSuggestionBoxOpen.value
@@ -60,7 +66,10 @@ const isDisabled = computed(() => {
     return true;
   }
 
-  const hasBlockingInput = !isInternalNote.value && isValidInputMessage.value;
+  const hasBlockingInput =
+    !isInternalNote.value &&
+    !isMediaMessagesWithTextEnabled.value &&
+    isValidInputMessage.value;
 
   return (
     hasBlockingInput ||
@@ -71,7 +80,7 @@ const isDisabled = computed(() => {
 });
 
 function handleClick() {
-  if (isInternalNote.value) {
+  if (isInternalNote.value || isMediaMessagesWithTextEnabled.value) {
     audioMessage.value = null;
     audioRecorderStatus.value = 'idle';
   } else {

--- a/src/components/chats/MessageManager/TextBox/Actions/EmojiAction.vue
+++ b/src/components/chats/MessageManager/TextBox/Actions/EmojiAction.vue
@@ -16,6 +16,8 @@ import { storeToRefs } from 'pinia';
 
 import { useMessageManager } from '@/store/modules/chats/messageManager';
 import { useAiTextImprovement } from '@/store/modules/chats/aiTextImprovement';
+import { useFeatureFlag } from '@/store/modules/featureFlag';
+import { useMediaMessagesWithTextFeatureFlag } from '@/composables/useMediaMessagesWithTextFeatureFlag';
 
 import ActionItem from './ActionItem.vue';
 
@@ -38,6 +40,11 @@ const {
 } = storeToRefs(useMessageManager());
 
 const { isLoading: isAiLoading } = storeToRefs(useAiTextImprovement());
+const { featureFlags } = storeToRefs(useFeatureFlag());
+
+const isMediaMessagesWithTextEnabled = computed(() =>
+  useMediaMessagesWithTextFeatureFlag(featureFlags.value),
+);
 
 const isDisabled = computed(() => {
   if (isInternalNote.value) {
@@ -48,7 +55,8 @@ const isDisabled = computed(() => {
     isDictationListening.value ||
     audioRecorderStatus.value !== 'idle' ||
     !!audioMessage.value ||
-    mediaUploadFiles.value.length > 0 ||
+    (mediaUploadFiles.value.length > 0 &&
+      !isMediaMessagesWithTextEnabled.value) ||
     inputMessage.value.startsWith('/')
   );
 });

--- a/src/components/chats/MessageManager/TextBox/TextArea.vue
+++ b/src/components/chats/MessageManager/TextBox/TextArea.vue
@@ -67,6 +67,7 @@ import MessageManagerTextBoxMedias from './Medias.vue';
 import { useMessageManager } from '@/store/modules/chats/messageManager';
 import { useAiTextImprovement } from '@/store/modules/chats/aiTextImprovement';
 import { useFeatureFlag } from '@/store/modules/featureFlag';
+import { useMediaMessagesWithTextFeatureFlag } from '@/composables/useMediaMessagesWithTextFeatureFlag';
 
 import i18n from '@/plugins/i18n';
 
@@ -102,12 +103,20 @@ const MAX_TEXTAREA_ROWS = 5;
 
 const textInputRef = useTemplateRef<HTMLTextAreaElement>('textInput');
 
+const isMediaMessagesWithTextEnabled = computed(() =>
+  useMediaMessagesWithTextFeatureFlag(featureFlags.value),
+);
+
 const showTextareaInput = computed(() => {
   if (isAudioRecorderVisible.value) {
     return false;
   }
 
-  if (mediaUploadFiles.value.length > 0 && !isInternalNote.value) {
+  if (
+    mediaUploadFiles.value.length > 0 &&
+    !isInternalNote.value &&
+    !isMediaMessagesWithTextEnabled.value
+  ) {
     return false;
   }
 

--- a/src/components/chats/MessageManager/TextBox/__tests__/Actions.spec.js
+++ b/src/components/chats/MessageManager/TextBox/__tests__/Actions.spec.js
@@ -12,6 +12,7 @@ import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
 
 import Actions from '../Actions/index.vue';
+import { MEDIA_MESSAGES_WITH_TEXT_FEATURE_FLAG } from '@/composables/useMediaMessagesWithTextFeatureFlag';
 import i18n from '@/plugins/i18n';
 
 vi.mock('@/services/api/resources/chats/aiTextImprovement', () => ({
@@ -50,6 +51,7 @@ const createWrapper = (options = {}) => {
     isInternalNote = false,
     isAiLoading = false,
     audioRecorderStatus = 'idle',
+    featureFlags = { active_features: [] },
   } = options;
 
   const pinia = createTestingPinia({
@@ -67,6 +69,7 @@ const createWrapper = (options = {}) => {
       },
       aiTextImprovement: { isLoading: isAiLoading },
       discussions: { activeDiscussion },
+      featureFlag: { featureFlags },
     },
   });
   setActivePinia(pinia);
@@ -167,6 +170,19 @@ describe('Actions', () => {
       const wrapper = createWrapper({
         inputMessage: 'hello',
         isInternalNote: true,
+      });
+      const attachButton = wrapper.findAll(
+        '.text-box__actions__item button',
+      )[3];
+      expect(attachButton.attributes('data-disabled')).toBe('false');
+    });
+
+    it('should enable attach when there is text and the media with text flag is on', () => {
+      const wrapper = createWrapper({
+        inputMessage: 'hello',
+        featureFlags: {
+          active_features: [MEDIA_MESSAGES_WITH_TEXT_FEATURE_FLAG],
+        },
       });
       const attachButton = wrapper.findAll(
         '.text-box__actions__item button',

--- a/src/components/chats/MessageManager/TextBox/__tests__/TextArea.spec.js
+++ b/src/components/chats/MessageManager/TextBox/__tests__/TextArea.spec.js
@@ -13,6 +13,7 @@ import { setActivePinia } from 'pinia';
 
 import TextArea from '../TextArea.vue';
 import { useMessageManager } from '@/store/modules/chats/messageManager';
+import { MEDIA_MESSAGES_WITH_TEXT_FEATURE_FLAG } from '@/composables/useMediaMessagesWithTextFeatureFlag';
 import i18n from '@/plugins/i18n';
 
 vi.mock('@/services/api/resources/chats/aiTextImprovement', () => ({
@@ -39,6 +40,7 @@ const createWrapper = (options = {}) => {
     isAiImproving = false,
     isInternalNote = false,
     mediaUploadFiles = [],
+    featureFlags = { active_features: [] },
   } = options;
 
   const pinia = createTestingPinia({
@@ -53,6 +55,7 @@ const createWrapper = (options = {}) => {
         inputMessageFocused: false,
       },
       aiTextImprovement: { isLoading: isAiImproving },
+      featureFlag: { featureFlags },
     },
   });
   setActivePinia(pinia);
@@ -166,6 +169,16 @@ describe('TextArea', () => {
         mediaUploadFiles: [new File(['x'], 'file.png', { type: 'image/png' })],
       });
       expect(wrapper.find('[data-testid="text-area"]').exists()).toBe(false);
+    });
+
+    it('should keep textarea visible when media is attached and the feature flag is enabled', () => {
+      const wrapper = createWrapper({
+        mediaUploadFiles: [new File(['x'], 'file.png', { type: 'image/png' })],
+        featureFlags: {
+          active_features: [MEDIA_MESSAGES_WITH_TEXT_FEATURE_FLAG],
+        },
+      });
+      expect(wrapper.find('[data-testid="text-area"]').exists()).toBe(true);
     });
   });
 });

--- a/src/components/chats/chat/ChatMessages/ChatMessageInternalNote/MediaDocumentCard.vue
+++ b/src/components/chats/chat/ChatMessages/ChatMessageInternalNote/MediaDocumentCard.vue
@@ -66,7 +66,12 @@ const downloadMedia = async () => {
     const filename =
       props.media.url?.split('/').at(-1) || props.media.file?.name;
 
-    await Media.download({ media: mediaToDownload, name: filename });
+    await Media.download({
+      media: mediaToDownload,
+      name: filename,
+      mediaUuid: undefined,
+      messageUuid: undefined,
+    });
   } catch (error) {
     console.error(
       'An error occurred when trying to download the media:',

--- a/src/components/chats/chat/ChatMessages/ChatMessageInternalNote/MediaDocumentCard.vue
+++ b/src/components/chats/chat/ChatMessages/ChatMessageInternalNote/MediaDocumentCard.vue
@@ -29,8 +29,8 @@ import { computed } from 'vue';
 import Media from '@/services/api/resources/chats/media';
 import { treatedMediaName } from '@/utils/medias';
 
-interface InternalNoteMedia {
-  content_type: string;
+interface GridMedia {
+  content_type?: string;
   url?: string;
   message?: string;
   preview?: string;
@@ -40,7 +40,7 @@ interface InternalNoteMedia {
 }
 
 interface Props {
-  media: InternalNoteMedia;
+  media: GridMedia;
 }
 
 const props = defineProps<Props>();

--- a/src/components/chats/chat/ChatMessages/MediasGrid.vue
+++ b/src/components/chats/chat/ChatMessages/MediasGrid.vue
@@ -1,0 +1,347 @@
+<!-- eslint-disable vuejs-accessibility/alt-text -->
+<!-- eslint-disable vuejs-accessibility/media-has-caption -->
+<template>
+  <section
+    class="chat-messages__medias-grid"
+    data-testid="medias-grid"
+    @click.stop
+  >
+    <section
+      v-for="media in previewableMedias"
+      :key="getMediaKey(media)"
+      class="chat-messages__medias-grid__slot"
+      :class="{
+        'chat-messages__medias-grid__slot--interactive':
+          !showMediaLoading(media) && isImage(media),
+      }"
+    >
+      <Transition name="medias-grid-loading">
+        <div
+          v-if="showMediaLoading(media)"
+          class="chat-messages__medias-grid__loading"
+        >
+          <UnnnicIconLoading
+            scheme="fg-base"
+            size="lg"
+          />
+        </div>
+      </Transition>
+
+      <button
+        v-if="isImage(media)"
+        type="button"
+        class="chat-messages__medias-grid__preview-button"
+        :disabled="!getMediaSrc(media)"
+        @click="openFullscreen(media)"
+      >
+        <img
+          v-if="getMediaSrc(media)"
+          :ref="(element) => registerImage(element, media)"
+          class="chat-messages__medias-grid__preview"
+          :class="{
+            'chat-messages__medias-grid__preview--visible':
+              isMediaRendered(media),
+          }"
+          :src="getMediaSrc(media)"
+          @load="handleMediaLoad(media)"
+        />
+      </button>
+
+      <div
+        v-else-if="isVideo(media) && !isLoading(media)"
+        class="chat-messages__medias-grid__content"
+      >
+        <VideoPlayer
+          class="chat-messages__medias-grid__video media"
+          :src="getMediaSrc(media)"
+        />
+      </div>
+
+      <div
+        v-else-if="isDocument(media) && !isLoading(media)"
+        class="chat-messages__medias-grid__content"
+      >
+        <MediaDocumentCard :media="media" />
+      </div>
+    </section>
+
+    <FullscreenPreview
+      v-if="isFullscreen && currentMedia"
+      :downloadMediaUrl="getMediaSrc(currentMedia)"
+      :downloadMediaName="currentMedia.message || ''"
+      :mediaCurrent="currentMediaIndex"
+      :mediaTotal="imageMedias.length"
+      @close="closeFullscreen"
+      @next="nextMedia"
+      @previous="previousMedia"
+    >
+      <img
+        :src="getMediaSrc(currentMedia)"
+        @click.stop
+        @keypress.enter.stop
+      />
+    </FullscreenPreview>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+
+import VideoPlayer from '@/components/chats/MediaMessage/Previews/Video.vue';
+import FullscreenPreview from '@/components/chats/MediaMessage/Previews/Fullscreen.vue';
+import MediaDocumentCard from './ChatMessageInternalNote/MediaDocumentCard.vue';
+
+interface GridMedia {
+  content_type?: string;
+  url?: string;
+  message?: string;
+  preview?: string;
+  tempId?: string;
+  isLoading?: boolean;
+  file?: File | { name?: string };
+}
+
+interface Props {
+  medias: GridMedia[];
+}
+
+const props = defineProps<Props>();
+
+defineOptions({
+  name: 'ChatMessagesMediasGrid',
+});
+
+const isFullscreen = ref(false);
+const currentMedia = ref<GridMedia | null>(null);
+const renderedMediaKeys = ref<Record<string, boolean>>({});
+
+const getMediaSrc = (media?: GridMedia | null) =>
+  media?.url || media?.preview || '';
+
+const getMediaKey = (media: GridMedia) =>
+  media.tempId || media.message || media.url || media.preview;
+
+const isLoading = (media: GridMedia) =>
+  !!media.isLoading || (!getMediaSrc(media) && !!media.file);
+
+const isMediaRendered = (media: GridMedia) =>
+  !!renderedMediaKeys.value[getMediaKey(media)];
+
+const isMediaOfType = (media: GridMedia, type: string) =>
+  media?.content_type?.includes(type);
+
+const isImage = (media: GridMedia) => isMediaOfType(media, 'image');
+
+const isVideo = (media: GridMedia) =>
+  isMediaOfType(media, 'video') || isMediaOfType(media, 'mp4');
+
+const isAudio = (media: GridMedia) => isMediaOfType(media, 'audio');
+
+const isGeolocation = (media: GridMedia) => isMediaOfType(media, 'geo');
+
+const isDocument = (media: GridMedia) =>
+  !isImage(media) &&
+  !isVideo(media) &&
+  !isAudio(media) &&
+  !isGeolocation(media);
+
+const showMediaLoading = (media: GridMedia) => {
+  if (isLoading(media)) {
+    return true;
+  }
+
+  if (isImage(media) && getMediaSrc(media) && !isMediaRendered(media)) {
+    return true;
+  }
+
+  return false;
+};
+
+const handleMediaLoad = (media: GridMedia) => {
+  const key = getMediaKey(media);
+
+  if (renderedMediaKeys.value[key]) {
+    return;
+  }
+
+  renderedMediaKeys.value = {
+    ...renderedMediaKeys.value,
+    [key]: true,
+  };
+};
+
+const registerImage = (element: unknown, media: GridMedia) => {
+  if (!(element instanceof HTMLImageElement) || !element.complete) {
+    return;
+  }
+
+  handleMediaLoad(media);
+};
+
+const previewableMedias = computed(() =>
+  props.medias.filter(
+    (media) =>
+      isLoading(media) || isImage(media) || isVideo(media) || isDocument(media),
+  ),
+);
+
+const imageMedias = computed(() =>
+  props.medias.filter((media) => isImage(media) && getMediaSrc(media)),
+);
+
+const currentMediaIndex = computed(() => {
+  const currentSrc = getMediaSrc(currentMedia.value);
+  if (!currentSrc) {
+    return 0;
+  }
+
+  return (
+    imageMedias.value.findIndex((media) => getMediaSrc(media) === currentSrc) +
+    1
+  );
+});
+
+const openFullscreen = (media: GridMedia) => {
+  if (!getMediaSrc(media)) {
+    return;
+  }
+
+  currentMedia.value = media;
+  isFullscreen.value = true;
+};
+
+const closeFullscreen = () => {
+  isFullscreen.value = false;
+  currentMedia.value = null;
+};
+
+const nextMedia = () => {
+  if (!currentMedia.value) return;
+
+  const currentSrc = getMediaSrc(currentMedia.value);
+  const currentIndex = imageMedias.value.findIndex(
+    (media) => getMediaSrc(media) === currentSrc,
+  );
+
+  if (currentIndex + 1 < imageMedias.value.length) {
+    currentMedia.value = imageMedias.value[currentIndex + 1];
+  }
+};
+
+const previousMedia = () => {
+  if (!currentMedia.value) return;
+
+  const currentSrc = getMediaSrc(currentMedia.value);
+  const currentIndex = imageMedias.value.findIndex(
+    (media) => getMediaSrc(media) === currentSrc,
+  );
+
+  if (currentIndex - 1 >= 0) {
+    currentMedia.value = imageMedias.value[currentIndex - 1];
+  }
+};
+</script>
+
+<style scoped lang="scss">
+.chat-messages__medias-grid {
+  display: flex;
+  flex-direction: row;
+  gap: $unnnic-space-2;
+  flex-wrap: wrap;
+
+  &__slot {
+    position: relative;
+    width: 200px;
+    height: 200px;
+    min-width: 200px;
+    min-height: 200px;
+    flex-shrink: 0;
+    border-radius: $unnnic-radius-2;
+    overflow: hidden;
+    background-color: $unnnic-color-bg-soft;
+
+    &--interactive {
+      cursor: pointer;
+    }
+  }
+
+  &__content {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+
+    :deep(.chat-messages__internal-note-media-document-card) {
+      width: 100%;
+      height: 100%;
+    }
+  }
+
+  &__loading {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: $unnnic-color-bg-soft;
+  }
+
+  &__preview-button {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    border: none;
+    background: transparent;
+    cursor: inherit;
+
+    &:disabled {
+      cursor: default;
+      pointer-events: none;
+    }
+  }
+
+  &__preview {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    opacity: 0;
+    transition: opacity 0.25s ease;
+    pointer-events: none;
+
+    &--visible {
+      opacity: 1;
+    }
+  }
+
+  &__video {
+    width: 100%;
+    height: 100%;
+    border-radius: $unnnic-radius-2;
+    overflow: hidden;
+
+    :deep(.video-preview) {
+      width: 100%;
+      height: 100%;
+    }
+
+    :deep(.plyr) {
+      width: 100%;
+      height: 100%;
+    }
+  }
+}
+
+.medias-grid-loading-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.medias-grid-loading-leave-to {
+  opacity: 0;
+}
+</style>

--- a/src/components/chats/chat/ChatMessages/__tests__/ChatMessages.spec.js
+++ b/src/components/chats/chat/ChatMessages/__tests__/ChatMessages.spec.js
@@ -5,6 +5,8 @@ import ChatMessages from '../index.vue';
 import { useDashboard } from '@/store/modules/dashboard';
 import { useMessageManager } from '@/store/modules/chats/messageManager';
 import { useRooms } from '@/store/modules/chats/rooms';
+import { useFeatureFlag } from '@/store/modules/featureFlag';
+import { MEDIA_MESSAGES_WITH_TEXT_FEATURE_FLAG } from '@/composables/useMediaMessagesWithTextFeatureFlag';
 import moment from 'moment';
 
 // Mock components
@@ -54,6 +56,21 @@ vi.mock('./ChatMessagesFeedbackMessage.vue', () => ({
   default: {
     name: 'ChatMessagesFeedbackMessage',
     template: '<div class="mock-feedback-message">Feedback Message</div>',
+  },
+}));
+
+vi.mock('../MediasGrid.vue', () => ({
+  default: {
+    name: 'ChatMessagesMediasGrid',
+    props: ['medias'],
+    template: '<div data-testid="medias-grid" />',
+  },
+}));
+
+vi.mock('../ChatMessageAudio/ChatMessageAudio.vue', () => ({
+  default: {
+    name: 'ChatMessageAudio',
+    template: '<div data-testid="chat-message-audio" />',
   },
 }));
 
@@ -265,6 +282,66 @@ describe('ChatMessages', () => {
         Element.prototype.scrollIntoView = originalScrollIntoView;
         vi.useRealTimers();
       }
+    });
+  });
+
+  describe('combined media messages', () => {
+    const mediaMessage = {
+      uuid: 'media-1',
+      text: 'Look at this',
+      created_on: '2024-03-20T10:00:00Z',
+      user: { email: 'agent@example.com', first_name: 'Agent' },
+      media: [
+        {
+          uuid: 'm1',
+          content_type: 'image/jpeg',
+          url: 'https://example.com/1.jpg',
+        },
+        {
+          uuid: 'm2',
+          content_type: 'image/png',
+          url: 'https://example.com/2.png',
+        },
+      ],
+    };
+
+    const mediaMessageProps = {
+      messages: [mediaMessage],
+      messagesSorted: [
+        {
+          date: '2024-03-20',
+          minutes: [
+            {
+              minute: '10:00',
+              messages: [mediaMessage],
+            },
+          ],
+        },
+      ],
+    };
+
+    it('renders one bubble per media when the flag is off', async () => {
+      await wrapper.setProps(mediaMessageProps);
+      await wrapper.vm.$nextTick();
+
+      const bubbles = wrapper.findAll('[data-testid="chat-message"]');
+      expect(bubbles).toHaveLength(3);
+      expect(wrapper.find('[data-testid="medias-grid"]').exists()).toBe(false);
+    });
+
+    it('renders a single bubble with the media grid and text below when the flag is on', async () => {
+      const featureFlagStore = useFeatureFlag();
+      featureFlagStore.featureFlags = {
+        active_features: [MEDIA_MESSAGES_WITH_TEXT_FEATURE_FLAG],
+      };
+
+      await wrapper.setProps(mediaMessageProps);
+      await wrapper.vm.$nextTick();
+
+      const bubbles = wrapper.findAll('[data-testid="chat-message"]');
+      expect(bubbles).toHaveLength(1);
+      expect(wrapper.find('[data-testid="medias-grid"]').exists()).toBe(true);
+      expect(bubbles[0].text()).toContain('Look at this');
     });
   });
 });

--- a/src/components/chats/chat/ChatMessages/index.vue
+++ b/src/components/chats/chat/ChatMessages/index.vue
@@ -62,8 +62,8 @@
 
             <template v-else-if="!isInternalNoteMessage(message)">
               <ChatsMessage
-                v-if="message.text || isGeolocation(message.media?.[0])"
-                :key="message.uuid"
+                v-if="shouldRenderCombinedMediaMessage(message)"
+                :key="`combined-${message.uuid}`"
                 :ref="`message-${message.uuid}`"
                 :type="messageType(message)"
                 :class="[
@@ -76,7 +76,6 @@
                 :status="messageStatus({ message })"
                 :title="messageFormatTitle(new Date(message.created_on))"
                 :signature="messageSignature(message)"
-                :mediaType="isGeolocation(message.media?.[0]) ? 'geo' : ''"
                 :enableReply="enableReply"
                 :replyMessage="message.replied_message"
                 :automatic="
@@ -98,74 +97,18 @@
                   handlerClickReplyMessage(message.replied_message)
                 "
                 @reply="
-                  handlerMessageReply({ ...message, content_type: 'text' })
+                  handlerMessageReply({ ...message, content_type: 'media' })
                 "
-                @click="handleFailedTextClick(message)"
+                @click="handleFailedCombinedMediaClick(message)"
               >
-                {{
-                  isGeolocation(message.media?.[0])
-                    ? message.media?.[0]?.url
-                    : message.text
-                }}
-              </ChatsMessage>
-              <template v-for="media in message.media">
-                <ChatsMessage
-                  v-if="isMedia(media) && !isGeolocation(media)"
-                  :key="media.message"
-                  :ref="`message-${message.uuid}`"
-                  :type="messageType(message)"
-                  :class="[
-                    'chat-messages__message',
-                    messageType(message),
-                    { 'different-user': isMessageByTwoDifferentUsers(message) },
-                    { highlighted: highlightedMessageUuid === message.uuid },
-                  ]"
-                  :mediaType="
-                    isImage(media)
-                      ? 'image'
-                      : isVideo(media)
-                        ? 'video'
-                        : 'audio'
-                  "
-                  :time="new Date(message.created_on)"
-                  :status="messageStatus({ message })"
-                  :title="messageFormatTitle(new Date(message.created_on))"
-                  :signature="messageSignature(message)"
-                  :enableReply="enableReply"
-                  :replyMessage="message.replied_message"
-                  :highlighted="message.uuid === toScrollMessage?.uuid"
-                  data-testid="chat-message"
-                  @click-reply-message="
-                    handlerClickReplyMessage(message.replied_message)
-                  "
-                  @reply="
-                    handlerMessageReply({
-                      ...message,
-                      content_type: isImage(media)
-                        ? 'image'
-                        : isVideo(media)
-                          ? 'video'
-                          : 'audio',
-                    })
-                  "
-                  @click="
-                    resendMedia({ message, media, roomUuid: message.room })
-                  "
-                >
-                  <img
-                    v-if="isImage(media)"
-                    class="media image"
-                    :src="media.url || media.preview"
-                    @click="openFullScreen(media.url)"
-                    @keypress.enter="openFullScreen(media.url)"
-                  />
-                  <VideoPlayer
-                    v-else-if="isVideo(media)"
-                    class="media"
-                    :src="media.url || media.preview"
+                <template #medias>
+                  <ChatMessagesMediasGrid
+                    v-if="getPreviewableMedias(message).length"
+                    :medias="getPreviewableMedias(message)"
                   />
                   <ChatMessageAudio
-                    v-else-if="isAudio(media)"
+                    v-for="media in getAudioMedias(message)"
+                    :key="media.uuid || media.preview || media.url"
                     :message="message"
                     :messageStatus="messageStatus({ message, media })"
                     :isClosedChat="isClosedChat"
@@ -173,10 +116,13 @@
                       resendMedia({ message, media, roomUuid: message.room })
                     "
                   />
-                </ChatsMessage>
+                </template>
+                {{ message.text }}
+              </ChatsMessage>
+              <template v-else>
                 <ChatsMessage
-                  v-else-if="!isGeolocation(media)"
-                  :key="media.created_on"
+                  v-if="message.text || isGeolocation(message.media?.[0])"
+                  :key="message.uuid"
                   :ref="`message-${message.uuid}`"
                   :type="messageType(message)"
                   :class="[
@@ -186,29 +132,147 @@
                     { highlighted: highlightedMessageUuid === message.uuid },
                   ]"
                   :time="new Date(message.created_on)"
-                  :documentName="
-                    handleMediaName(
-                      media.url?.split('/').at(-1) || media.file?.name,
-                    )
-                  "
                   :status="messageStatus({ message })"
                   :title="messageFormatTitle(new Date(message.created_on))"
                   :signature="messageSignature(message)"
+                  :mediaType="isGeolocation(message.media?.[0]) ? 'geo' : ''"
                   :enableReply="enableReply"
                   :replyMessage="message.replied_message"
+                  :automatic="
+                    !!message.bulk_message || message.is_automatic_message
+                  "
+                  :automaticType="
+                    !!message.bulk_message
+                      ? 'bulk_message'
+                      : message.automatic_message_type || ''
+                  "
+                  :bulkMessageSender="
+                    message.bulk_message?.sent_by?.name ||
+                    message.bulk_message?.sent_by?.email
+                  "
+                  :locale="$i18n.locale"
                   data-testid="chat-message"
                   :highlighted="message.uuid === toScrollMessage?.uuid"
                   @click-reply-message="
                     handlerClickReplyMessage(message.replied_message)
                   "
                   @reply="
-                    handlerMessageReply({
-                      ...message,
-                      content_type: 'attachment',
-                    })
+                    handlerMessageReply({ ...message, content_type: 'text' })
                   "
-                  @click="documentClickHandler({ message, media })"
-                />
+                  @click="handleFailedTextClick(message)"
+                >
+                  {{
+                    isGeolocation(message.media?.[0])
+                      ? message.media?.[0]?.url
+                      : message.text
+                  }}
+                </ChatsMessage>
+                <template v-for="media in message.media">
+                  <ChatsMessage
+                    v-if="isMedia(media) && !isGeolocation(media)"
+                    :key="media.message"
+                    :ref="`message-${message.uuid}`"
+                    :type="messageType(message)"
+                    :class="[
+                      'chat-messages__message',
+                      messageType(message),
+                      {
+                        'different-user': isMessageByTwoDifferentUsers(message),
+                      },
+                      { highlighted: highlightedMessageUuid === message.uuid },
+                    ]"
+                    :mediaType="
+                      isImage(media)
+                        ? 'image'
+                        : isVideo(media)
+                          ? 'video'
+                          : 'audio'
+                    "
+                    :time="new Date(message.created_on)"
+                    :status="messageStatus({ message })"
+                    :title="messageFormatTitle(new Date(message.created_on))"
+                    :signature="messageSignature(message)"
+                    :enableReply="enableReply"
+                    :replyMessage="message.replied_message"
+                    :highlighted="message.uuid === toScrollMessage?.uuid"
+                    data-testid="chat-message"
+                    @click-reply-message="
+                      handlerClickReplyMessage(message.replied_message)
+                    "
+                    @reply="
+                      handlerMessageReply({
+                        ...message,
+                        content_type: isImage(media)
+                          ? 'image'
+                          : isVideo(media)
+                            ? 'video'
+                            : 'audio',
+                      })
+                    "
+                    @click="
+                      resendMedia({ message, media, roomUuid: message.room })
+                    "
+                  >
+                    <img
+                      v-if="isImage(media)"
+                      class="media image"
+                      :src="media.url || media.preview"
+                      @click="openFullScreen(media.url)"
+                      @keypress.enter="openFullScreen(media.url)"
+                    />
+                    <VideoPlayer
+                      v-else-if="isVideo(media)"
+                      class="media"
+                      :src="media.url || media.preview"
+                    />
+                    <ChatMessageAudio
+                      v-else-if="isAudio(media)"
+                      :message="message"
+                      :messageStatus="messageStatus({ message, media })"
+                      :isClosedChat="isClosedChat"
+                      @failed-click="
+                        resendMedia({ message, media, roomUuid: message.room })
+                      "
+                    />
+                  </ChatsMessage>
+                  <ChatsMessage
+                    v-else-if="!isGeolocation(media)"
+                    :key="media.created_on"
+                    :ref="`message-${message.uuid}`"
+                    :type="messageType(message)"
+                    :class="[
+                      'chat-messages__message',
+                      messageType(message),
+                      {
+                        'different-user': isMessageByTwoDifferentUsers(message),
+                      },
+                      { highlighted: highlightedMessageUuid === message.uuid },
+                    ]"
+                    :time="new Date(message.created_on)"
+                    :documentName="
+                      handleMediaName(
+                        media.url?.split('/').at(-1) || media.file?.name,
+                      )
+                    "
+                    :status="messageStatus({ message })"
+                    :title="messageFormatTitle(new Date(message.created_on))"
+                    :signature="messageSignature(message)"
+                    :enableReply="enableReply"
+                    :replyMessage="message.replied_message"
+                    data-testid="chat-message"
+                    :highlighted="message.uuid === toScrollMessage?.uuid"
+                    @click-reply-message="
+                      handlerClickReplyMessage(message.replied_message)
+                    "
+                    @reply="
+                      handlerMessageReply({
+                        ...message,
+                        content_type: 'attachment',
+                      })
+                    "
+                    @click="documentClickHandler({ message, media })"
+                  />
+                </template>
               </template>
             </template>
           </template>
@@ -275,6 +339,8 @@ import { useDashboard } from '@/store/modules/dashboard';
 import { useRoomMessages } from '@/store/modules/chats/roomMessages';
 import { useRooms } from '@/store/modules/chats/rooms';
 import { useMessageManager } from '@/store/modules/chats/messageManager';
+import { useFeatureFlag } from '@/store/modules/featureFlag';
+import { useMediaMessagesWithTextFeatureFlag } from '@/composables/useMediaMessagesWithTextFeatureFlag';
 
 import moment from 'moment';
 
@@ -291,6 +357,7 @@ import ChatMessagesStartFeedbacks from './ChatMessagesStartFeedbacks.vue';
 import ChatMessagesFeedbackMessage from './ChatMessagesFeedbackMessage.vue';
 import ChatMessagesInternalNote from './ChatMessageInternalNote/index.vue';
 import ChatMessageAudio from './ChatMessageAudio/ChatMessageAudio.vue';
+import ChatMessagesMediasGrid from './MediasGrid.vue';
 
 import { isString } from '@/utils/string';
 import { SEE_ALL_INTERNAL_NOTES_CHIP_CONTENT } from '@/utils/chats';
@@ -311,6 +378,7 @@ export default {
     VideoPlayer,
     ChatMessagesInternalNote,
     ChatMessageAudio,
+    ChatMessagesMediasGrid,
   },
 
   props: {
@@ -411,6 +479,7 @@ export default {
     }),
     ...mapState(useDashboard, ['viewedAgent']),
     ...mapState(useRoomMessages, ['roomMessagesNext']),
+    ...mapState(useFeatureFlag, ['featureFlags']),
     ...mapWritableState(useMessageManager, ['replyMessage', 'inputMessage']),
     ...mapWritableState(useRoomMessages, [
       'toScrollNote',
@@ -434,6 +503,9 @@ export default {
     },
     isViewMode() {
       return !!this.viewedAgent?.email;
+    },
+    isMediaMessagesWithTextEnabled() {
+      return useMediaMessagesWithTextFeatureFlag(this.featureFlags);
     },
     isSkeletonLoadingActive() {
       const { isLoading, prevChatUuid, chatUuid } = this;
@@ -557,6 +629,40 @@ export default {
     isMedia(media) {
       const { isAudio, isImage, isVideo } = this;
       return isAudio(media) || isImage(media) || isVideo(media);
+    },
+    shouldRenderCombinedMediaMessage(message) {
+      if (!this.isMediaMessagesWithTextEnabled) {
+        return false;
+      }
+
+      return (message.media || []).some(
+        (media) => media && !this.isGeolocation(media),
+      );
+    },
+    getPreviewableMedias(message) {
+      return (message.media || []).filter(
+        (media) =>
+          this.isImage(media) ||
+          this.isVideo(media) ||
+          (!this.isMedia(media) && !this.isGeolocation(media)),
+      );
+    },
+    getAudioMedias(message) {
+      return (message.media || []).filter((media) => this.isAudio(media));
+    },
+    handleFailedCombinedMediaClick(message) {
+      if (this.messageStatus({ message }) !== 'failed') {
+        return;
+      }
+
+      const firstMedia = message.media?.[0];
+      if (firstMedia) {
+        this.resendMedia({
+          message,
+          media: firstMedia,
+          roomUuid: message.room,
+        });
+      }
     },
     messageStatus({ message, media }) {
       if (message) {

--- a/src/composables/__tests__/useMediaMessagesWithTextFeatureFlag.spec.ts
+++ b/src/composables/__tests__/useMediaMessagesWithTextFeatureFlag.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MEDIA_MESSAGES_WITH_TEXT_FEATURE_FLAG,
+  useMediaMessagesWithTextFeatureFlag,
+} from '../useMediaMessagesWithTextFeatureFlag';
+
+describe('useMediaMessagesWithTextFeatureFlag', () => {
+  it('exports the media messages with text feature flag name', () => {
+    expect(MEDIA_MESSAGES_WITH_TEXT_FEATURE_FLAG).toBe(
+      'weniChatsEnableMediaMessagesWithText',
+    );
+  });
+
+  it('returns true when the flag is active', () => {
+    expect(
+      useMediaMessagesWithTextFeatureFlag({
+        active_features: ['weniChatsEnableMediaMessagesWithText'],
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when the flag is not active', () => {
+    expect(
+      useMediaMessagesWithTextFeatureFlag({
+        active_features: ['weniChatsSocketMessageSend'],
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when feature flags are missing', () => {
+    expect(useMediaMessagesWithTextFeatureFlag(null)).toBe(false);
+    expect(useMediaMessagesWithTextFeatureFlag(undefined)).toBe(false);
+    expect(useMediaMessagesWithTextFeatureFlag({})).toBe(false);
+  });
+});

--- a/src/composables/useMediaMessagesWithTextFeatureFlag.ts
+++ b/src/composables/useMediaMessagesWithTextFeatureFlag.ts
@@ -1,0 +1,14 @@
+export const MEDIA_MESSAGES_WITH_TEXT_FEATURE_FLAG =
+  'weniChatsEnableMediaMessagesWithText';
+
+type FeatureFlags = {
+  active_features?: string[];
+};
+
+export function useMediaMessagesWithTextFeatureFlag(
+  featureFlags?: FeatureFlags | null,
+): boolean {
+  return !!featureFlags?.active_features?.includes(
+    MEDIA_MESSAGES_WITH_TEXT_FEATURE_FLAG,
+  );
+}

--- a/src/services/api/resources/chats/__tests__/media.unit.spec.js
+++ b/src/services/api/resources/chats/__tests__/media.unit.spec.js
@@ -5,6 +5,10 @@ import http from '@/services/api/http';
 vi.mock('@/services/api/http', () => ({
   default: {
     get: vi.fn(),
+    postForm: vi.fn(),
+    defaults: {
+      baseURL: 'https://api.example.com/v1',
+    },
   },
 }));
 
@@ -687,6 +691,56 @@ describe('Media service', () => {
         expect(result).toBe(mockBlob);
         expect(result.type).toBe(mediaType.type);
       }
+    });
+  });
+
+  describe('uploadRoomMedia', () => {
+    it('should upload media to v2 with room, content_type and media_file', async () => {
+      const mediaFile = new File(['image'], 'photo.jpg', {
+        type: 'image/jpeg',
+      });
+      const mockResponse = {
+        data: { uuid: 'media-uuid-1', url: 'https://cdn.example.com/photo.jpg' },
+      };
+      http.postForm.mockResolvedValue(mockResponse);
+
+      const result = await mediaService.uploadRoomMedia('room-123', {
+        media: mediaFile,
+      });
+
+      expect(http.postForm).toHaveBeenCalledWith(
+        '/media/',
+        {
+          content_type: 'image/jpeg',
+          media_file: mediaFile,
+          room: 'room-123',
+        },
+        expect.objectContaining({
+          baseURL: 'https://api.example.com/v2',
+          onUploadProgress: expect.any(Function),
+        }),
+      );
+      expect(result).toEqual(mockResponse.data);
+    });
+
+    it('should report upload progress', async () => {
+      const mediaFile = new File(['image'], 'photo.jpg', {
+        type: 'image/jpeg',
+      });
+      http.postForm.mockImplementation((_url, _data, config) => {
+        config.onUploadProgress({ loaded: 50, total: 100 });
+        return Promise.resolve({ data: { uuid: 'media-uuid-2' } });
+      });
+
+      const updateLoadingFiles = vi.fn();
+      await mediaService.uploadRoomMedia('room-123', {
+        media: mediaFile,
+        updateLoadingFiles,
+        loadingKey: 'temp-1',
+      });
+
+      expect(updateLoadingFiles).toHaveBeenCalledWith('temp-1', 0);
+      expect(updateLoadingFiles).toHaveBeenCalledWith('temp-1', 0.5);
     });
   });
 });

--- a/src/services/api/resources/chats/__tests__/message.unit.spec.js
+++ b/src/services/api/resources/chats/__tests__/message.unit.spec.js
@@ -282,6 +282,53 @@ describe('Message service', () => {
       });
       expect(result).toEqual(mockResponse.data);
     });
+
+    it('should send a message with media uuids', async () => {
+      const mockResponse = {
+        data: {
+          uuid: 'msg-media-1',
+          text: 'caption',
+          media: ['uuid-2', 'uuid-1'],
+        },
+      };
+      http.post.mockResolvedValue(mockResponse);
+
+      const result = await messageService.sendRoomMessage('room-123', {
+        text: 'caption',
+        user_email: 'user@example.com',
+        seen: true,
+        media: ['uuid-2', 'uuid-1'],
+      });
+
+      expect(http.post).toHaveBeenCalledWith('/msg/', {
+        room: 'room-123',
+        text: 'caption',
+        user_email: 'user@example.com',
+        seen: true,
+        replied_message_id: undefined,
+        media: ['uuid-2', 'uuid-1'],
+      });
+      expect(result).toEqual(mockResponse.data);
+    });
+
+    it('should omit media from the payload when the array is empty', async () => {
+      http.post.mockResolvedValue({ data: { uuid: 'msg-1', text: 'Hi' } });
+
+      await messageService.sendRoomMessage('room-123', {
+        text: 'Hi',
+        user_email: 'user@example.com',
+        seen: true,
+        media: [],
+      });
+
+      expect(http.post).toHaveBeenCalledWith('/msg/', {
+        room: 'room-123',
+        text: 'Hi',
+        user_email: 'user@example.com',
+        seen: true,
+        replied_message_id: undefined,
+      });
+    });
   });
 
   describe('sendDiscussionMessage', () => {

--- a/src/services/api/resources/chats/media.js
+++ b/src/services/api/resources/chats/media.js
@@ -143,4 +143,30 @@ export default {
     };
   },
   extractCursor,
+
+  async uploadRoomMedia(
+    roomId,
+    { media, updateLoadingFiles, loadingKey } = {},
+  ) {
+    const progressKey = loadingKey || `${media.name}${Date.now()}`;
+    updateLoadingFiles?.(progressKey, 0);
+
+    const response = await http.postForm(
+      '/media/',
+      {
+        content_type: media.type,
+        media_file: media,
+        room: roomId,
+      },
+      {
+        baseURL: http.defaults.baseURL.replace('/v1', '/v2'),
+        onUploadProgress: (event) => {
+          const progress = event.loaded / event.total;
+          updateLoadingFiles?.(progressKey, progress);
+        },
+      },
+    );
+
+    return response.data;
+  },
 };

--- a/src/services/api/resources/chats/message.js
+++ b/src/services/api/resources/chats/message.js
@@ -70,7 +70,7 @@ export default {
 
   async sendRoomMessage(
     roomId,
-    { text, user_email, seen, repliedMessageId, aiTextImprovement },
+    { text, user_email, seen, repliedMessageId, aiTextImprovement, media },
   ) {
     const payload = {
       room: roomId,
@@ -82,6 +82,10 @@ export default {
 
     if (aiTextImprovement) {
       payload.ai_text_improvement = aiTextImprovement;
+    }
+
+    if (Array.isArray(media) && media.length) {
+      payload.media = media;
     }
 
     const response = await http.post('/msg/', payload);

--- a/src/services/api/websocket/__tests__/messages.unit.spec.js
+++ b/src/services/api/websocket/__tests__/messages.unit.spec.js
@@ -75,4 +75,58 @@ describe('sendRoomMessageBySocket', () => {
       text: 'Hello',
     });
   });
+
+  it('should include media in content when media uuids are provided', async () => {
+    isSocketOpen.mockReturnValue(true);
+
+    const promise = sendRoomMessageBySocket({
+      room: 'room-1',
+      text: 'Caption',
+      media: ['media-1', 'media-2'],
+      requestId: 'req-2',
+    });
+
+    expect(sendMock).toHaveBeenCalledWith({
+      type: 'method',
+      action: 'message_create',
+      content: {
+        request_id: 'req-2',
+        room: 'room-1',
+        text: 'Caption',
+        media: ['media-1', 'media-2'],
+      },
+    });
+
+    resolvePendingRequest('req-2', {
+      request_id: 'req-2',
+      uuid: 'server-uuid-2',
+      text: 'Caption',
+    });
+
+    await expect(promise).resolves.toMatchObject({
+      uuid: 'server-uuid-2',
+      text: 'Caption',
+    });
+  });
+
+  it('should omit media from content for text-only messages', async () => {
+    isSocketOpen.mockReturnValue(true);
+
+    sendRoomMessageBySocket({
+      room: 'room-1',
+      text: 'Hello',
+      requestId: 'req-3',
+    });
+
+    expect(sendMock).toHaveBeenCalledWith({
+      type: 'method',
+      action: 'message_create',
+      content: {
+        request_id: 'req-3',
+        room: 'room-1',
+        text: 'Hello',
+      },
+    });
+    expect(sendMock.mock.calls[0][0].content.media).toBeUndefined();
+  });
 });

--- a/src/services/api/websocket/messages.js
+++ b/src/services/api/websocket/messages.js
@@ -9,6 +9,7 @@ export async function sendRoomMessageBySocket({
   text,
   aiTextImprovement,
   requestId,
+  media,
 }) {
   if (!isSocketOpen()) {
     throw new SocketNotConnectedError();
@@ -26,6 +27,10 @@ export async function sendRoomMessageBySocket({
 
   if (aiTextImprovement) {
     content.ai_text_improvement = aiTextImprovement;
+  }
+
+  if (Array.isArray(media) && media.length) {
+    content.media = media;
   }
 
   getActiveConnection().ws.send({

--- a/src/store/modules/chats/__tests__/messageManager.spec.js
+++ b/src/store/modules/chats/__tests__/messageManager.spec.js
@@ -125,6 +125,25 @@ describe('useMessageManager Store', () => {
       );
     });
 
+    it('sends room medias with the trimmed caption text', () => {
+      const file = new File(['x'], 'image.png', { type: 'image/png' });
+      const { store, roomMessagesStore } = setup({
+        messageManager: {
+          mediaUploadFiles: [file],
+          inputMessage: '  look at this  ',
+        },
+      });
+
+      store.sendMediasMessage(ROOM_UUID);
+
+      expect(roomMessagesStore.sendRoomMedias).toHaveBeenCalledWith(
+        expect.objectContaining({
+          roomUuid: ROOM_UUID,
+          text: 'look at this',
+        }),
+      );
+    });
+
     it('sends discussion medias (without room uuid) when there is an active discussion', () => {
       const file = new File(['x'], 'image.png', { type: 'image/png' });
       const { store, roomMessagesStore, discussionMessagesStore } = setup({

--- a/src/store/modules/chats/__tests__/roomMessages.spec.js
+++ b/src/store/modules/chats/__tests__/roomMessages.spec.js
@@ -3,9 +3,11 @@ import { setActivePinia, createPinia } from 'pinia';
 import { useRoomMessages } from '../roomMessages';
 import { useRooms } from '../rooms';
 import Message from '@/services/api/resources/chats/message';
+import Media from '@/services/api/resources/chats/media';
 import RoomNotes from '@/services/api/resources/chats/roomNotes';
 import { useFeatureFlag } from '@/store/modules/featureFlag';
 import { sendRoomMessageBySocket } from '@/services/api/websocket/messages';
+import { MEDIA_MESSAGES_WITH_TEXT_FEATURE_FLAG } from '@/composables/useMediaMessagesWithTextFeatureFlag';
 
 vi.mock('../rooms');
 vi.mock('@/store/modules/profile', () => ({
@@ -21,6 +23,11 @@ vi.mock('@/services/api/resources/chats/message', () => ({
     getByRoom: vi.fn(),
     sendRoomMessage: vi.fn(),
     sendRoomMedia: vi.fn(),
+  },
+}));
+vi.mock('@/services/api/resources/chats/media', () => ({
+  default: {
+    uploadRoomMedia: vi.fn(),
   },
 }));
 vi.mock('@/services/api/resources/chats/roomNotes', () => ({
@@ -268,6 +275,66 @@ describe('useRoomMessages Store', () => {
     expect(
       Message.sendRoomMedia.mock.calls[0][1].createMessage,
     ).toBeUndefined();
+  });
+
+  it('should upload all medias via v2 and create one message when the media with text flag is enabled', async () => {
+    globalThis.URL.createObjectURL = vi.fn(() => 'blob:preview');
+    useFeatureFlag.mockReturnValue({
+      featureFlags: {
+        active_features: [MEDIA_MESSAGES_WITH_TEXT_FEATURE_FLAG],
+      },
+    });
+    Media.uploadRoomMedia
+      .mockResolvedValueOnce({ uuid: 'uploaded-1' })
+      .mockResolvedValueOnce({ uuid: 'uploaded-2' });
+    Message.sendRoomMessage.mockResolvedValue({
+      uuid: 'msg-1',
+      text: 'caption',
+      media: [{ uuid: 'uploaded-1' }, { uuid: 'uploaded-2' }],
+    });
+    const file1 = new File(['x'], 'image.png', { type: 'image/png' });
+    const file2 = new File(['y'], 'photo.jpg', { type: 'image/jpeg' });
+
+    await roomMessagesStore.sendRoomMedias({
+      files: [file1, file2],
+      text: 'caption',
+      updateLoadingFiles: vi.fn(),
+      repliedMessage: null,
+      roomUuid: 'room-123',
+    });
+
+    expect(Media.uploadRoomMedia).toHaveBeenCalledTimes(2);
+    expect(Message.sendRoomMessage).toHaveBeenCalledWith(
+      'room-123',
+      expect.objectContaining({
+        text: 'caption',
+        media: ['uploaded-1', 'uploaded-2'],
+      }),
+    );
+    expect(Message.sendRoomMedia).not.toHaveBeenCalled();
+  });
+
+  it('should not create a message when a v2 upload fails', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    globalThis.URL.createObjectURL = vi.fn(() => 'blob:preview');
+    useFeatureFlag.mockReturnValue({
+      featureFlags: {
+        active_features: [MEDIA_MESSAGES_WITH_TEXT_FEATURE_FLAG],
+      },
+    });
+    Media.uploadRoomMedia.mockRejectedValue(new Error('upload failed'));
+    const file = new File(['x'], 'image.png', { type: 'image/png' });
+
+    await roomMessagesStore.sendRoomMedias({
+      files: [file],
+      text: 'caption',
+      updateLoadingFiles: vi.fn(),
+      repliedMessage: null,
+      roomUuid: 'room-123',
+    });
+
+    expect(Message.sendRoomMessage).not.toHaveBeenCalled();
+    expect(Message.sendRoomMedia).not.toHaveBeenCalled();
   });
 
   it('should create media message via socket when the feature flag is enabled', async () => {

--- a/src/store/modules/chats/messageManager.ts
+++ b/src/store/modules/chats/messageManager.ts
@@ -198,18 +198,27 @@ export const useMessageManager = defineStore('messageManager', () => {
   }
 
   function sendMediasMessage(activeRoomUuid: string) {
+    const files = [...mediaUploadFiles.value];
+    const text = inputMessage.value.trim();
+    const repliedMessage = replyMessage.value;
+    const aiTextImprovementStore = useAiTextImprovement();
+    const aiTextImprovementPayload =
+      aiTextImprovementStore.getAiTextImprovementPayload(text);
+
     try {
       isLoadingSend.value = true;
       if (discussionsStore.activeDiscussion?.uuid) {
         discussionMessagesStore.sendDiscussionMedias({
-          files: [...mediaUploadFiles.value],
+          files,
           updateLoadingFiles: () => {},
         });
       } else {
         roomMessagesStore.sendRoomMedias({
-          files: [...mediaUploadFiles.value],
+          files,
+          text,
+          aiTextImprovement: aiTextImprovementPayload,
           updateLoadingFiles: () => {},
-          repliedMessage: replyMessage.value,
+          repliedMessage,
           roomUuid: activeRoomUuid,
         });
       }

--- a/src/store/modules/chats/roomMessages.js
+++ b/src/store/modules/chats/roomMessages.js
@@ -3,11 +3,13 @@ import { defineStore } from 'pinia';
 import { useRooms } from './rooms';
 
 import Message from '@/services/api/resources/chats/message';
+import Media from '@/services/api/resources/chats/media';
 import RoomNotes from '@/services/api/resources/chats/roomNotes';
 
 import { useMessageManager } from './messageManager';
 import { useFeatureFlag } from '@/store/modules/featureFlag';
 import { useSocketMessageFeatureFlag } from '@/composables/useSocketMessageFeatureFlag';
+import { useMediaMessagesWithTextFeatureFlag } from '@/composables/useMediaMessagesWithTextFeatureFlag';
 import { sendRoomMessageBySocket } from '@/services/api/websocket/messages';
 
 import {
@@ -17,6 +19,7 @@ import {
   treatMessages,
   sendMessage,
   sendMedias,
+  sendMediasWithText,
   resendMedia,
   resendMessage,
   removeFromGroupedMessages,
@@ -296,6 +299,8 @@ export const useRoomMessages = defineStore('roomMessages', {
       updateLoadingFiles,
       repliedMessage,
       roomUuid,
+      text = '',
+      aiTextImprovement = null,
     }) {
       const roomsStore = useRooms();
       const { activeRoom } = roomsStore;
@@ -305,6 +310,61 @@ export const useRoomMessages = defineStore('roomMessages', {
       const useSocket = useSocketMessageFeatureFlag(
         featureFlagStore.featureFlags,
       );
+      const useMediaWithText = useMediaMessagesWithTextFeatureFlag(
+        featureFlagStore.featureFlags,
+      );
+
+      const createMediaMessage = ({ text: messageText, media }) => {
+        if (useSocket) {
+          const requestId = crypto.randomUUID();
+          return sendRoomMessageBySocket({
+            room: roomUuid,
+            text: messageText,
+            media,
+            aiTextImprovement,
+            requestId,
+          });
+        }
+
+        return Message.sendRoomMessage(roomUuid, {
+          text: messageText,
+          user_email: activeRoom.user.email,
+          seen: true,
+          repliedMessageId: repliedMessage?.uuid,
+          aiTextImprovement,
+          media,
+        });
+      };
+
+      if (useMediaWithText) {
+        await sendMediasWithText({
+          itemType: 'room',
+          itemUuid: roomUuid,
+          itemUser: activeRoom.user,
+          medias,
+          text,
+          repliedMessage,
+          uploadItemMedia: (media, loadingKey) =>
+            Media.uploadRoomMedia(roomUuid, {
+              media,
+              updateLoadingFiles,
+              loadingKey,
+            }),
+          createItemMessage: createMediaMessage,
+          addMessage: (message) => this.handlingAddMessage({ message }),
+          addSortedMessage: (message) => this.addRoomMessageSorted({ message }),
+          addFailedMessage: (message) =>
+            this.addFailedMessage({
+              message,
+            }),
+          updateMessage: ({ message, toUpdateMessageUuid }) =>
+            this.updateMessage({
+              message,
+              toUpdateMessageUuid,
+            }),
+        });
+        return;
+      }
 
       await sendMedias({
         itemType: 'room',
@@ -540,6 +600,61 @@ export const useRoomMessages = defineStore('roomMessages', {
       const useSocket = useSocketMessageFeatureFlag(
         featureFlagStore.featureFlags,
       );
+      const useMediaWithText = useMediaMessagesWithTextFeatureFlag(
+        featureFlagStore.featureFlags,
+      );
+
+      if (useMediaWithText) {
+        if (isMessageFromCurrentUser(message)) {
+          this.removeMessageFromFaileds(message.uuid);
+          if (!this.roomMessagesSendingUuids.includes(message.uuid)) {
+            this.roomMessagesSendingUuids.push(message.uuid);
+          }
+        }
+
+        await sendMediasWithText({
+          itemType: 'room',
+          itemUuid: roomUuid,
+          itemUser: activeRoom.user,
+          medias: message.media?.length ? message.media : [media],
+          text: message.text || '',
+          repliedMessage: message.replied_message,
+          existingMessage: message,
+          uploadItemMedia: (file, loadingKey) =>
+            Media.uploadRoomMedia(roomUuid, {
+              media: file,
+              loadingKey,
+            }),
+          createItemMessage: ({ text: messageText, media: mediaUuids }) => {
+            if (useSocket) {
+              const requestId = crypto.randomUUID();
+              return sendRoomMessageBySocket({
+                room: roomUuid,
+                text: messageText,
+                media: mediaUuids,
+                requestId,
+              });
+            }
+
+            return Message.sendRoomMessage(roomUuid, {
+              text: messageText,
+              user_email: activeRoom.user.email,
+              seen: true,
+              media: mediaUuids,
+            });
+          },
+          addMessage: () => {},
+          addSortedMessage: () => {},
+          addFailedMessage: (failedMessage) =>
+            this.addFailedMessage({ message: failedMessage }),
+          updateMessage: ({ message: updatedMessage, toUpdateMessageUuid }) =>
+            this.updateMessage({
+              message: updatedMessage,
+              toUpdateMessageUuid,
+            }),
+        });
+        return;
+      }
 
       await resendMedia({
         itemUuid: roomUuid,

--- a/src/utils/__tests__/messages/sendMedias.spec.js
+++ b/src/utils/__tests__/messages/sendMedias.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { sendMedias, resendMedia } from '@/utils/messages';
+import { sendMedias, sendMediasWithText, resendMedia } from '@/utils/messages';
 import { useRooms } from '@/store/modules/chats/rooms';
 
 vi.mock('@/store/modules/profile', () => ({
@@ -160,6 +160,95 @@ describe('Messages utils', () => {
       });
 
       expect(mockAddFailedMessage).toHaveBeenCalledTimes(2);
+      expect(mockUpdateMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('sendMediasWithText', () => {
+    let mockUploadItemMedia;
+    let mockCreateItemMessage;
+    let mockAddMessage;
+    let mockAddFailedMessage;
+    let mockAddSortedMessage;
+    let mockUpdateMessage;
+
+    beforeEach(() => {
+      mockUploadItemMedia = vi.fn();
+      mockCreateItemMessage = vi.fn();
+      mockAddMessage = vi.fn();
+      mockAddFailedMessage = vi.fn();
+      mockAddSortedMessage = vi.fn();
+      mockUpdateMessage = vi.fn();
+      vi.clearAllMocks();
+      window.URL.createObjectURL = () => 'url';
+    });
+
+    it('should wait for all uploads before creating the message', async () => {
+      const media1 = new File(['content1'], 'file1.jpg', {
+        type: 'image/jpeg',
+      });
+      const media2 = new File(['content2'], 'file2.png', { type: 'image/png' });
+
+      mockUploadItemMedia
+        .mockResolvedValueOnce({ uuid: 'uploaded-1' })
+        .mockResolvedValueOnce({ uuid: 'uploaded-2' });
+      mockCreateItemMessage.mockResolvedValue({
+        uuid: 'server-msg',
+        text: 'caption',
+        media: [{ uuid: 'uploaded-1' }, { uuid: 'uploaded-2' }],
+      });
+
+      await sendMediasWithText({
+        itemType: 'room',
+        itemUuid: 'uuid1',
+        itemUser: { id: 1 },
+        medias: [media1, media2],
+        text: 'caption',
+        uploadItemMedia: mockUploadItemMedia,
+        createItemMessage: mockCreateItemMessage,
+        addMessage: mockAddMessage,
+        addFailedMessage: mockAddFailedMessage,
+        addSortedMessage: mockAddSortedMessage,
+        updateMessage: mockUpdateMessage,
+      });
+
+      expect(mockUploadItemMedia).toHaveBeenCalledTimes(2);
+      expect(mockCreateItemMessage).toHaveBeenCalledWith({
+        text: 'caption',
+        media: ['uploaded-1', 'uploaded-2'],
+      });
+      expect(mockAddFailedMessage).not.toHaveBeenCalled();
+      expect(mockUpdateMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not create the message when any upload fails', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const media1 = new File(['content1'], 'file1.jpg', {
+        type: 'image/jpeg',
+      });
+      const media2 = new File(['content2'], 'file2.png', { type: 'image/png' });
+
+      mockUploadItemMedia
+        .mockResolvedValueOnce({ uuid: 'uploaded-1' })
+        .mockRejectedValueOnce(new Error('upload failed'));
+
+      await sendMediasWithText({
+        itemType: 'room',
+        itemUuid: 'uuid1',
+        itemUser: { id: 1 },
+        medias: [media1, media2],
+        text: 'caption',
+        uploadItemMedia: mockUploadItemMedia,
+        createItemMessage: mockCreateItemMessage,
+        addMessage: mockAddMessage,
+        addFailedMessage: mockAddFailedMessage,
+        addSortedMessage: mockAddSortedMessage,
+        updateMessage: mockUpdateMessage,
+      });
+
+      expect(mockCreateItemMessage).not.toHaveBeenCalled();
+      expect(mockAddFailedMessage).toHaveBeenCalledTimes(1);
       expect(mockUpdateMessage).not.toHaveBeenCalled();
     });
   });

--- a/src/utils/messages.js
+++ b/src/utils/messages.js
@@ -313,6 +313,82 @@ export async function sendMedias({
   );
 }
 
+export async function sendMediasWithText({
+  itemType,
+  itemUuid,
+  itemUser,
+  medias,
+  text = '',
+  repliedMessage,
+  uploadItemMedia,
+  createItemMessage,
+  addMessage,
+  addFailedMessage,
+  addSortedMessage,
+  updateMessage,
+  existingMessage = null,
+}) {
+  if (!itemUuid) {
+    return;
+  }
+
+  const files = medias
+    .map((media) => (media instanceof File ? media : media?.file))
+    .filter(Boolean);
+
+  if (!files.length) {
+    return;
+  }
+
+  let temporaryMessage = existingMessage;
+
+  if (!temporaryMessage) {
+    const temporaryMedias = files.map((file) => ({
+      preview: URL.createObjectURL(file),
+      file,
+      content_type: file.type,
+    }));
+
+    temporaryMessage = createTemporaryMessage({
+      itemType,
+      itemUuid,
+      itemUser,
+      message: text,
+      repliedMessage,
+      medias: temporaryMedias,
+    });
+
+    addMessage(temporaryMessage);
+    addSortedMessage(temporaryMessage);
+  }
+
+  try {
+    const uploadedMedias = await Promise.all(
+      files.map((file) => uploadItemMedia(file, temporaryMessage.uuid)),
+    );
+
+    const mediaUuids = uploadedMedias.map(
+      (uploaded) => uploaded.uuid || uploaded.id,
+    );
+
+    const sentMessage = await createItemMessage({
+      text: text || existingMessage?.text || '',
+      media: mediaUuids,
+    });
+
+    updateMessage({
+      message: {
+        ...sentMessage,
+        media: sentMessage.media?.length ? sentMessage.media : uploadedMedias,
+      },
+      toUpdateMessageUuid: temporaryMessage.uuid,
+    });
+  } catch (error) {
+    addFailedMessage(temporaryMessage);
+    console.error('An error occurred while sending the media', error);
+  }
+}
+
 export async function resendMedia({
   itemUuid,
   sendItemMedia,


### PR DESCRIPTION
### Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Tests
- [ ] Chore
- [ ] Locales

### Why
Agents need to be able to attach media files alongside a caption text in a single message bubble, rather than having media and text sent as separate messages. This improves the chat experience and aligns with how most messaging platforms handle media with captions.

### What Changed
A new feature flag `weniChatsEnableMediaMessagesWithText` controls the behavior throughout the send and render pipeline.

**Composable & flag**
- Added `useMediaMessagesWithTextFeatureFlag` composable that reads the `weniChatsEnableMediaMessagesWithText` flag from the feature flag store.

**Message sending**
- `sendMediasWithText` utility function uploads all selected files in parallel via the new `Media.uploadRoomMedia` (v2 endpoint), collects the returned UUIDs, and creates a single message containing both the media UUIDs and the caption text.
- `Message.sendRoomMessage` and `sendRoomMessageBySocket` now accept a `media` array so the combined message can be delivered over HTTP or WebSocket.
- `messageManager.sendMediasMessage` forwards the trimmed caption text and replied-message context to `sendRoomMedias`.
- `roomMessages.sendRoomMedias` and `resendRoomMedia` branch on the flag: when enabled they call `sendMediasWithText`; otherwise they fall back to the existing per-file flow.

**Message rendering**
- `ChatMessages/index.vue` introduces `shouldRenderCombinedMediaMessage` which, when the flag is on, collapses all media for a message into a single `ChatsMessage` bubble using a new `medias` slot.
- `ChatsMessage` gains an `is-medias-group` CSS class and a `medias` named slot that renders a `MediasGrid` container above the text.
- New `MediasGrid.vue` component renders images, videos, and documents in a fixed-size grid with loading skeletons, fade-in transitions, and a fullscreen image carousel.

**Composer UI**
- `AttachAction` and `EmojiAction` no longer disable themselves when media files are already queued if the flag is active.
- `TextArea` stays visible while media is attached when the flag is active, allowing the agent to type a caption.