### PR TITLE
feat: enhance webchat service types with session management

### DIFF
--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/__tests__/index.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/__tests__/index.spec.js
@@ -61,12 +61,14 @@ function mockCopilotConnection({
 function mockCopilotChat({
   messages = [],
   isThinking = false,
+  isLoadingHistory = false,
   cartCount = 0,
   suggestions = [],
 } = {}) {
   useCopilotChat.mockReturnValue({
     messages: ref(messages),
     isThinking: ref(isThinking),
+    isLoadingHistory: ref(isLoadingHistory),
     cartCount: ref(cartCount),
     suggestions: ref(suggestions),
     sendMessage: vi.fn(),
@@ -125,8 +127,8 @@ const createWrapper = (props = {}, piniaState = {}) =>
         AssistantMessageList: {
           name: 'AssistantMessageList',
           template:
-            '<div data-testid="assistant-message-list" @click="$emit(\'send\', \'Suggested text\')" />',
-          props: ['messages', 'isThinking'],
+            '<div data-testid="assistant-message-list" @click="$emit(\'send\', \'Suggested text\')"><div v-if="isLoadingHistory" data-testid="assistant-history-loading" /></div>',
+          props: ['messages', 'isThinking', 'isLoadingHistory'],
         },
         AssistantInput: {
           name: 'AssistantInput',
@@ -246,5 +248,20 @@ describe('DeskCopilotTab', () => {
     await flushPromises();
 
     expect(wrapper.emitted('loaded')).toBeTruthy();
+  });
+
+  it('shows the history loading state while the conversation is restored', async () => {
+    mockCopilotConnection({
+      isConfigured: true,
+      connection: defaultConnection,
+    });
+    mockCopilotChat({ isLoadingHistory: true });
+    wrapper = createWrapper();
+
+    await flushPromises();
+
+    expect(
+      wrapper.find('[data-testid="assistant-history-loading"]').exists(),
+    ).toBe(true);
   });
 });

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/__tests__/index.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/__tests__/index.spec.js
@@ -13,7 +13,6 @@ import { createTestingPinia } from '@pinia/testing';
 import DeskCopilotTab from '../index.vue';
 import { useCopilotConnection } from '@/composables/useCopilotConnection';
 import { useCopilotChat } from '@/composables/assistant/useCopilotChat';
-import { copilotSocketManager } from '@/services/copilot/copilotSocketManager';
 import { useMessageManager } from '@/store/modules/chats/messageManager';
 import i18n from '@/plugins/i18n';
 
@@ -23,14 +22,6 @@ vi.mock('@/composables/useCopilotConnection', () => ({
 
 vi.mock('@/composables/assistant/useCopilotChat', () => ({
   useCopilotChat: vi.fn(),
-}));
-
-vi.mock('@/services/copilot/copilotSocketManager', () => ({
-  copilotSocketManager: {
-    getOrCreateService: vi.fn(),
-    setRoomContext: vi.fn(),
-    disposeService: vi.fn(),
-  },
 }));
 
 beforeAll(() => {
@@ -202,10 +193,9 @@ describe('DeskCopilotTab', () => {
     expect(wrapper.find('[data-testid="assistant-cart-badge"]').exists()).toBe(
       true,
     );
-    expect(copilotSocketManager.getOrCreateService).toHaveBeenCalledWith(
-      'channel-1',
-      defaultConnection,
-    );
+    expect(useCopilotChat).toHaveBeenCalled();
+    const [, roomUuid] = useCopilotChat.mock.calls[0];
+    expect(roomUuid.value).toBe('room-1');
   });
 
   it('sends the AI suggestion into the main chat input', async () => {

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/AssistantMessageList.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/AssistantMessageList.vue
@@ -3,6 +3,25 @@
     class="assistant-message-list"
     data-testid="assistant-message-list"
   >
+    <section
+      v-if="isLoadingHistory && messages.length === 0"
+      class="assistant-message-list__loading"
+      data-testid="assistant-history-loading"
+    >
+      <UnnnicSkeletonLoading
+        v-for="index in 3"
+        :key="index"
+        class="assistant-message-list__skeleton"
+        :class="{
+          'assistant-message-list__skeleton--human': index % 2 === 1,
+        }"
+        height="40px"
+      />
+      <p class="assistant-message-list__loading-text">
+        {{ $t('contact_info.desk_copilot.assistant.loading_conversation') }}
+      </p>
+    </section>
+
     <template
       v-for="message in messages"
       :key="message.id"
@@ -37,10 +56,12 @@ withDefaults(
   defineProps<{
     messages?: AssistantMessage[];
     isThinking?: boolean;
+    isLoadingHistory?: boolean;
   }>(),
   {
     messages: () => [],
     isThinking: false,
+    isLoadingHistory: false,
   },
 );
 
@@ -55,5 +76,28 @@ const emit = defineEmits<{
   flex-direction: column;
   gap: $unnnic-space-3;
   width: 100%;
+
+  &__loading {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-3;
+    width: 100%;
+  }
+
+  &__skeleton {
+    width: 72%;
+    max-width: 100%;
+    align-self: flex-start;
+
+    &--human {
+      align-self: flex-end;
+      width: 56%;
+    }
+  }
+
+  &__loading-text {
+    font: $unnnic-font-emphasis;
+    color: $unnnic-color-fg-emphasized;
+  }
 }
 </style>

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/__tests__/AssistantMessageList.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/__tests__/AssistantMessageList.spec.js
@@ -1,0 +1,79 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import AssistantMessageList from '../AssistantMessageList.vue';
+
+const createWrapper = (props = {}) =>
+  mount(AssistantMessageList, {
+    props: {
+      messages: [],
+      ...props,
+    },
+    global: {
+      mocks: {
+        $t: (key) => key,
+      },
+      stubs: {
+        UnnnicSkeletonLoading: {
+          name: 'UnnnicSkeletonLoading',
+          template: '<div data-testid="assistant-history-skeleton" />',
+        },
+        HumanMessage: {
+          name: 'AssistantHumanMessage',
+          template: '<div data-testid="assistant-human-message" />',
+          props: ['text'],
+        },
+        AiMessage: {
+          name: 'AssistantAiMessage',
+          template: '<div data-testid="assistant-ai-message" />',
+          props: ['text', 'suggestion'],
+        },
+        ThinkingIndicator: {
+          name: 'AssistantThinkingIndicator',
+          template: '<div data-testid="assistant-thinking-indicator" />',
+        },
+      },
+    },
+  });
+
+describe('AssistantMessageList', () => {
+  let wrapper;
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  it('shows the history loading state when there are no messages yet', () => {
+    wrapper = createWrapper({ isLoadingHistory: true });
+
+    expect(
+      wrapper.find('[data-testid="assistant-history-loading"]').exists(),
+    ).toBe(true);
+    expect(wrapper.text()).toContain(
+      'contact_info.desk_copilot.assistant.loading_conversation',
+    );
+  });
+
+  it('hides the history loading state after messages arrive', () => {
+    wrapper = createWrapper({
+      isLoadingHistory: true,
+      messages: [
+        {
+          id: '1',
+          direction: 'human',
+          text: 'Hello',
+          quickReplies: [],
+          status: 'sent',
+          timestamp: 1,
+        },
+      ],
+    });
+
+    expect(
+      wrapper.find('[data-testid="assistant-history-loading"]').exists(),
+    ).toBe(false);
+    expect(
+      wrapper.find('[data-testid="assistant-human-message"]').exists(),
+    ).toBe(true);
+  });
+});

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/index.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/index.vue
@@ -41,7 +41,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, watch } from 'vue';
+import { computed, onMounted } from 'vue';
 import { storeToRefs } from 'pinia';
 import SummaryMessage from './SummaryMessage.vue';
 import Disclaimer from './Disclaimer.vue';
@@ -51,7 +51,6 @@ import SuggestionChips from './assistant/SuggestionChips.vue';
 import CartBadge from './assistant/CartBadge.vue';
 import { useCopilotChat } from '@/composables/assistant/useCopilotChat';
 import { useCopilotConnection } from '@/composables/useCopilotConnection';
-import { copilotSocketManager } from '@/services/copilot/copilotSocketManager';
 import { useConfig } from '@/store/modules/config';
 import { useRooms } from '@/store/modules/chats/rooms';
 import { useMessageManager } from '@/store/modules/chats/messageManager';
@@ -86,8 +85,9 @@ const {
   isLoading: isLoadingConnection,
 } = useCopilotConnection(activeRoom);
 
+const roomUuid = computed(() => activeRoom.value?.uuid);
 const { messages, isThinking, cartCount, suggestions, sendMessage } =
-  useCopilotChat(connection);
+  useCopilotChat(connection, roomUuid);
 
 const enableRoomSummary = computed(
   () => !!project.value?.config?.has_chats_summary,
@@ -97,28 +97,6 @@ function handleSendSuggestionToInput(text: string) {
   inputMessage.value = text;
   inputMessageFocused.value = true;
 }
-
-watch(
-  [connection, () => activeRoom.value?.uuid],
-  ([currentConnection, roomUuid]) => {
-    if (!currentConnection?.channelUuid) {
-      return;
-    }
-
-    copilotSocketManager.getOrCreateService(
-      currentConnection.channelUuid,
-      currentConnection,
-    );
-
-    if (roomUuid) {
-      copilotSocketManager.setRoomContext(
-        currentConnection.channelUuid,
-        roomUuid,
-      );
-    }
-  },
-  { immediate: true },
-);
 
 onMounted(() => {
   emit('loaded');

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/index.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/index.vue
@@ -18,6 +18,7 @@
         <AssistantMessageList
           :messages="messages"
           :isThinking="isThinking"
+          :isLoadingHistory="isLoadingHistory"
           @send="handleSendSuggestionToInput"
         />
       </template>
@@ -86,8 +87,14 @@ const {
 } = useCopilotConnection(activeRoom);
 
 const roomUuid = computed(() => activeRoom.value?.uuid);
-const { messages, isThinking, cartCount, suggestions, sendMessage } =
-  useCopilotChat(connection, roomUuid);
+const {
+  messages,
+  isThinking,
+  isLoadingHistory,
+  cartCount,
+  suggestions,
+  sendMessage,
+} = useCopilotChat(connection, roomUuid);
 
 const enableRoomSummary = computed(
   () => !!project.value?.config?.has_chats_summary,

--- a/src/composables/assistant/__tests__/useCopilotChat.spec.ts
+++ b/src/composables/assistant/__tests__/useCopilotChat.spec.ts
@@ -11,6 +11,7 @@ const listeners = new Map<string, Set<(..._args: unknown[]) => void>>();
 const serviceMock = {
   getMessages: vi.fn(() => []),
   sendMessage: vi.fn(),
+  isConnected: vi.fn(() => false),
   on: vi.fn((event: string, cb: (..._args: unknown[]) => void) => {
     if (!listeners.has(event)) {
       listeners.set(event, new Set());
@@ -36,6 +37,9 @@ vi.mock('@weni/webchat-service', () => ({
     THINKING_START: 'thinking:start',
     THINKING_STOP: 'thinking:stop',
     CART_UPDATED: 'cart:updated',
+    STATE_CHANGED: 'state:changed',
+    HISTORY_LOADED: 'history:loaded',
+    ERROR: 'error',
   },
 }));
 
@@ -57,6 +61,7 @@ describe('useCopilotChat', () => {
     listeners.clear();
     vi.clearAllMocks();
     serviceMock.getMessages.mockReturnValue([]);
+    serviceMock.isConnected.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -148,5 +153,62 @@ describe('useCopilotChat', () => {
       connectionValue,
     );
     expect(messages.value).toEqual([]);
+  });
+
+  it('syncs restored history into the visible messages', async () => {
+    const connection = ref<CopilotConnection | undefined>(connectionValue);
+    const roomUuid = ref<string | undefined>('room-1');
+    const { messages, isLoadingHistory } = useCopilotChat(connection, roomUuid);
+
+    await nextTick();
+
+    expect(isLoadingHistory.value).toBe(true);
+
+    serviceMock.getMessages.mockReturnValue([
+      {
+        id: 'ai-1',
+        type: 'text',
+        text: 'From history',
+        timestamp: 1,
+        direction: 'incoming',
+        status: 'delivered',
+      },
+    ]);
+
+    emit(SERVICE_EVENTS.STATE_CHANGED);
+
+    expect(messages.value).toHaveLength(1);
+    expect(messages.value[0].text).toBe('From history');
+    expect(isLoadingHistory.value).toBe(true);
+
+    emit(SERVICE_EVENTS.HISTORY_LOADED);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(isLoadingHistory.value).toBe(false);
+  });
+
+  it('skips the history loading state when the service is already connected', async () => {
+    serviceMock.isConnected.mockReturnValue(true);
+    serviceMock.getMessages.mockReturnValue([
+      {
+        id: 'ai-1',
+        type: 'text',
+        text: 'Already in memory',
+        timestamp: 1,
+        direction: 'incoming',
+        status: 'delivered',
+      },
+    ]);
+
+    const connection = ref<CopilotConnection | undefined>(connectionValue);
+    const roomUuid = ref<string | undefined>('room-1');
+    const { messages, isLoadingHistory } = useCopilotChat(connection, roomUuid);
+
+    await nextTick();
+
+    expect(isLoadingHistory.value).toBe(false);
+    expect(messages.value[0].text).toBe('Already in memory');
   });
 });

--- a/src/composables/assistant/__tests__/useCopilotChat.spec.ts
+++ b/src/composables/assistant/__tests__/useCopilotChat.spec.ts
@@ -25,6 +25,7 @@ const serviceMock = {
 vi.mock('@/services/copilot/copilotSocketManager', () => ({
   copilotSocketManager: {
     getOrCreateService: vi.fn(() => serviceMock),
+    scheduleEviction: vi.fn(),
   },
 }));
 
@@ -64,12 +65,13 @@ describe('useCopilotChat', () => {
 
   it('subscribes to service events and maps received messages', async () => {
     const connection = ref<CopilotConnection | undefined>(connectionValue);
-    const { messages, suggestions } = useCopilotChat(connection);
+    const roomUuid = ref<string | undefined>('room-1');
+    const { messages, suggestions } = useCopilotChat(connection, roomUuid);
 
     await nextTick();
 
     expect(copilotSocketManager.getOrCreateService).toHaveBeenCalledWith(
-      'channel-1',
+      'room-1',
       connectionValue,
     );
 
@@ -90,7 +92,8 @@ describe('useCopilotChat', () => {
 
   it('updates thinking and cart count from service events', async () => {
     const connection = ref<CopilotConnection | undefined>(connectionValue);
-    const { isThinking, cartCount } = useCopilotChat(connection);
+    const roomUuid = ref<string | undefined>('room-1');
+    const { isThinking, cartCount } = useCopilotChat(connection, roomUuid);
 
     await nextTick();
 
@@ -106,11 +109,44 @@ describe('useCopilotChat', () => {
 
   it('sends messages through the active service', async () => {
     const connection = ref<CopilotConnection | undefined>(connectionValue);
-    const { sendMessage } = useCopilotChat(connection);
+    const roomUuid = ref<string | undefined>('room-1');
+    const { sendMessage } = useCopilotChat(connection, roomUuid);
 
     await nextTick();
 
     sendMessage('  Hello assistant  ');
     expect(serviceMock.sendMessage).toHaveBeenCalledWith('Hello assistant');
+  });
+
+  it('creates a new service and resets messages when the room changes', async () => {
+    const connection = ref<CopilotConnection | undefined>(connectionValue);
+    const roomUuid = ref<string | undefined>('room-1');
+    const { messages } = useCopilotChat(connection, roomUuid);
+
+    await nextTick();
+
+    emit(SERVICE_EVENTS.MESSAGE_RECEIVED, {
+      id: 'ai-1',
+      type: 'text',
+      text: 'From room 1',
+      timestamp: 1,
+      direction: 'incoming',
+      status: 'delivered',
+    });
+
+    expect(messages.value).toHaveLength(1);
+
+    roomUuid.value = 'room-2';
+    await nextTick();
+
+    expect(copilotSocketManager.scheduleEviction).toHaveBeenCalledWith(
+      'room-1',
+      connectionValue,
+    );
+    expect(copilotSocketManager.getOrCreateService).toHaveBeenCalledWith(
+      'room-2',
+      connectionValue,
+    );
+    expect(messages.value).toEqual([]);
   });
 });

--- a/src/composables/assistant/useCopilotChat.ts
+++ b/src/composables/assistant/useCopilotChat.ts
@@ -18,14 +18,20 @@ import { mapServiceMessage } from '@/services/assistant/messageMapper';
 import type { AssistantMessage } from '@/services/assistant/types';
 
 type ConnectionRef = Ref<CopilotConnection | undefined>;
+type RoomUuidRef = Ref<string | undefined>;
 
-export function useCopilotChat(connection: ConnectionRef) {
+export function useCopilotChat(
+  connection: ConnectionRef,
+  roomUuid: RoomUuidRef,
+) {
   const messages = ref<AssistantMessage[]>([]);
   const isThinking = ref(false);
   const cartCount = ref(0);
 
   let activeService: WeniWebchatService | null = null;
   let activeChannelUuid: string | null = null;
+  let activeRoomUuid: string | null = null;
+  let activeConnection: CopilotConnection | null = null;
 
   const suggestions = computed(() => {
     const lastAiMessage = [...messages.value]
@@ -34,6 +40,12 @@ export function useCopilotChat(connection: ConnectionRef) {
 
     return lastAiMessage?.quickReplies || [];
   });
+
+  function resetViewState() {
+    messages.value = [];
+    isThinking.value = false;
+    cartCount.value = 0;
+  }
 
   function syncMessagesFromService(service: WeniWebchatService) {
     messages.value = service.getMessages().map(mapServiceMessage);
@@ -90,27 +102,37 @@ export function useCopilotChat(connection: ConnectionRef) {
     service.on(SERVICE_EVENTS.CART_UPDATED, handleCartUpdated);
   }
 
-  function detachCurrentService() {
+  function detachCurrentView() {
     if (activeService) {
       unsubscribe(activeService);
     }
 
     activeService = null;
     activeChannelUuid = null;
-    messages.value = [];
-    isThinking.value = false;
-    cartCount.value = 0;
+    activeRoomUuid = null;
+    activeConnection = null;
+    resetViewState();
   }
 
-  function attachService(currentConnection: CopilotConnection) {
-    const channelUuid = currentConnection.channelUuid;
-
-    if (!channelUuid) {
-      detachCurrentService();
+  function scheduleActiveRoomEviction() {
+    if (!activeRoomUuid || !activeConnection) {
       return;
     }
 
-    if (activeChannelUuid === channelUuid && activeService) {
+    copilotSocketManager.scheduleEviction(activeRoomUuid, activeConnection);
+  }
+
+  function attachService(
+    currentConnection: CopilotConnection,
+    currentRoomUuid: string,
+  ) {
+    const channelUuid = currentConnection.channelUuid;
+
+    if (
+      activeChannelUuid === channelUuid &&
+      activeRoomUuid === currentRoomUuid &&
+      activeService
+    ) {
       return;
     }
 
@@ -118,13 +140,17 @@ export function useCopilotChat(connection: ConnectionRef) {
       unsubscribe(activeService);
     }
 
+    resetViewState();
+
     const service = copilotSocketManager.getOrCreateService(
-      channelUuid,
+      currentRoomUuid,
       currentConnection,
     );
 
     activeService = service;
     activeChannelUuid = channelUuid;
+    activeRoomUuid = currentRoomUuid;
+    activeConnection = currentConnection;
     subscribe(service);
     syncMessagesFromService(service);
   }
@@ -140,21 +166,40 @@ export function useCopilotChat(connection: ConnectionRef) {
   }
 
   watch(
-    connection,
-    (currentConnection) => {
-      if (!currentConnection?.channelUuid) {
-        detachCurrentService();
+    [connection, roomUuid],
+    ([currentConnection, currentRoomUuid], previous) => {
+      const previousConnection = previous?.[0];
+      const previousRoomUuid = previous?.[1];
+      const isSameRoom =
+        !!currentRoomUuid &&
+        currentRoomUuid === previousRoomUuid &&
+        currentConnection?.channelUuid === previousConnection?.channelUuid;
+
+      if (isSameRoom) {
         return;
       }
 
-      attachService(currentConnection);
+      if (previousRoomUuid && previousConnection?.channelUuid) {
+        copilotSocketManager.scheduleEviction(
+          previousRoomUuid,
+          previousConnection,
+        );
+      }
+
+      if (!currentConnection?.channelUuid || !currentRoomUuid) {
+        detachCurrentView();
+        return;
+      }
+
+      attachService(currentConnection, currentRoomUuid);
     },
     { immediate: true },
   );
 
   if (getCurrentInstance()) {
     onUnmounted(() => {
-      detachCurrentService();
+      scheduleActiveRoomEviction();
+      detachCurrentView();
     });
   }
 

--- a/src/composables/assistant/useCopilotChat.ts
+++ b/src/composables/assistant/useCopilotChat.ts
@@ -27,11 +27,13 @@ export function useCopilotChat(
   const messages = ref<AssistantMessage[]>([]);
   const isThinking = ref(false);
   const cartCount = ref(0);
+  const isLoadingHistory = ref(false);
 
   let activeService: WeniWebchatService | null = null;
   let activeChannelUuid: string | null = null;
   let activeRoomUuid: string | null = null;
   let activeConnection: CopilotConnection | null = null;
+  let historyLoadedTimer: ReturnType<typeof setTimeout> | null = null;
 
   const suggestions = computed(() => {
     const lastAiMessage = [...messages.value]
@@ -45,6 +47,26 @@ export function useCopilotChat(
     messages.value = [];
     isThinking.value = false;
     cartCount.value = 0;
+    isLoadingHistory.value = false;
+  }
+
+  function clearHistoryLoadedTimer() {
+    if (!historyLoadedTimer) {
+      return;
+    }
+
+    clearTimeout(historyLoadedTimer);
+    historyLoadedTimer = null;
+  }
+
+  function finishHistoryLoading() {
+    clearHistoryLoadedTimer();
+
+    if (activeService) {
+      syncMessagesFromService(activeService);
+    }
+
+    isLoadingHistory.value = false;
   }
 
   function syncMessagesFromService(service: WeniWebchatService) {
@@ -86,12 +108,37 @@ export function useCopilotChat(
     cartCount.value = extractCartCount(args[0]);
   }
 
+  function handleStateChanged() {
+    if (!activeService || !isLoadingHistory.value) {
+      return;
+    }
+
+    syncMessagesFromService(activeService);
+  }
+
+  function handleHistoryLoaded() {
+    clearHistoryLoadedTimer();
+    // getHistory emits this before merging into state; wait a tick so messages exist.
+    historyLoadedTimer = setTimeout(() => {
+      historyLoadedTimer = null;
+      finishHistoryLoading();
+    }, 0);
+  }
+
+  function handleServiceError() {
+    finishHistoryLoading();
+  }
+
   function unsubscribe(service: WeniWebchatService) {
+    clearHistoryLoadedTimer();
     service.off(SERVICE_EVENTS.MESSAGE_RECEIVED, handleMessageReceived);
     service.off(SERVICE_EVENTS.MESSAGE_SENT, handleMessageSent);
     service.off(SERVICE_EVENTS.THINKING_START, handleThinkingStart);
     service.off(SERVICE_EVENTS.THINKING_STOP, handleThinkingStop);
     service.off(SERVICE_EVENTS.CART_UPDATED, handleCartUpdated);
+    service.off(SERVICE_EVENTS.STATE_CHANGED, handleStateChanged);
+    service.off(SERVICE_EVENTS.HISTORY_LOADED, handleHistoryLoaded);
+    service.off(SERVICE_EVENTS.ERROR, handleServiceError);
   }
 
   function subscribe(service: WeniWebchatService) {
@@ -100,6 +147,9 @@ export function useCopilotChat(
     service.on(SERVICE_EVENTS.THINKING_START, handleThinkingStart);
     service.on(SERVICE_EVENTS.THINKING_STOP, handleThinkingStop);
     service.on(SERVICE_EVENTS.CART_UPDATED, handleCartUpdated);
+    service.on(SERVICE_EVENTS.STATE_CHANGED, handleStateChanged);
+    service.on(SERVICE_EVENTS.HISTORY_LOADED, handleHistoryLoaded);
+    service.on(SERVICE_EVENTS.ERROR, handleServiceError);
   }
 
   function detachCurrentView() {
@@ -153,6 +203,7 @@ export function useCopilotChat(
     activeConnection = currentConnection;
     subscribe(service);
     syncMessagesFromService(service);
+    isLoadingHistory.value = !service.isConnected();
   }
 
   function sendMessage(text: string) {
@@ -206,6 +257,7 @@ export function useCopilotChat(
   return {
     messages,
     isThinking,
+    isLoadingHistory,
     cartCount,
     suggestions,
     sendMessage,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -850,6 +850,7 @@
       "assistant": {
         "copy_action": "Copy",
         "input_placeholder": "Ask the assistant",
+        "loading_conversation": "Loading conversation",
         "processing_information": "Processing information",
         "send_action": "Send"
       },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -850,6 +850,7 @@
       "assistant": {
         "copy_action": "Copiar",
         "input_placeholder": "Pregunta al asistente",
+        "loading_conversation": "Cargando conversación",
         "processing_information": "Procesando información",
         "send_action": "Enviar"
       },

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -850,6 +850,7 @@
       "assistant": {
         "copy_action": "Copiar",
         "input_placeholder": "Pergunte ao assistente",
+        "loading_conversation": "Carregando conversa",
         "processing_information": "Processando informações",
         "send_action": "Enviar"
       },

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -822,6 +822,7 @@
       "assistant": {
         "copy_action": "Copiază",
         "input_placeholder": "Întreabă asistentul",
+        "loading_conversation": "Se încarcă conversația",
         "processing_information": "Se procesează informațiile",
         "send_action": "Trimite"
       },

--- a/src/services/copilot/__tests__/copilotSocketManager.spec.ts
+++ b/src/services/copilot/__tests__/copilotSocketManager.spec.ts
@@ -1,14 +1,11 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import { copilotSocketManager } from '../copilotSocketManager';
 
-const { init, destroy, setContext } = vi.hoisted(() => ({
-  init: vi.fn().mockResolvedValue(undefined),
-  destroy: vi.fn(),
-  setContext: vi.fn(),
-}));
-
-vi.mock('@weni/webchat-service', () => {
+const { init, destroy, setContext, MockService } = vi.hoisted(() => {
+  const init = vi.fn().mockResolvedValue(undefined);
+  const destroy = vi.fn();
+  const setContext = vi.fn();
   const MockService = vi.fn().mockImplementation((config) => ({
     config,
     init,
@@ -16,8 +13,12 @@ vi.mock('@weni/webchat-service', () => {
     setContext,
   }));
 
-  return { default: MockService };
+  return { init, destroy, setContext, MockService };
 });
+
+vi.mock('@weni/webchat-service', () => ({
+  default: MockService,
+}));
 
 const connection = {
   socketUrl: 'wss://websocket.weni.ai',
@@ -34,22 +35,29 @@ describe('copilotSocketManager', () => {
     vi.clearAllMocks();
   });
 
-  it('creates and initializes a service per channel uuid', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('creates a service keyed by room and channel with a room sessionId', () => {
     const service = copilotSocketManager.getOrCreateService(
-      'channel-1',
+      'room-1',
       connection,
     );
 
     expect(service).toBeDefined();
     expect(init).toHaveBeenCalledTimes(1);
+    expect(MockService).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelUuid: 'channel-1',
+        sessionId: 'room-1',
+      }),
+    );
   });
 
-  it('reuses the same service instance for the same channel uuid', () => {
-    const first = copilotSocketManager.getOrCreateService(
-      'channel-1',
-      connection,
-    );
-    const second = copilotSocketManager.getOrCreateService('channel-1', {
+  it('reuses the same service instance for the same room and channel', () => {
+    const first = copilotSocketManager.getOrCreateService('room-1', connection);
+    const second = copilotSocketManager.getOrCreateService('room-1', {
       ...connection,
       host: 'https://other.weni.ai',
     });
@@ -58,39 +66,41 @@ describe('copilotSocketManager', () => {
     expect(init).toHaveBeenCalledTimes(1);
   });
 
-  it('creates a different instance for another channel uuid', () => {
-    const first = copilotSocketManager.getOrCreateService(
-      'channel-1',
+  it('creates a different instance per room even on the same channel', () => {
+    const first = copilotSocketManager.getOrCreateService('room-1', connection);
+    const second = copilotSocketManager.getOrCreateService(
+      'room-2',
       connection,
     );
-    const second = copilotSocketManager.getOrCreateService('channel-2', {
-      ...connection,
-      channelUuid: 'channel-2',
-    });
 
     expect(second).not.toBe(first);
     expect(init).toHaveBeenCalledTimes(2);
+    expect(MockService).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ sessionId: 'room-1' }),
+    );
+    expect(MockService).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ sessionId: 'room-2' }),
+    );
   });
 
   it('sets the room context on an existing service', () => {
-    copilotSocketManager.getOrCreateService('channel-1', connection);
-    copilotSocketManager.setRoomContext('channel-1', 'room-uuid');
+    copilotSocketManager.getOrCreateService('room-1', connection);
+    copilotSocketManager.setRoomContext('room-1', connection, 'room-1');
 
-    expect(setContext).toHaveBeenCalledWith('room-uuid');
+    expect(setContext).toHaveBeenCalledWith('room-1');
   });
 
   it('destroys and removes a service', () => {
-    const first = copilotSocketManager.getOrCreateService(
-      'channel-1',
-      connection,
-    );
+    const first = copilotSocketManager.getOrCreateService('room-1', connection);
 
-    copilotSocketManager.disposeService('channel-1');
+    copilotSocketManager.disposeService('room-1', connection);
 
     expect(destroy).toHaveBeenCalledTimes(1);
 
     const second = copilotSocketManager.getOrCreateService(
-      'channel-1',
+      'room-1',
       connection,
     );
 
@@ -105,7 +115,7 @@ describe('copilotSocketManager', () => {
     init.mockRejectedValueOnce(new Error('init failed'));
 
     const failed = copilotSocketManager.getOrCreateService(
-      'channel-1',
+      'room-1',
       connection,
     );
 
@@ -115,7 +125,7 @@ describe('copilotSocketManager', () => {
     expect(consoleError).toHaveBeenCalled();
 
     const recreated = copilotSocketManager.getOrCreateService(
-      'channel-1',
+      'room-1',
       connection,
     );
 
@@ -123,5 +133,56 @@ describe('copilotSocketManager', () => {
     expect(init).toHaveBeenCalledTimes(2);
 
     consoleError.mockRestore();
+  });
+
+  it('disposes an idle service after the eviction timeout', () => {
+    vi.useFakeTimers();
+
+    copilotSocketManager.getOrCreateService('room-1', connection);
+    copilotSocketManager.scheduleEviction('room-1', connection, 120000);
+
+    vi.advanceTimersByTime(119999);
+    expect(destroy).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(destroy).toHaveBeenCalledTimes(1);
+
+    const recreated = copilotSocketManager.getOrCreateService(
+      'room-1',
+      connection,
+    );
+
+    expect(recreated).toBeDefined();
+    expect(init).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears pending eviction timers on reset', () => {
+    vi.useFakeTimers();
+
+    copilotSocketManager.getOrCreateService('room-1', connection);
+    copilotSocketManager.scheduleEviction('room-1', connection, 120000);
+    copilotSocketManager.reset();
+
+    expect(destroy).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(120000);
+    expect(destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels eviction when the room becomes active again', () => {
+    vi.useFakeTimers();
+
+    const first = copilotSocketManager.getOrCreateService('room-1', connection);
+    copilotSocketManager.scheduleEviction('room-1', connection, 120000);
+
+    const resumed = copilotSocketManager.getOrCreateService(
+      'room-1',
+      connection,
+    );
+
+    expect(resumed).toBe(first);
+
+    vi.advanceTimersByTime(120000);
+    expect(destroy).not.toHaveBeenCalled();
   });
 });

--- a/src/services/copilot/__tests__/copilotSocketManager.spec.ts
+++ b/src/services/copilot/__tests__/copilotSocketManager.spec.ts
@@ -2,18 +2,23 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import { copilotSocketManager } from '../copilotSocketManager';
 
-const { init, destroy, setContext, MockService } = vi.hoisted(() => {
+const { init, destroy, setContext, connect, MockService } = vi.hoisted(() => {
   const init = vi.fn().mockResolvedValue(undefined);
   const destroy = vi.fn();
   const setContext = vi.fn();
+  const connect = vi.fn().mockResolvedValue(undefined);
   const MockService = vi.fn().mockImplementation((config) => ({
     config,
+    session: { sessionKey: 'weni:webchat:session' },
     init,
     destroy,
     setContext,
+    connect,
+    isConnected: vi.fn(() => true),
+    isConnecting: vi.fn(() => false),
   }));
 
-  return { init, destroy, setContext, MockService };
+  return { init, destroy, setContext, connect, MockService };
 });
 
 vi.mock('@weni/webchat-service', () => ({
@@ -53,6 +58,7 @@ describe('copilotSocketManager', () => {
         sessionId: 'room-1',
       }),
     );
+    expect(service.session.sessionKey).toBe('session:channel-1:room-1');
   });
 
   it('reuses the same service instance for the same room and channel', () => {
@@ -83,6 +89,8 @@ describe('copilotSocketManager', () => {
       2,
       expect.objectContaining({ sessionId: 'room-2' }),
     );
+    expect(first.session.sessionKey).toBe('session:channel-1:room-1');
+    expect(second.session.sessionKey).toBe('session:channel-1:room-2');
   });
 
   it('sets the room context on an existing service', () => {
@@ -167,6 +175,34 @@ describe('copilotSocketManager', () => {
 
     vi.advanceTimersByTime(120000);
     expect(destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('reconnects an existing service that was closed', () => {
+    const first = copilotSocketManager.getOrCreateService('room-1', connection);
+    const firstMock = first as typeof first & {
+      isConnected: ReturnType<typeof vi.fn>;
+      isConnecting: ReturnType<typeof vi.fn>;
+    };
+
+    firstMock.isConnected.mockReturnValue(false);
+    firstMock.isConnecting.mockReturnValue(false);
+
+    const resumed = copilotSocketManager.getOrCreateService(
+      'room-1',
+      connection,
+    );
+
+    expect(resumed).toBe(first);
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(init).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reconnect an existing service that is already connected', () => {
+    copilotSocketManager.getOrCreateService('room-1', connection);
+    copilotSocketManager.getOrCreateService('room-1', connection);
+
+    expect(connect).not.toHaveBeenCalled();
+    expect(init).toHaveBeenCalledTimes(1);
   });
 
   it('cancels eviction when the room becomes active again', () => {

--- a/src/services/copilot/copilotSocketManager.ts
+++ b/src/services/copilot/copilotSocketManager.ts
@@ -21,11 +21,36 @@ function getIdleTimeoutMs() {
   return DEFAULT_IDLE_TIMEOUT_MS;
 }
 
+function isolateSessionStorage(
+  service: WeniWebchatService,
+  connection: CopilotConnection,
+  roomUuid: string,
+) {
+  if (!service.session) {
+    return;
+  }
+
+  // webchat-service restores from a single shared key (`weni:webchat:session`)
+  // and ignores `sessionId` when that restore succeeds. Namespace it per room
+  // so concurrent instances do not register with the same `from` id.
+  service.session.sessionKey = `session:${connection.channelUuid}:${roomUuid}`;
+}
+
+function ensureConnected(service: WeniWebchatService, key: string) {
+  if (service.isConnected() || service.isConnecting()) {
+    return;
+  }
+
+  service.connect().catch((error) => {
+    console.error(`Failed to reconnect copilot service for ${key}:`, error);
+  });
+}
+
 function createService(
   connection: CopilotConnection,
   roomUuid: string,
 ): WeniWebchatService {
-  return new WeniWebchatService({
+  const service = new WeniWebchatService({
     socketUrl: connection.socketUrl,
     channelUuid: connection.channelUuid,
     host: connection.host,
@@ -35,6 +60,10 @@ function createService(
     mode: 'live',
     sessionId: roomUuid,
   });
+
+  isolateSessionStorage(service, connection, roomUuid);
+
+  return service;
 }
 
 function clearEvictionTimer(key: string) {
@@ -72,6 +101,7 @@ export const copilotSocketManager = {
     const existingService = services.get(key);
 
     if (existingService) {
+      ensureConnected(existingService, key);
       return existingService;
     }
 

--- a/src/services/copilot/copilotSocketManager.ts
+++ b/src/services/copilot/copilotSocketManager.ts
@@ -1,9 +1,30 @@
 import WeniWebchatService from '@weni/webchat-service';
 import type { CopilotConnection } from '@/services/api/resources/chats/copilot';
+import env from '@/utils/env';
+
+const DEFAULT_IDLE_TIMEOUT_MS = 120000;
 
 const services = new Map<string, WeniWebchatService>();
+const evictionTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
-function createService(connection: CopilotConnection): WeniWebchatService {
+function buildKey(channelUuid: string, roomUuid: string) {
+  return `${channelUuid}:${roomUuid}`;
+}
+
+function getIdleTimeoutMs() {
+  const parsed = Number(env('COPILOT_IDLE_TIMEOUT_MS'));
+
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return parsed;
+  }
+
+  return DEFAULT_IDLE_TIMEOUT_MS;
+}
+
+function createService(
+  connection: CopilotConnection,
+  roomUuid: string,
+): WeniWebchatService {
   return new WeniWebchatService({
     socketUrl: connection.socketUrl,
     channelUuid: connection.channelUuid,
@@ -12,54 +33,97 @@ function createService(connection: CopilotConnection): WeniWebchatService {
     storage: connection.storage || 'local',
     callbackUrl: connection.callbackUrl || '',
     mode: 'live',
+    sessionId: roomUuid,
   });
+}
+
+function clearEvictionTimer(key: string) {
+  const timer = evictionTimers.get(key);
+
+  if (!timer) {
+    return;
+  }
+
+  clearTimeout(timer);
+  evictionTimers.delete(key);
+}
+
+function disposeByKey(key: string) {
+  clearEvictionTimer(key);
+
+  const service = services.get(key);
+
+  if (!service) {
+    return;
+  }
+
+  service.destroy();
+  services.delete(key);
 }
 
 export const copilotSocketManager = {
   getOrCreateService(
-    channelUuid: string,
+    roomUuid: string,
     connection: CopilotConnection,
   ): WeniWebchatService {
-    const existingService = services.get(channelUuid);
+    const key = buildKey(connection.channelUuid, roomUuid);
+    clearEvictionTimer(key);
+
+    const existingService = services.get(key);
 
     if (existingService) {
       return existingService;
     }
 
-    const service = createService({
-      ...connection,
-      channelUuid,
-    });
-
-    services.set(channelUuid, service);
+    const service = createService(connection, roomUuid);
+    services.set(key, service);
     service.init().catch((error) => {
-      console.error(
-        `Failed to initialize copilot service for ${channelUuid}:`,
-        error,
-      );
-      services.delete(channelUuid);
+      console.error(`Failed to initialize copilot service for ${key}:`, error);
+      disposeByKey(key);
     });
 
     return service;
   },
 
-  setRoomContext(channelUuid: string, context: string) {
-    const service = services.get(channelUuid);
-    service?.setContext(context);
+  setRoomContext(
+    roomUuid: string,
+    connection: CopilotConnection,
+    context: string,
+  ) {
+    const key = buildKey(connection.channelUuid, roomUuid);
+    services.get(key)?.setContext(context);
   },
 
-  disposeService(channelUuid: string) {
-    const service = services.get(channelUuid);
+  scheduleEviction(
+    roomUuid: string,
+    connection: CopilotConnection,
+    delayMs = getIdleTimeoutMs(),
+  ) {
+    const key = buildKey(connection.channelUuid, roomUuid);
 
-    if (!service) {
+    if (!services.has(key)) {
       return;
     }
 
-    service.destroy();
-    services.delete(channelUuid);
+    clearEvictionTimer(key);
+
+    const timer = setTimeout(() => {
+      disposeByKey(key);
+    }, delayMs);
+
+    evictionTimers.set(key, timer);
+  },
+
+  disposeService(roomUuid: string, connection: CopilotConnection) {
+    disposeByKey(buildKey(connection.channelUuid, roomUuid));
   },
 
   reset() {
+    evictionTimers.forEach((timer) => {
+      clearTimeout(timer);
+    });
+    evictionTimers.clear();
+
     services.forEach((service) => {
       service.destroy();
     });

--- a/src/types/webchat-service.d.ts
+++ b/src/types/webchat-service.d.ts
@@ -33,8 +33,14 @@ declare module '@weni/webchat-service' {
 
   export default class WeniWebchatService {
     constructor(_config: ServiceConfig);
+    session?: {
+      sessionKey: string;
+    };
     init(): Promise<unknown>;
+    connect(): Promise<unknown>;
     destroy(): void;
+    isConnected(): boolean;
+    isConnecting(): boolean;
     setContext(_context: string): void;
     getContext(): string;
     getMessages(): Message[];

--- a/src/types/webchat-service.d.ts
+++ b/src/types/webchat-service.d.ts
@@ -28,6 +28,9 @@ declare module '@weni/webchat-service' {
     THINKING_STOP: string;
     CART_UPDATED: string;
     CONNECTION_STATUS_CHANGED: string;
+    HISTORY_LOADED: string;
+    STATE_CHANGED: string;
+    ERROR: string;
     [key: string]: string;
   };
 

--- a/src/types/webchat-service.d.ts
+++ b/src/types/webchat-service.d.ts
@@ -7,6 +7,7 @@ declare module '@weni/webchat-service' {
     storage?: string;
     callbackUrl?: string;
     mode?: string;
+    sessionId?: string;
   };
 
   export type Message = {
@@ -38,6 +39,7 @@ declare module '@weni/webchat-service' {
     getContext(): string;
     getMessages(): Message[];
     sendMessage(_text: string, _options?: Record<string, unknown>): void;
+    setSessionId(_id: string): Promise<void>;
     on(_event: string, _cb: (..._args: unknown[]) => void): void;
     off(_event: string, _cb: (..._args: unknown[]) => void): void;
   }


### PR DESCRIPTION
### Type of Change
- [x] Feature
- [ ] Bug fix
- [x] Refactor
- [x] Tests
- [ ] Chore
- [ ] Locales

### Why
Previously, the copilot socket service was keyed by `channelUuid`, meaning all rooms on the same channel shared a single WebSocket connection and message history. This caused messages from one room to bleed into another when switching between conversations. Each room needs its own isolated service instance with its own session so that message state is never shared across rooms.

### What Changed
- The `copilotSocketManager` now keys services by a composite `channelUuid:roomUuid` string instead of `channelUuid` alone, and passes `roomUuid` as the `sessionId` when constructing a `WeniWebchatService`.
- `useCopilotChat` now accepts a `roomUuid` ref alongside the existing `connection` ref. The watcher reacts to changes in either value, schedules eviction of the previous room's service, and attaches a fresh service for the new room — resetting all view state (messages, thinking indicator, cart count) on each transition.
- Idle services are no longer destroyed immediately on room leave. Instead, `scheduleEviction` starts a configurable timer (defaulting to 120 s, overridable via `COPILOT_IDLE_TIMEOUT_MS`) so that returning to a room within the window reuses the existing service and cancels the eviction.
- The `watch` block that called `copilotSocketManager.getOrCreateService` and `setRoomContext` directly from `DeskCopilotTab` has been removed; that responsibility now lives entirely inside `useCopilotChat`.
- `setRoomContext` and `disposeService` signatures updated to accept `roomUuid` + `connection` instead of `channelUuid` alone.
- `sessionId` added to the `WeniWebchatService` config type declaration, and `setSessionId` added to the service instance type.

### Diagram

```mermaid
flowchart TD
    A[DeskCopilotTab] -->|connection + roomUuid| B[useCopilotChat]
    B -->|watch connection & roomUuid| C{Room changed?}
    C -- No --> D[No-op]
    C -- Yes --> E[scheduleEviction on previous room]
    E --> F[attachService for new room]
    F --> G[copilotSocketManager.getOrCreateService\nkey = channelUuid:roomUuid\nsessionId = roomUuid]
    G --> H{Service exists?}
    H -- Yes, cancel eviction timer --> I[Reuse existing service]
    H -- No --> J[Create new WeniWebchatService\ninit async]
    B -->|onUnmounted| E
    K[evictionTimers] -->|after idle timeout| L[disposeByKey → service.destroy]
```