### PR TITLE
feat: add assistant localization for Desk Copilot

### DIFF
--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/__tests__/index.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/__tests__/index.spec.js
@@ -12,11 +12,17 @@ import { mount, config, flushPromises } from '@vue/test-utils';
 import { createTestingPinia } from '@pinia/testing';
 import DeskCopilotTab from '../index.vue';
 import { useCopilotConnection } from '@/composables/useCopilotConnection';
+import { useCopilotChat } from '@/composables/assistant/useCopilotChat';
 import { copilotSocketManager } from '@/services/copilot/copilotSocketManager';
+import { useMessageManager } from '@/store/modules/chats/messageManager';
 import i18n from '@/plugins/i18n';
 
 vi.mock('@/composables/useCopilotConnection', () => ({
   useCopilotConnection: vi.fn(),
+}));
+
+vi.mock('@/composables/assistant/useCopilotChat', () => ({
+  useCopilotChat: vi.fn(),
 }));
 
 vi.mock('@/services/copilot/copilotSocketManager', () => ({
@@ -61,6 +67,21 @@ function mockCopilotConnection({
   });
 }
 
+function mockCopilotChat({
+  messages = [],
+  isThinking = false,
+  cartCount = 0,
+  suggestions = [],
+} = {}) {
+  useCopilotChat.mockReturnValue({
+    messages: ref(messages),
+    isThinking: ref(isThinking),
+    cartCount: ref(cartCount),
+    suggestions: ref(suggestions),
+    sendMessage: vi.fn(),
+  });
+}
+
 const createWrapper = (props = {}, piniaState = {}) =>
   mount(DeskCopilotTab, {
     props,
@@ -79,6 +100,10 @@ const createWrapper = (props = {}, piniaState = {}) =>
             },
             config: {
               project: { config: { has_chats_summary: true } },
+            },
+            messageManager: {
+              inputMessage: '',
+              inputMessageFocused: false,
             },
             ...piniaState,
           },
@@ -106,6 +131,26 @@ const createWrapper = (props = {}, piniaState = {}) =>
           template: '<div data-testid="desk-copilot-disclaimer" />',
           props: ['hasSummary', 'isHistory', 'isViewMode'],
         },
+        AssistantMessageList: {
+          name: 'AssistantMessageList',
+          template:
+            '<div data-testid="assistant-message-list" @click="$emit(\'send\', \'Suggested text\')" />',
+          props: ['messages', 'isThinking'],
+        },
+        AssistantInput: {
+          name: 'AssistantInput',
+          template: '<div data-testid="assistant-input" />',
+        },
+        SuggestionChips: {
+          name: 'AssistantSuggestionChips',
+          template: '<div data-testid="assistant-suggestion-chips" />',
+          props: ['suggestions'],
+        },
+        CartBadge: {
+          name: 'AssistantCartBadge',
+          template: '<div data-testid="assistant-cart-badge" />',
+          props: ['count'],
+        },
       },
     },
   });
@@ -120,6 +165,7 @@ describe('DeskCopilotTab', () => {
 
   it('renders the summary and disclaimer when there are no connections', async () => {
     mockCopilotConnection();
+    mockCopilotChat();
     wrapper = createWrapper();
 
     await flushPromises();
@@ -133,10 +179,14 @@ describe('DeskCopilotTab', () => {
     ).toBe(true);
   });
 
-  it('hides the disclaimer when the project has copilot connections', async () => {
+  it('hides the disclaimer and shows chat UI when configured', async () => {
     mockCopilotConnection({
       isConfigured: true,
       connection: defaultConnection,
+    });
+    mockCopilotChat({
+      cartCount: 1,
+      suggestions: ['Ask about color'],
     });
     wrapper = createWrapper();
 
@@ -145,21 +195,40 @@ describe('DeskCopilotTab', () => {
     expect(
       wrapper.find('[data-testid="desk-copilot-disclaimer"]').exists(),
     ).toBe(false);
-    expect(wrapper.find('[data-testid="desk-copilot-summary"]').exists()).toBe(
+    expect(
+      wrapper.find('[data-testid="assistant-message-list"]').exists(),
+    ).toBe(true);
+    expect(wrapper.find('[data-testid="assistant-input"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="assistant-cart-badge"]').exists()).toBe(
       true,
     );
     expect(copilotSocketManager.getOrCreateService).toHaveBeenCalledWith(
       'channel-1',
       defaultConnection,
     );
-    expect(copilotSocketManager.setRoomContext).toHaveBeenCalledWith(
-      'channel-1',
-      'room-1',
-    );
+  });
+
+  it('sends the AI suggestion into the main chat input', async () => {
+    mockCopilotConnection({
+      isConfigured: true,
+      connection: defaultConnection,
+    });
+    mockCopilotChat();
+    wrapper = createWrapper();
+
+    await flushPromises();
+    await wrapper
+      .find('[data-testid="assistant-message-list"]')
+      .trigger('click');
+
+    const messageManager = useMessageManager();
+    expect(messageManager.inputMessage).toBe('Suggested text');
+    expect(messageManager.inputMessageFocused).toBe(true);
   });
 
   it('hides the summary when has_chats_summary is disabled', async () => {
     mockCopilotConnection();
+    mockCopilotChat();
     wrapper = createWrapper(
       {},
       {
@@ -181,22 +250,11 @@ describe('DeskCopilotTab', () => {
 
   it('emits loaded on mount so the contact drawer can leave the skeleton', async () => {
     mockCopilotConnection();
+    mockCopilotChat();
     wrapper = createWrapper();
 
     await flushPromises();
 
     expect(wrapper.emitted('loaded')).toBeTruthy();
-  });
-
-  it('shows the disclaimer when the connections request is not configured', async () => {
-    mockCopilotConnection({ isConfigured: false });
-    wrapper = createWrapper();
-
-    await flushPromises();
-
-    expect(
-      wrapper.find('[data-testid="desk-copilot-disclaimer"]').exists(),
-    ).toBe(true);
-    expect(copilotSocketManager.getOrCreateService).not.toHaveBeenCalled();
   });
 });

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/AiMessage.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/AiMessage.vue
@@ -1,0 +1,205 @@
+<template>
+  <section
+    class="ai-message"
+    data-testid="assistant-ai-message"
+  >
+    <UnnnicIcon
+      class="ai-message__icon"
+      icon="bi:stars"
+      size="sm"
+      scheme="fg-emphasized"
+    />
+
+    <section class="ai-message__body">
+      <p
+        v-if="leadingText"
+        class="ai-message__leading"
+        data-testid="assistant-ai-leading"
+      >
+        {{ leadingText }}
+      </p>
+
+      <section
+        v-if="suggestionText"
+        class="ai-message__suggestion"
+        data-testid="assistant-ai-suggestion"
+      >
+        <p class="ai-message__suggestion-text">{{ suggestionText }}</p>
+      </section>
+
+      <section
+        v-if="suggestionText"
+        class="ai-message__actions"
+        data-testid="assistant-ai-actions"
+      >
+        <section class="ai-message__actions-left">
+          <UnnnicButton
+            type="tertiary"
+            size="small"
+            data-testid="assistant-ai-copy"
+            @click="handleCopy"
+          >
+            {{ $t('contact_info.desk_copilot.assistant.copy_action') }}
+          </UnnnicButton>
+          <UnnnicButton
+            type="secondary"
+            size="small"
+            data-testid="assistant-ai-send"
+            @click="emit('send', suggestionText)"
+          >
+            {{ $t('contact_info.desk_copilot.assistant.send_action') }}
+          </UnnnicButton>
+        </section>
+
+        <section class="ai-message__actions-right">
+          <UnnnicToolTip
+            enabled
+            :text="$t('chats.summary.feedback.positive')"
+            side="left"
+          >
+            <UnnnicIcon
+              icon="thumb_up"
+              :filled="feedbackLiked === true"
+              size="ant"
+              clickable
+              scheme="fg-base"
+              data-testid="assistant-ai-thumb-up"
+              @click="feedbackLiked = true"
+            />
+          </UnnnicToolTip>
+          <UnnnicToolTip
+            enabled
+            :text="$t('chats.summary.feedback.negative')"
+            side="left"
+          >
+            <UnnnicIcon
+              icon="thumb_down"
+              :filled="feedbackLiked === false"
+              size="ant"
+              clickable
+              scheme="fg-base"
+              data-testid="assistant-ai-thumb-down"
+              @click="feedbackLiked = false"
+            />
+          </UnnnicToolTip>
+        </section>
+      </section>
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { UnnnicCallAlert } from '@weni/unnnic-system';
+import i18n from '@/plugins/i18n';
+
+defineOptions({
+  name: 'AssistantAiMessage',
+});
+
+const props = defineProps<{
+  text: string;
+  suggestion?: string;
+}>();
+
+const emit = defineEmits<{
+  send: [text: string];
+}>();
+
+const feedbackLiked = ref<boolean | null>(null);
+
+const leadingText = computed(() => {
+  if (props.suggestion?.trim()) {
+    return props.text.trim();
+  }
+
+  return '';
+});
+
+const suggestionText = computed(() => {
+  if (props.suggestion?.trim()) {
+    return props.suggestion.trim();
+  }
+
+  return props.text.trim();
+});
+
+async function handleCopy() {
+  if (!suggestionText.value || !navigator.clipboard) {
+    return;
+  }
+
+  try {
+    await navigator.clipboard.writeText(suggestionText.value);
+    UnnnicCallAlert({
+      props: {
+        text: i18n.global.t('contact_info.value_copied'),
+        type: 'success',
+      },
+    });
+  } catch (error) {
+    console.error('Failed to copy suggestion:', error);
+    UnnnicCallAlert({
+      props: {
+        text: i18n.global.t('contact_info.error_copying_value'),
+        type: 'error',
+      },
+    });
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.ai-message {
+  display: flex;
+  align-items: flex-start;
+  gap: $unnnic-space-2;
+  width: 100%;
+
+  &__icon {
+    flex-shrink: 0;
+  }
+
+  &__body {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-2;
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__leading {
+    font: $unnnic-font-emphasis;
+    color: $unnnic-color-fg-emphasized;
+    overflow-wrap: anywhere;
+  }
+
+  &__suggestion {
+    width: 100%;
+    padding: $unnnic-space-3 $unnnic-space-4;
+    border: 1px solid $unnnic-color-border-base;
+    border-radius: $unnnic-radius-2;
+  }
+
+  &__suggestion-text {
+    font: $unnnic-font-body;
+    color: $unnnic-color-fg-base;
+    overflow-wrap: anywhere;
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: $unnnic-space-2;
+    width: 100%;
+  }
+
+  &__actions-left,
+  &__actions-right {
+    display: flex;
+    align-items: center;
+    gap: $unnnic-space-2;
+  }
+}
+</style>

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/AssistantInput.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/AssistantInput.vue
@@ -1,0 +1,117 @@
+<template>
+  <section
+    class="assistant-input"
+    data-testid="assistant-input"
+  >
+    <textarea
+      ref="textareaRef"
+      v-model="draft"
+      class="assistant-input__textarea"
+      rows="1"
+      :placeholder="$t('contact_info.desk_copilot.assistant.input_placeholder')"
+      data-testid="assistant-input-textarea"
+      @keydown.enter.exact.prevent="handleSend"
+      @input="autoGrow"
+    />
+
+    <hr class="assistant-input__divider" />
+
+    <section class="assistant-input__actions">
+      <UnnnicButton
+        type="tertiary"
+        size="small"
+        iconCenter="attach_file_add"
+        disabled
+        data-testid="assistant-input-attach"
+      />
+      <UnnnicButton
+        type="secondary"
+        size="small"
+        iconCenter="graphic_eq"
+        disabled
+        data-testid="assistant-input-mic"
+      />
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { nextTick, onMounted, ref } from 'vue';
+
+defineOptions({
+  name: 'AssistantInput',
+});
+
+const emit = defineEmits<{
+  send: [text: string];
+}>();
+
+const draft = ref('');
+const textareaRef = ref<HTMLTextAreaElement | null>(null);
+
+function autoGrow() {
+  const el = textareaRef.value;
+  if (!el) return;
+
+  el.style.height = 'auto';
+  el.style.height = `${el.scrollHeight}px`;
+}
+
+async function handleSend() {
+  const text = draft.value.trim();
+  if (!text) return;
+
+  emit('send', text);
+  draft.value = '';
+  await nextTick();
+  autoGrow();
+}
+
+onMounted(() => {
+  autoGrow();
+});
+</script>
+
+<style lang="scss" scoped>
+.assistant-input {
+  display: flex;
+  flex-direction: column;
+  gap: $unnnic-space-2;
+  width: 100%;
+  padding: $unnnic-space-3 $unnnic-space-4;
+  border: 1px solid $unnnic-color-border-base;
+  border-radius: $unnnic-radius-2;
+  background-color: $unnnic-color-bg-base;
+  flex-shrink: 0;
+
+  &__textarea {
+    width: 100%;
+    min-height: $unnnic-space-5;
+    max-height: $unnnic-space-16;
+    resize: none;
+    border: none;
+    outline: none;
+    background: transparent;
+    font: $unnnic-font-body;
+    color: $unnnic-color-fg-base;
+
+    &::placeholder {
+      color: $unnnic-color-fg-muted;
+    }
+  }
+
+  &__divider {
+    width: 100%;
+    margin: 0;
+    border: none;
+    border-top: 1px solid $unnnic-color-border-base;
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+  }
+}
+</style>

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/AssistantMessageList.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/AssistantMessageList.vue
@@ -1,0 +1,59 @@
+<template>
+  <section
+    class="assistant-message-list"
+    data-testid="assistant-message-list"
+  >
+    <template
+      v-for="message in messages"
+      :key="message.id"
+    >
+      <HumanMessage
+        v-if="message.direction === 'human'"
+        :text="message.text"
+      />
+      <AiMessage
+        v-else
+        :text="message.text"
+        :suggestion="message.suggestion"
+        @send="emit('send', $event)"
+      />
+    </template>
+
+    <ThinkingIndicator v-if="isThinking" />
+  </section>
+</template>
+
+<script setup lang="ts">
+import type { AssistantMessage } from '@/services/assistant/types';
+import HumanMessage from './HumanMessage.vue';
+import AiMessage from './AiMessage.vue';
+import ThinkingIndicator from './ThinkingIndicator.vue';
+
+defineOptions({
+  name: 'AssistantMessageList',
+});
+
+withDefaults(
+  defineProps<{
+    messages?: AssistantMessage[];
+    isThinking?: boolean;
+  }>(),
+  {
+    messages: () => [],
+    isThinking: false,
+  },
+);
+
+const emit = defineEmits<{
+  send: [text: string];
+}>();
+</script>
+
+<style lang="scss" scoped>
+.assistant-message-list {
+  display: flex;
+  flex-direction: column;
+  gap: $unnnic-space-3;
+  width: 100%;
+}
+</style>

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/CartBadge.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/CartBadge.vue
@@ -1,0 +1,44 @@
+<template>
+  <section
+    class="cart-badge"
+    data-testid="assistant-cart-badge"
+  >
+    <UnnnicIcon
+      icon="shopping_cart"
+      size="sm"
+      scheme="neutral-white"
+    />
+    <span class="cart-badge__count">{{ count }}</span>
+  </section>
+</template>
+
+<script setup lang="ts">
+defineOptions({
+  name: 'AssistantCartBadge',
+});
+
+defineProps<{
+  count: number;
+}>();
+</script>
+
+<style lang="scss" scoped>
+.cart-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: $unnnic-space-1;
+  align-self: flex-end;
+  min-width: $unnnic-space-10;
+  height: $unnnic-space-8;
+  padding: 0 $unnnic-space-4;
+  border-radius: $unnnic-radius-2;
+  background-color: $unnnic-color-bg-accent-strong;
+  color: $unnnic-color-fg-on-primary;
+
+  &__count {
+    font: $unnnic-font-action;
+    color: $unnnic-color-fg-on-primary;
+  }
+}
+</style>

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/HumanMessage.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/HumanMessage.vue
@@ -1,0 +1,37 @@
+<template>
+  <section
+    class="human-message"
+    data-testid="assistant-human-message"
+  >
+    <p class="human-message__text">{{ text }}</p>
+  </section>
+</template>
+
+<script setup lang="ts">
+defineOptions({
+  name: 'AssistantHumanMessage',
+});
+
+defineProps<{
+  text: string;
+}>();
+</script>
+
+<style lang="scss" scoped>
+.human-message {
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+
+  &__text {
+    max-width: 100%;
+    padding: $unnnic-space-3 $unnnic-space-4;
+    border-radius: $unnnic-radius-2;
+    background-color: $unnnic-color-bg-base;
+    border: 1px solid $unnnic-color-border-base;
+    font: $unnnic-font-body;
+    color: $unnnic-color-fg-base;
+    overflow-wrap: anywhere;
+  }
+}
+</style>

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/SuggestionChips.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/SuggestionChips.vue
@@ -1,0 +1,47 @@
+<template>
+  <section
+    v-if="suggestions.length"
+    class="suggestion-chips"
+    data-testid="assistant-suggestion-chips"
+  >
+    <UnnnicChip
+      v-for="suggestion in suggestions"
+      :key="suggestion"
+      type="single"
+      isClickable
+      :text="suggestion"
+      data-testid="assistant-suggestion-chip"
+      @click="emit('select', suggestion)"
+    />
+  </section>
+</template>
+
+<script setup lang="ts">
+defineOptions({
+  name: 'AssistantSuggestionChips',
+});
+
+withDefaults(
+  defineProps<{
+    suggestions?: string[];
+  }>(),
+  {
+    suggestions: () => [],
+  },
+);
+
+const emit = defineEmits<{
+  select: [text: string];
+}>();
+</script>
+
+<style lang="scss" scoped>
+.suggestion-chips {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: $unnnic-space-2;
+  width: 100%;
+  flex-shrink: 0;
+}
+</style>

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/ThinkingIndicator.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/ThinkingIndicator.vue
@@ -1,0 +1,51 @@
+<template>
+  <section
+    class="thinking-indicator"
+    data-testid="assistant-thinking-indicator"
+  >
+    <UnnnicIcon
+      class="thinking-indicator__icon"
+      icon="progress_activity"
+      size="sm"
+      scheme="fg-emphasized"
+    />
+    <p class="thinking-indicator__text">
+      {{ $t('contact_info.desk_copilot.assistant.processing_information') }}
+    </p>
+  </section>
+</template>
+
+<script setup lang="ts">
+defineOptions({
+  name: 'AssistantThinkingIndicator',
+});
+</script>
+
+<style lang="scss" scoped>
+.thinking-indicator {
+  display: flex;
+  align-items: center;
+  gap: $unnnic-space-2;
+  width: 100%;
+
+  &__icon {
+    flex-shrink: 0;
+    animation: assistant-spin 1s linear infinite;
+  }
+
+  &__text {
+    font: $unnnic-font-emphasis;
+    color: $unnnic-color-fg-emphasized;
+  }
+}
+
+@keyframes assistant-spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/__tests__/AiMessage.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/__tests__/AiMessage.spec.js
@@ -1,0 +1,76 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import AiMessage from '../AiMessage.vue';
+
+vi.mock('@weni/unnnic-system', () => ({
+  UnnnicCallAlert: vi.fn(),
+}));
+
+const createWrapper = (props = {}) =>
+  mount(AiMessage, {
+    props: {
+      text: 'Intro text',
+      suggestion: 'Suggested reply for the customer',
+      ...props,
+    },
+    global: {
+      mocks: {
+        $t: (key) => key,
+      },
+      stubs: {
+        UnnnicIcon: true,
+        UnnnicButton: {
+          name: 'UnnnicButton',
+          template: '<button @click="$emit(\'click\')"><slot /></button>',
+        },
+        UnnnicToolTip: {
+          name: 'UnnnicToolTip',
+          template: '<div><slot /></div>',
+        },
+      },
+    },
+  });
+
+describe('AssistantAiMessage', () => {
+  let wrapper;
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  it('renders leading text and suggestion when suggestion is provided', () => {
+    wrapper = createWrapper();
+
+    expect(wrapper.find('[data-testid="assistant-ai-leading"]').text()).toBe(
+      'Intro text',
+    );
+    expect(
+      wrapper.find('[data-testid="assistant-ai-suggestion"]').text(),
+    ).toContain('Suggested reply for the customer');
+  });
+
+  it('uses text as suggestion when metadata suggestion is missing', () => {
+    wrapper = createWrapper({
+      text: 'Only text reply',
+      suggestion: undefined,
+    });
+
+    expect(wrapper.find('[data-testid="assistant-ai-leading"]').exists()).toBe(
+      false,
+    );
+    expect(
+      wrapper.find('[data-testid="assistant-ai-suggestion"]').text(),
+    ).toContain('Only text reply');
+  });
+
+  it('emits send with the suggestion text', async () => {
+    wrapper = createWrapper();
+
+    await wrapper.find('[data-testid="assistant-ai-send"]').trigger('click');
+
+    expect(wrapper.emitted('send')?.[0]).toEqual([
+      'Suggested reply for the customer',
+    ]);
+  });
+});

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/__tests__/SuggestionChips.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/__tests__/SuggestionChips.spec.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import SuggestionChips from '../SuggestionChips.vue';
+
+const createWrapper = (suggestions = ['Ask about color']) =>
+  mount(SuggestionChips, {
+    props: { suggestions },
+    global: {
+      stubs: {
+        UnnnicChip: {
+          name: 'UnnnicChip',
+          props: ['text', 'type', 'isClickable'],
+          template:
+            '<button data-testid="assistant-suggestion-chip" @click="$emit(\'click\')">{{ text }}</button>',
+        },
+      },
+    },
+  });
+
+describe('AssistantSuggestionChips', () => {
+  let wrapper;
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('does not render when there are no suggestions', () => {
+    wrapper = createWrapper([]);
+    expect(
+      wrapper.find('[data-testid="assistant-suggestion-chips"]').exists(),
+    ).toBe(false);
+  });
+
+  it('emits select when a chip is clicked', async () => {
+    wrapper = createWrapper(['Ask about color', 'Ask about size']);
+
+    await wrapper
+      .findAll('[data-testid="assistant-suggestion-chip"]')[0]
+      .trigger('click');
+
+    expect(wrapper.emitted('select')?.[0]).toEqual(['Ask about color']);
+  });
+});

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/index.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/index.vue
@@ -8,7 +8,28 @@
       data-testid="desk-copilot-chat"
     >
       <SummaryMessage v-if="enableRoomSummary" />
+
+      <template v-if="isConfigured">
+        <CartBadge
+          v-if="cartCount > 0"
+          :count="cartCount"
+        />
+
+        <AssistantMessageList
+          :messages="messages"
+          :isThinking="isThinking"
+          @send="handleSendSuggestionToInput"
+        />
+      </template>
     </section>
+
+    <template v-if="isConfigured">
+      <SuggestionChips
+        :suggestions="suggestions"
+        @select="sendMessage"
+      />
+      <AssistantInput @send="sendMessage" />
+    </template>
 
     <Disclaimer
       v-if="!isLoadingConnection && !isConfigured"
@@ -24,10 +45,16 @@ import { computed, onMounted, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 import SummaryMessage from './SummaryMessage.vue';
 import Disclaimer from './Disclaimer.vue';
+import AssistantMessageList from './assistant/AssistantMessageList.vue';
+import AssistantInput from './assistant/AssistantInput.vue';
+import SuggestionChips from './assistant/SuggestionChips.vue';
+import CartBadge from './assistant/CartBadge.vue';
+import { useCopilotChat } from '@/composables/assistant/useCopilotChat';
 import { useCopilotConnection } from '@/composables/useCopilotConnection';
 import { copilotSocketManager } from '@/services/copilot/copilotSocketManager';
 import { useConfig } from '@/store/modules/config';
 import { useRooms } from '@/store/modules/chats/rooms';
+import { useMessageManager } from '@/store/modules/chats/messageManager';
 
 defineOptions({
   name: 'DeskCopilotTab',
@@ -50,15 +77,26 @@ const emit = defineEmits<{
 
 const { project } = storeToRefs(useConfig());
 const { activeRoom } = storeToRefs(useRooms());
+const messageManagerStore = useMessageManager();
+const { inputMessage, inputMessageFocused } = storeToRefs(messageManagerStore);
+
 const {
   connection,
   isConfigured,
   isLoading: isLoadingConnection,
 } = useCopilotConnection(activeRoom);
 
+const { messages, isThinking, cartCount, suggestions, sendMessage } =
+  useCopilotChat(connection);
+
 const enableRoomSummary = computed(
   () => !!project.value?.config?.has_chats_summary,
 );
+
+function handleSendSuggestionToInput(text: string) {
+  inputMessage.value = text;
+  inputMessageFocused.value = true;
+}
 
 watch(
   [connection, () => activeRoom.value?.uuid],

--- a/src/composables/assistant/__tests__/useCopilotChat.spec.ts
+++ b/src/composables/assistant/__tests__/useCopilotChat.spec.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ref, nextTick } from 'vue';
+import { SERVICE_EVENTS } from '@weni/webchat-service';
+
+import { useCopilotChat } from '../useCopilotChat';
+import { copilotSocketManager } from '@/services/copilot/copilotSocketManager';
+import type { CopilotConnection } from '@/services/api/resources/chats/copilot';
+
+const listeners = new Map<string, Set<(..._args: unknown[]) => void>>();
+
+const serviceMock = {
+  getMessages: vi.fn(() => []),
+  sendMessage: vi.fn(),
+  on: vi.fn((event: string, cb: (..._args: unknown[]) => void) => {
+    if (!listeners.has(event)) {
+      listeners.set(event, new Set());
+    }
+    listeners.get(event)?.add(cb);
+  }),
+  off: vi.fn((event: string, cb: (..._args: unknown[]) => void) => {
+    listeners.get(event)?.delete(cb);
+  }),
+};
+
+vi.mock('@/services/copilot/copilotSocketManager', () => ({
+  copilotSocketManager: {
+    getOrCreateService: vi.fn(() => serviceMock),
+  },
+}));
+
+vi.mock('@weni/webchat-service', () => ({
+  SERVICE_EVENTS: {
+    MESSAGE_RECEIVED: 'message:received',
+    MESSAGE_SENT: 'message:sent',
+    THINKING_START: 'thinking:start',
+    THINKING_STOP: 'thinking:stop',
+    CART_UPDATED: 'cart:updated',
+  },
+}));
+
+const connectionValue: CopilotConnection = {
+  socketUrl: 'wss://example.com',
+  channelUuid: 'channel-1',
+  host: 'https://flows.weni.ai',
+  connectOn: 'mount',
+  storage: 'local',
+  callbackUrl: '',
+};
+
+function emit(event: string, payload?: unknown) {
+  listeners.get(event)?.forEach((cb) => cb(payload));
+}
+
+describe('useCopilotChat', () => {
+  beforeEach(() => {
+    listeners.clear();
+    vi.clearAllMocks();
+    serviceMock.getMessages.mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    listeners.clear();
+  });
+
+  it('subscribes to service events and maps received messages', async () => {
+    const connection = ref<CopilotConnection | undefined>(connectionValue);
+    const { messages, suggestions } = useCopilotChat(connection);
+
+    await nextTick();
+
+    expect(copilotSocketManager.getOrCreateService).toHaveBeenCalledWith(
+      'channel-1',
+      connectionValue,
+    );
+
+    emit(SERVICE_EVENTS.MESSAGE_RECEIVED, {
+      id: 'ai-1',
+      type: 'text',
+      text: 'Suggestion intro',
+      timestamp: 1,
+      direction: 'incoming',
+      status: 'delivered',
+      quick_replies: ['Ask about color'],
+    });
+
+    expect(messages.value).toHaveLength(1);
+    expect(messages.value[0].direction).toBe('ai');
+    expect(suggestions.value).toEqual(['Ask about color']);
+  });
+
+  it('updates thinking and cart count from service events', async () => {
+    const connection = ref<CopilotConnection | undefined>(connectionValue);
+    const { isThinking, cartCount } = useCopilotChat(connection);
+
+    await nextTick();
+
+    emit(SERVICE_EVENTS.THINKING_START);
+    expect(isThinking.value).toBe(true);
+
+    emit(SERVICE_EVENTS.THINKING_STOP);
+    expect(isThinking.value).toBe(false);
+
+    emit(SERVICE_EVENTS.CART_UPDATED, { count: 3 });
+    expect(cartCount.value).toBe(3);
+  });
+
+  it('sends messages through the active service', async () => {
+    const connection = ref<CopilotConnection | undefined>(connectionValue);
+    const { sendMessage } = useCopilotChat(connection);
+
+    await nextTick();
+
+    sendMessage('  Hello assistant  ');
+    expect(serviceMock.sendMessage).toHaveBeenCalledWith('Hello assistant');
+  });
+});

--- a/src/composables/assistant/useCopilotChat.ts
+++ b/src/composables/assistant/useCopilotChat.ts
@@ -1,0 +1,168 @@
+import {
+  computed,
+  getCurrentInstance,
+  onUnmounted,
+  ref,
+  watch,
+  type Ref,
+} from 'vue';
+import WeniWebchatService, {
+  SERVICE_EVENTS,
+  type Message,
+} from '@weni/webchat-service';
+
+import type { CopilotConnection } from '@/services/api/resources/chats/copilot';
+import { copilotSocketManager } from '@/services/copilot/copilotSocketManager';
+import { extractCartCount } from '@/services/assistant/cartCount';
+import { mapServiceMessage } from '@/services/assistant/messageMapper';
+import type { AssistantMessage } from '@/services/assistant/types';
+
+type ConnectionRef = Ref<CopilotConnection | undefined>;
+
+export function useCopilotChat(connection: ConnectionRef) {
+  const messages = ref<AssistantMessage[]>([]);
+  const isThinking = ref(false);
+  const cartCount = ref(0);
+
+  let activeService: WeniWebchatService | null = null;
+  let activeChannelUuid: string | null = null;
+
+  const suggestions = computed(() => {
+    const lastAiMessage = [...messages.value]
+      .reverse()
+      .find((message) => message.direction === 'ai');
+
+    return lastAiMessage?.quickReplies || [];
+  });
+
+  function syncMessagesFromService(service: WeniWebchatService) {
+    messages.value = service.getMessages().map(mapServiceMessage);
+  }
+
+  function handleMessageReceived(...args: unknown[]) {
+    const message = args[0] as Message;
+    if (!message?.id) {
+      return;
+    }
+
+    const mapped = mapServiceMessage(message);
+    const existingIndex = messages.value.findIndex(
+      (item) => item.id === mapped.id,
+    );
+
+    if (existingIndex >= 0) {
+      messages.value.splice(existingIndex, 1, mapped);
+      return;
+    }
+
+    messages.value.push(mapped);
+  }
+
+  function handleMessageSent(...args: unknown[]) {
+    handleMessageReceived(...args);
+  }
+
+  function handleThinkingStart() {
+    isThinking.value = true;
+  }
+
+  function handleThinkingStop() {
+    isThinking.value = false;
+  }
+
+  function handleCartUpdated(...args: unknown[]) {
+    cartCount.value = extractCartCount(args[0]);
+  }
+
+  function unsubscribe(service: WeniWebchatService) {
+    service.off(SERVICE_EVENTS.MESSAGE_RECEIVED, handleMessageReceived);
+    service.off(SERVICE_EVENTS.MESSAGE_SENT, handleMessageSent);
+    service.off(SERVICE_EVENTS.THINKING_START, handleThinkingStart);
+    service.off(SERVICE_EVENTS.THINKING_STOP, handleThinkingStop);
+    service.off(SERVICE_EVENTS.CART_UPDATED, handleCartUpdated);
+  }
+
+  function subscribe(service: WeniWebchatService) {
+    service.on(SERVICE_EVENTS.MESSAGE_RECEIVED, handleMessageReceived);
+    service.on(SERVICE_EVENTS.MESSAGE_SENT, handleMessageSent);
+    service.on(SERVICE_EVENTS.THINKING_START, handleThinkingStart);
+    service.on(SERVICE_EVENTS.THINKING_STOP, handleThinkingStop);
+    service.on(SERVICE_EVENTS.CART_UPDATED, handleCartUpdated);
+  }
+
+  function detachCurrentService() {
+    if (activeService) {
+      unsubscribe(activeService);
+    }
+
+    activeService = null;
+    activeChannelUuid = null;
+    messages.value = [];
+    isThinking.value = false;
+    cartCount.value = 0;
+  }
+
+  function attachService(currentConnection: CopilotConnection) {
+    const channelUuid = currentConnection.channelUuid;
+
+    if (!channelUuid) {
+      detachCurrentService();
+      return;
+    }
+
+    if (activeChannelUuid === channelUuid && activeService) {
+      return;
+    }
+
+    if (activeService) {
+      unsubscribe(activeService);
+    }
+
+    const service = copilotSocketManager.getOrCreateService(
+      channelUuid,
+      currentConnection,
+    );
+
+    activeService = service;
+    activeChannelUuid = channelUuid;
+    subscribe(service);
+    syncMessagesFromService(service);
+  }
+
+  function sendMessage(text: string) {
+    const trimmed = text.trim();
+
+    if (!trimmed || !activeService) {
+      return;
+    }
+
+    activeService.sendMessage(trimmed);
+  }
+
+  watch(
+    connection,
+    (currentConnection) => {
+      if (!currentConnection?.channelUuid) {
+        detachCurrentService();
+        return;
+      }
+
+      attachService(currentConnection);
+    },
+    { immediate: true },
+  );
+
+  if (getCurrentInstance()) {
+    onUnmounted(() => {
+      detachCurrentService();
+    });
+  }
+
+  return {
+    messages,
+    isThinking,
+    cartCount,
+    suggestions,
+    sendMessage,
+  };
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -847,6 +847,12 @@
       }
     },
     "desk_copilot": {
+      "assistant": {
+        "copy_action": "Copy",
+        "input_placeholder": "Ask the assistant",
+        "processing_information": "Processing information",
+        "send_action": "Send"
+      },
       "copy_summary": "Copy summary",
       "disclaimer": {
         "description": "Desk Copilot can help you with:",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -847,6 +847,12 @@
       }
     },
     "desk_copilot": {
+      "assistant": {
+        "copy_action": "Copiar",
+        "input_placeholder": "Pregunta al asistente",
+        "processing_information": "Procesando información",
+        "send_action": "Enviar"
+      },
       "copy_summary": "Copiar resumen",
       "disclaimer": {
         "description": "Desk Copilot puede ayudarte con:",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -847,6 +847,12 @@
       }
     },
     "desk_copilot": {
+      "assistant": {
+        "copy_action": "Copiar",
+        "input_placeholder": "Pergunte ao assistente",
+        "processing_information": "Processando informações",
+        "send_action": "Enviar"
+      },
       "copy_summary": "Copiar resumo",
       "disclaimer": {
         "description": "O Desk Copilot pode ajudar você com:",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -819,6 +819,12 @@
       }
     },
     "desk_copilot": {
+      "assistant": {
+        "copy_action": "Copiază",
+        "input_placeholder": "Întreabă asistentul",
+        "processing_information": "Se procesează informațiile",
+        "send_action": "Trimite"
+      },
       "copy_summary": "Copiază rezumatul",
       "disclaimer": {
         "description": "Desk Copilot te poate ajuta cu:",

--- a/src/services/assistant/__tests__/cartCount.spec.ts
+++ b/src/services/assistant/__tests__/cartCount.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { extractCartCount } from '../cartCount';
+
+describe('extractCartCount', () => {
+  it('returns 0 for empty payloads', () => {
+    expect(extractCartCount(null)).toBe(0);
+    expect(extractCartCount(undefined)).toBe(0);
+    expect(extractCartCount('invalid')).toBe(0);
+  });
+
+  it('accepts a numeric payload', () => {
+    expect(extractCartCount(3)).toBe(3);
+    expect(extractCartCount(-1)).toBe(0);
+  });
+
+  it('reads count from the root object', () => {
+    expect(extractCartCount({ count: 2 })).toBe(2);
+  });
+
+  it('reads items length from the root object', () => {
+    expect(extractCartCount({ items: [{ id: 1 }, { id: 2 }] })).toBe(2);
+  });
+
+  it('reads count and items from nested data', () => {
+    expect(extractCartCount({ data: { count: 4 } })).toBe(4);
+    expect(extractCartCount({ data: { items: [{ id: 1 }] } })).toBe(1);
+  });
+});

--- a/src/services/assistant/__tests__/messageMapper.spec.ts
+++ b/src/services/assistant/__tests__/messageMapper.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { mapServiceMessage } from '../messageMapper';
+import type { Message } from '@weni/webchat-service';
+
+function buildMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: 'msg-1',
+    type: 'text',
+    text: 'Hello',
+    timestamp: 1,
+    direction: 'incoming',
+    status: 'delivered',
+    ...overrides,
+  };
+}
+
+describe('mapServiceMessage', () => {
+  it('maps outgoing messages to human and incoming to ai', () => {
+    expect(
+      mapServiceMessage(buildMessage({ direction: 'outgoing' })).direction,
+    ).toBe('human');
+    expect(
+      mapServiceMessage(buildMessage({ direction: 'incoming' })).direction,
+    ).toBe('ai');
+  });
+
+  it('normalizes string quick replies', () => {
+    const mapped = mapServiceMessage(
+      buildMessage({
+        quick_replies: ['Ask about color', ' Ask about size '],
+      }),
+    );
+
+    expect(mapped.quickReplies).toEqual(['Ask about color', 'Ask about size']);
+  });
+
+  it('normalizes object quick replies with title or text', () => {
+    const mapped = mapServiceMessage(
+      buildMessage({
+        quick_replies: [
+          { title: 'Color' },
+          { text: 'Size' },
+          { title: '' },
+          '  Material  ',
+        ],
+      }),
+    );
+
+    expect(mapped.quickReplies).toEqual(['Color', 'Size', 'Material']);
+  });
+
+  it('extracts suggestion from metadata when present', () => {
+    const mapped = mapServiceMessage(
+      buildMessage({
+        text: 'Intro text',
+        metadata: { suggestion: 'Suggested reply' },
+      }),
+    );
+
+    expect(mapped.text).toBe('Intro text');
+    expect(mapped.suggestion).toBe('Suggested reply');
+  });
+});

--- a/src/services/assistant/cartCount.ts
+++ b/src/services/assistant/cartCount.ts
@@ -1,0 +1,45 @@
+type CartUpdatedPayload = {
+  count?: number;
+  data?: {
+    count?: number;
+    items?: unknown[];
+  };
+  items?: unknown[];
+};
+
+export function extractCartCount(payload: unknown): number {
+  if (payload == null) {
+    return 0;
+  }
+
+  if (typeof payload === 'number' && Number.isFinite(payload)) {
+    return Math.max(0, Math.floor(payload));
+  }
+
+  if (typeof payload !== 'object') {
+    return 0;
+  }
+
+  const cart = payload as CartUpdatedPayload;
+
+  if (typeof cart.count === 'number' && Number.isFinite(cart.count)) {
+    return Math.max(0, Math.floor(cart.count));
+  }
+
+  if (Array.isArray(cart.items)) {
+    return cart.items.length;
+  }
+
+  if (
+    typeof cart.data?.count === 'number' &&
+    Number.isFinite(cart.data.count)
+  ) {
+    return Math.max(0, Math.floor(cart.data.count));
+  }
+
+  if (Array.isArray(cart.data?.items)) {
+    return cart.data.items.length;
+  }
+
+  return 0;
+}

--- a/src/services/assistant/messageMapper.ts
+++ b/src/services/assistant/messageMapper.ts
@@ -1,0 +1,45 @@
+import type { Message } from '@weni/webchat-service';
+import type { AssistantMessage } from './types';
+
+type QuickReplyEntry = string | { title?: string; text?: string };
+
+function normalizeQuickReplies(
+  quickReplies?: Message['quick_replies'],
+): string[] {
+  if (!Array.isArray(quickReplies)) {
+    return [];
+  }
+
+  return quickReplies
+    .map((entry: QuickReplyEntry) => {
+      if (typeof entry === 'string') {
+        return entry.trim();
+      }
+
+      if (entry && typeof entry === 'object') {
+        const value = entry.title || entry.text || '';
+        return String(value).trim();
+      }
+
+      return '';
+    })
+    .filter(Boolean);
+}
+
+export function mapServiceMessage(message: Message): AssistantMessage {
+  const metadata = message.metadata || {};
+  const suggestion =
+    typeof metadata.suggestion === 'string' && metadata.suggestion.trim()
+      ? metadata.suggestion.trim()
+      : undefined;
+
+  return {
+    id: message.id,
+    direction: message.direction === 'outgoing' ? 'human' : 'ai',
+    text: message.text || '',
+    suggestion,
+    quickReplies: normalizeQuickReplies(message.quick_replies),
+    status: message.status || '',
+    timestamp: message.timestamp || Date.now(),
+  };
+}

--- a/src/services/assistant/types.ts
+++ b/src/services/assistant/types.ts
@@ -1,0 +1,13 @@
+export type AssistantDirection = 'human' | 'ai';
+
+export type AssistantMessage = {
+  id: string;
+  direction: AssistantDirection;
+  text: string;
+  suggestion?: string;
+  quickReplies: string[];
+  status: string;
+  timestamp: number;
+};
+
+export type AssistantQuickReply = string;

--- a/src/types/webchat-service.d.ts
+++ b/src/types/webchat-service.d.ts
@@ -9,11 +9,36 @@ declare module '@weni/webchat-service' {
     mode?: string;
   };
 
+  export type Message = {
+    id: string;
+    type: string;
+    text?: string;
+    timestamp: number;
+    direction: 'incoming' | 'outgoing';
+    status: string;
+    quick_replies?: Array<string | { title?: string; text?: string }>;
+    metadata?: Record<string, unknown>;
+  };
+
+  export const SERVICE_EVENTS: {
+    MESSAGE_RECEIVED: string;
+    MESSAGE_SENT: string;
+    THINKING_START: string;
+    THINKING_STOP: string;
+    CART_UPDATED: string;
+    CONNECTION_STATUS_CHANGED: string;
+    [key: string]: string;
+  };
+
   export default class WeniWebchatService {
     constructor(_config: ServiceConfig);
     init(): Promise<unknown>;
     destroy(): void;
     setContext(_context: string): void;
     getContext(): string;
+    getMessages(): Message[];
+    sendMessage(_text: string, _options?: Record<string, unknown>): void;
+    on(_event: string, _cb: (..._args: unknown[]) => void): void;
+    off(_event: string, _cb: (..._args: unknown[]) => void): void;
   }
 }


### PR DESCRIPTION
### Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Tests
- [ ] Chore
- [x] Locales

### Why
The Desk Copilot tab previously only showed a disclaimer and a chat summary. This change introduces a full conversational assistant UI so agents can interact with the AI copilot directly from the contact info panel, receive AI-generated reply suggestions, and send those suggestions into the main chat input with a single click.

### What Changed
- Added a `useCopilotChat` composable that connects to the `copilotSocketManager`, subscribes to service events (`MESSAGE_RECEIVED`, `MESSAGE_SENT`, `THINKING_START`, `THINKING_STOP`, `CART_UPDATED`), and exposes reactive `messages`, `isThinking`, `cartCount`, `suggestions`, and `sendMessage`.
- Introduced `AssistantMessage` types and two pure service utilities:
  - `messageMapper.ts` — normalises raw `WeniWebchatService` messages into `AssistantMessage` objects, handling both string and object quick-reply formats and extracting `suggestion` from message metadata.
  - `cartCount.ts` — safely extracts a cart item count from the various payload shapes the service can emit.
- Built six new assistant UI components under `DeskCopilot/assistant/`:
  - `AssistantMessageList` — renders the conversation thread and delegates `send` events upward.
  - `AiMessage` — displays an AI turn with optional leading text, a suggestion bubble, copy/send action buttons, and thumbs-up/down feedback icons.
  - `HumanMessage` — displays an agent turn aligned to the right.
  - `ThinkingIndicator` — shows a spinning icon with a "Processing information" label while the AI is responding.
  - `SuggestionChips` — renders quick-reply chips; hidden when the list is empty.
  - `CartBadge` — shows a shopping-cart icon with the current item count.
- Wired the new components into `DeskCopilot/index.vue`: when the copilot is configured, the disclaimer is replaced by the message list, input, suggestion chips, and cart badge. Clicking a suggestion or chip calls `handleSendSuggestionToInput`, which writes the text into `messageManager.inputMessage` and focuses the main chat input.
- Extended the `@weni/webchat-service` type declarations to include `Message`, `SERVICE_EVENTS`, and the `getMessages`, `sendMessage`, `on`, and `off` methods.
- Added i18n keys (`copy_action`, `send_action`, `input_placeholder`, `processing_information`) in English, Spanish, Portuguese, and Romanian.
- Added unit tests for `useCopilotChat`, `AiMessage`, `SuggestionChips`, `cartCount`, and `messageMapper`, and updated the `DeskCopilotTab` integration tests to cover the new chat UI and the suggestion-to-input flow.

### Diagram

```mermaid
flowchart TD
    A[DeskCopilotTab] -->|connection ref| B[useCopilotChat]
    B -->|getOrCreateService| C[copilotSocketManager]
    C --> D[WeniWebchatService]
    D -->|MESSAGE_RECEIVED / MESSAGE_SENT| B
    D -->|THINKING_START / THINKING_STOP| B
    D -->|CART_UPDATED| B
    B -->|messages, isThinking, cartCount, suggestions, sendMessage| A
    A --> E[AssistantMessageList]
    A --> F[AssistantInput]
    A --> G[SuggestionChips]
    A --> H[CartBadge]
    E -->|send event| A
    A -->|handleSendSuggestionToInput| I[messageManager.inputMessage]
```