### PR TITLE
feat: add streaming word reveal, typing indicator, animated thinking messages, and auto-scroll to Desk Copilot

### DIFF
--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/__tests__/index.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/__tests__/index.spec.js
@@ -61,6 +61,7 @@ function mockCopilotConnection({
 function mockCopilotChat({
   messages = [],
   isThinking = false,
+  isTyping = false,
   isLoadingHistory = false,
   cartCount = 0,
   suggestions = [],
@@ -68,6 +69,7 @@ function mockCopilotChat({
   useCopilotChat.mockReturnValue({
     messages: ref(messages),
     isThinking: ref(isThinking),
+    isTyping: ref(isTyping),
     isLoadingHistory: ref(isLoadingHistory),
     cartCount: ref(cartCount),
     suggestions: ref(suggestions),
@@ -128,7 +130,7 @@ const createWrapper = (props = {}, piniaState = {}) =>
           name: 'AssistantMessageList',
           template:
             '<div data-testid="assistant-message-list" @click="$emit(\'send\', \'Suggested text\')"><div v-if="isLoadingHistory" data-testid="assistant-history-loading" /></div>',
-          props: ['messages', 'isThinking', 'isLoadingHistory'],
+          props: ['messages', 'isThinking', 'isTyping', 'isLoadingHistory'],
         },
         AssistantInput: {
           name: 'AssistantInput',

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/__tests__/index.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/__tests__/index.spec.js
@@ -144,6 +144,11 @@ const createWrapper = (props = {}, piniaState = {}) =>
           template: '<div data-testid="assistant-cart-badge" />',
           props: ['count'],
         },
+        UnnnicButton: {
+          name: 'UnnnicButton',
+          inheritAttrs: false,
+          template: '<button v-bind="$attrs" @click="$emit(\'click\')" />',
+        },
       },
     },
   });

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/AiMessage.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/AiMessage.vue
@@ -155,6 +155,10 @@ async function handleCopy() {
   align-items: flex-start;
   gap: $unnnic-space-2;
   width: 100%;
+  max-width: 75%;
+  min-width: 0;
+  animation: assistant-bubble-in-left 0.3s ease-out both;
+  transform-origin: top left;
 
   &__icon {
     flex-shrink: 0;
@@ -191,6 +195,7 @@ async function handleCopy() {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    flex-wrap: wrap;
     gap: $unnnic-space-2;
     width: 100%;
   }
@@ -200,6 +205,23 @@ async function handleCopy() {
     display: flex;
     align-items: center;
     gap: $unnnic-space-2;
+    min-width: 0;
+  }
+}
+
+@keyframes assistant-bubble-in-left {
+  0% {
+    opacity: 0;
+    transform: translateX(-2px) scale(0.8);
+  }
+
+  60% {
+    transform: translateX(2px) scale(1.02);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateX(0) scale(1);
   }
 }
 </style>

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/AiMessage.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/AiMessage.vue
@@ -2,6 +2,7 @@
   <section
     class="ai-message"
     data-testid="assistant-ai-message"
+    :class="{ 'ai-message--streaming': isStreamingOrBuffering }"
   >
     <UnnnicIcon
       class="ai-message__icon"
@@ -20,15 +21,23 @@
       </p>
 
       <section
-        v-if="suggestionText"
+        v-if="suggestionText || isStreamingOrBuffering"
         class="ai-message__suggestion"
         data-testid="assistant-ai-suggestion"
+        :class="{ 'ai-message__suggestion--streaming': isStreamingOrBuffering }"
       >
-        <p class="ai-message__suggestion-text">{{ suggestionText }}</p>
+        <p class="ai-message__suggestion-text">
+          {{ displayedSuggestionText
+          }}<span
+            v-if="isStreamingOrBuffering"
+            class="ai-message__caret"
+            data-testid="assistant-ai-caret"
+          />
+        </p>
       </section>
 
       <section
-        v-if="suggestionText"
+        v-if="suggestionText && !isStreamingOrBuffering"
         class="ai-message__actions"
         data-testid="assistant-ai-actions"
       >
@@ -92,23 +101,55 @@
 import { computed, ref } from 'vue';
 import { UnnnicCallAlert } from '@weni/unnnic-system';
 import i18n from '@/plugins/i18n';
+import { useStreamingBuffer } from '@/composables/assistant/useStreamingBuffer';
 
 defineOptions({
   name: 'AssistantAiMessage',
 });
 
-const props = defineProps<{
-  text: string;
-  suggestion?: string;
-}>();
+const props = withDefaults(
+  defineProps<{
+    text: string;
+    suggestion?: string;
+    status?: string;
+  }>(),
+  {
+    suggestion: undefined,
+    status: '',
+  },
+);
 
 const emit = defineEmits<{
   send: [text: string];
+  wordRevealed: [];
 }>();
 
 const feedbackLiked = ref<boolean | null>(null);
 
+const isStreaming = computed(() => props.status === 'streaming');
+const sourceText = computed(() => {
+  if (props.suggestion?.trim()) {
+    return props.suggestion.trim();
+  }
+
+  return props.text.trim();
+});
+
+const { displayedText, isBuffering } = useStreamingBuffer(
+  sourceText,
+  isStreaming,
+  () => emit('wordRevealed'),
+);
+
+const isStreamingOrBuffering = computed(
+  () => isStreaming.value || isBuffering.value,
+);
+
 const leadingText = computed(() => {
+  if (isStreamingOrBuffering.value) {
+    return '';
+  }
+
   if (props.suggestion?.trim()) {
     return props.text.trim();
   }
@@ -117,12 +158,18 @@ const leadingText = computed(() => {
 });
 
 const suggestionText = computed(() => {
+  if (isStreamingOrBuffering.value) {
+    return displayedText.value;
+  }
+
   if (props.suggestion?.trim()) {
     return props.suggestion.trim();
   }
 
   return props.text.trim();
 });
+
+const displayedSuggestionText = computed(() => suggestionText.value);
 
 async function handleCopy() {
   if (!suggestionText.value || !navigator.clipboard) {
@@ -160,6 +207,10 @@ async function handleCopy() {
   animation: assistant-bubble-in-left 0.3s ease-out both;
   transform-origin: top left;
 
+  &--streaming {
+    animation: none;
+  }
+
   &__icon {
     flex-shrink: 0;
   }
@@ -183,12 +234,28 @@ async function handleCopy() {
     padding: $unnnic-space-3 $unnnic-space-4;
     border: 1px solid $unnnic-color-border-base;
     border-radius: $unnnic-radius-2;
+
+    &--streaming {
+      border-color: transparent;
+      padding-left: 0;
+      padding-right: 0;
+    }
   }
 
   &__suggestion-text {
     font: $unnnic-font-body;
     color: $unnnic-color-fg-base;
     overflow-wrap: anywhere;
+  }
+
+  &__caret {
+    display: inline-block;
+    width: 1px;
+    height: 1.2em;
+    margin-left: -1px;
+    background: currentColor;
+    animation: caret-blink 1s step-end infinite;
+    vertical-align: text-bottom;
   }
 
   &__actions {
@@ -222,6 +289,12 @@ async function handleCopy() {
   100% {
     opacity: 1;
     transform: translateX(0) scale(1);
+  }
+}
+
+@keyframes caret-blink {
+  50% {
+    opacity: 0;
   }
 }
 </style>

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/AssistantMessageList.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/AssistantMessageList.vue
@@ -34,11 +34,14 @@
         v-else
         :text="message.text"
         :suggestion="message.suggestion"
+        :status="message.status"
         @send="emit('send', $event)"
+        @word-revealed="emit('wordRevealed')"
       />
     </template>
 
     <ThinkingIndicator v-if="isThinking" />
+    <TypingIndicator v-else-if="isTyping" />
   </section>
 </template>
 
@@ -47,6 +50,7 @@ import type { AssistantMessage } from '@/services/assistant/types';
 import HumanMessage from './HumanMessage.vue';
 import AiMessage from './AiMessage.vue';
 import ThinkingIndicator from './ThinkingIndicator.vue';
+import TypingIndicator from './TypingIndicator.vue';
 
 defineOptions({
   name: 'AssistantMessageList',
@@ -56,17 +60,20 @@ withDefaults(
   defineProps<{
     messages?: AssistantMessage[];
     isThinking?: boolean;
+    isTyping?: boolean;
     isLoadingHistory?: boolean;
   }>(),
   {
     messages: () => [],
     isThinking: false,
+    isTyping: false,
     isLoadingHistory: false,
   },
 );
 
 const emit = defineEmits<{
   send: [text: string];
+  wordRevealed: [];
 }>();
 </script>
 

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/HumanMessage.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/HumanMessage.vue
@@ -24,7 +24,8 @@ defineProps<{
   width: 100%;
 
   &__text {
-    max-width: 100%;
+    max-width: 75%;
+    min-width: 0;
     padding: $unnnic-space-3 $unnnic-space-4;
     border-radius: $unnnic-radius-2;
     background-color: $unnnic-color-bg-base;
@@ -32,6 +33,24 @@ defineProps<{
     font: $unnnic-font-body;
     color: $unnnic-color-fg-base;
     overflow-wrap: anywhere;
+    animation: assistant-bubble-in-right 0.3s ease-out both;
+    transform-origin: top right;
+  }
+}
+
+@keyframes assistant-bubble-in-right {
+  0% {
+    opacity: 0;
+    transform: translateX(2px) scale(0.8);
+  }
+
+  60% {
+    transform: translateX(-2px) scale(1.02);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateX(0) scale(1);
   }
 }
 </style>

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/ThinkingIndicator.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/ThinkingIndicator.vue
@@ -9,15 +9,137 @@
       size="sm"
       scheme="fg-emphasized"
     />
-    <p class="thinking-indicator__text">
-      {{ $t('contact_info.desk_copilot.assistant.processing_information') }}
-    </p>
+    <section class="thinking-indicator__text-wrapper">
+      <section
+        class="thinking-indicator__text-track"
+        :class="{
+          'thinking-indicator__text-track--sliding':
+            isAnimatingOut || isInitializing,
+        }"
+      >
+        <p
+          v-if="isInitializing"
+          class="thinking-indicator__text"
+        >
+          &nbsp;
+        </p>
+        <p
+          v-else-if="isAnimatingOut"
+          class="thinking-indicator__text"
+        >
+          {{ currentMessage }}
+        </p>
+        <p
+          :key="currentMessageIndex"
+          class="thinking-indicator__text"
+          data-testid="assistant-thinking-text"
+        >
+          {{ isAnimatingOut ? nextMessage : currentMessage }}
+        </p>
+      </section>
+    </section>
   </section>
 </template>
 
 <script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+
 defineOptions({
   name: 'AssistantThinkingIndicator',
+});
+
+const MESSAGE_KEYS = [
+  'processing',
+  'connecting',
+  'refining',
+  'structuring',
+  'almost',
+] as const;
+
+const INIT_DELAY_MS = 500;
+const TRANSITION_MS = 500;
+const MIN_ROTATION_MS = 4000;
+const MAX_ROTATION_MS = 7500;
+
+const { t } = useI18n();
+
+const currentMessageIndex = ref(0);
+const isAnimatingOut = ref(false);
+const isInitializing = ref(true);
+
+let rotationTimer: ReturnType<typeof setTimeout> | null = null;
+let transitionTimer: ReturnType<typeof setTimeout> | null = null;
+let initTimer: ReturnType<typeof setTimeout> | null = null;
+
+const currentMessage = computed(() =>
+  t(
+    `contact_info.desk_copilot.assistant.thinking_messages.${MESSAGE_KEYS[currentMessageIndex.value]}`,
+  ),
+);
+
+const nextMessage = computed(() => {
+  const nextIndex = currentMessageIndex.value + 1;
+
+  if (nextIndex >= MESSAGE_KEYS.length) {
+    return currentMessage.value;
+  }
+
+  return t(
+    `contact_info.desk_copilot.assistant.thinking_messages.${MESSAGE_KEYS[nextIndex]}`,
+  );
+});
+
+function clearTimers() {
+  if (rotationTimer) {
+    clearTimeout(rotationTimer);
+    rotationTimer = null;
+  }
+
+  if (transitionTimer) {
+    clearTimeout(transitionTimer);
+    transitionTimer = null;
+  }
+
+  if (initTimer) {
+    clearTimeout(initTimer);
+    initTimer = null;
+  }
+}
+
+function nextRotationDelay() {
+  return MIN_ROTATION_MS + Math.random() * (MAX_ROTATION_MS - MIN_ROTATION_MS);
+}
+
+function scheduleNextMessage() {
+  if (rotationTimer) {
+    clearTimeout(rotationTimer);
+    rotationTimer = null;
+  }
+
+  if (currentMessageIndex.value >= MESSAGE_KEYS.length - 1) {
+    return;
+  }
+
+  rotationTimer = setTimeout(() => {
+    isAnimatingOut.value = true;
+    transitionTimer = setTimeout(() => {
+      currentMessageIndex.value += 1;
+      isAnimatingOut.value = false;
+    }, TRANSITION_MS);
+  }, nextRotationDelay());
+}
+
+onMounted(() => {
+  initTimer = setTimeout(() => {
+    isInitializing.value = false;
+  }, INIT_DELAY_MS);
+});
+
+watch(currentMessageIndex, scheduleNextMessage, { immediate: true });
+
+onBeforeUnmount(() => {
+  clearTimers();
 });
 </script>
 
@@ -27,15 +149,40 @@ defineOptions({
   align-items: center;
   gap: $unnnic-space-2;
   width: 100%;
+  height: $unnnic-font-size-body-gt;
 
   &__icon {
     flex-shrink: 0;
     animation: assistant-spin 1s linear infinite;
   }
 
+  &__text-wrapper {
+    height: $unnnic-font-size-body-gt;
+    overflow: hidden;
+  }
+
+  &__text-track {
+    display: flex;
+    flex-direction: column;
+
+    &--sliding {
+      animation: thinking-push 0.5s ease-in-out forwards;
+
+      .thinking-indicator__text:first-child {
+        animation: thinking-fade-out 0.5s ease-in-out forwards;
+      }
+
+      .thinking-indicator__text:last-child {
+        animation: thinking-fade-in 0.5s ease-in-out forwards;
+      }
+    }
+  }
+
   &__text {
     font: $unnnic-font-emphasis;
     color: $unnnic-color-fg-emphasized;
+    white-space: nowrap;
+    flex-shrink: 0;
   }
 }
 
@@ -46,6 +193,40 @@ defineOptions({
 
   to {
     transform: rotate(360deg);
+  }
+}
+
+@keyframes thinking-push {
+  from {
+    transform: translateY(0);
+  }
+
+  to {
+    transform: translateY(-50%);
+  }
+}
+
+@keyframes thinking-fade-out {
+  0%,
+  25% {
+    opacity: 1;
+  }
+
+  75%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes thinking-fade-in {
+  0%,
+  25% {
+    opacity: 0;
+  }
+
+  75%,
+  100% {
+    opacity: 1;
   }
 }
 </style>

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/TypingIndicator.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/TypingIndicator.vue
@@ -1,0 +1,60 @@
+<template>
+  <section
+    class="typing-indicator"
+    data-testid="assistant-typing-indicator"
+  >
+    <span class="typing-indicator__dot" />
+    <span class="typing-indicator__dot" />
+    <span class="typing-indicator__dot" />
+  </section>
+</template>
+
+<script setup lang="ts">
+defineOptions({
+  name: 'AssistantTypingIndicator',
+});
+</script>
+
+<style lang="scss" scoped>
+.typing-indicator {
+  display: flex;
+  align-items: center;
+  gap: $unnnic-space-1;
+  width: 100%;
+  height: $unnnic-font-size-body-gt;
+
+  &__dot {
+    width: $unnnic-space-1;
+    height: $unnnic-space-1;
+    border-radius: 50%;
+    background-color: $unnnic-color-fg-emphasized;
+    animation: typing-bounce 1.3s infinite ease-in-out both;
+
+    &:nth-child(1) {
+      animation-delay: -0.32s;
+    }
+
+    &:nth-child(2) {
+      animation-delay: -0.16s;
+    }
+
+    &:nth-child(3) {
+      animation-delay: 0s;
+    }
+  }
+}
+
+@keyframes typing-bounce {
+  0%,
+  80%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.1;
+  }
+
+  40% {
+    transform: translateY(-2px);
+    opacity: 1;
+  }
+}
+</style>

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/__tests__/AiMessage.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/__tests__/AiMessage.spec.js
@@ -73,4 +73,19 @@ describe('AssistantAiMessage', () => {
       'Suggested reply for the customer',
     ]);
   });
+
+  it('shows a caret and hides actions while streaming', () => {
+    wrapper = createWrapper({
+      text: 'Hello world',
+      suggestion: undefined,
+      status: 'streaming',
+    });
+
+    expect(wrapper.find('[data-testid="assistant-ai-caret"]').exists()).toBe(
+      true,
+    );
+    expect(wrapper.find('[data-testid="assistant-ai-actions"]').exists()).toBe(
+      false,
+    );
+  });
 });

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/__tests__/AssistantMessageList.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/__tests__/AssistantMessageList.spec.js
@@ -25,11 +25,15 @@ const createWrapper = (props = {}) =>
         AiMessage: {
           name: 'AssistantAiMessage',
           template: '<div data-testid="assistant-ai-message" />',
-          props: ['text', 'suggestion'],
+          props: ['text', 'suggestion', 'status'],
         },
         ThinkingIndicator: {
           name: 'AssistantThinkingIndicator',
           template: '<div data-testid="assistant-thinking-indicator" />',
+        },
+        TypingIndicator: {
+          name: 'AssistantTypingIndicator',
+          template: '<div data-testid="assistant-typing-indicator" />',
         },
       },
     },
@@ -83,5 +87,42 @@ describe('AssistantMessageList', () => {
     expect(
       wrapper.find('[data-testid="assistant-thinking-indicator"]').exists(),
     ).toBe(true);
+  });
+
+  it('shows the typing indicator while waiting for a reply', () => {
+    wrapper = createWrapper({ isTyping: true });
+
+    expect(
+      wrapper.find('[data-testid="assistant-typing-indicator"]').exists(),
+    ).toBe(true);
+  });
+
+  it('prefers thinking over typing when both are active', () => {
+    wrapper = createWrapper({ isTyping: true, isThinking: true });
+
+    expect(
+      wrapper.find('[data-testid="assistant-thinking-indicator"]').exists(),
+    ).toBe(true);
+    expect(
+      wrapper.find('[data-testid="assistant-typing-indicator"]').exists(),
+    ).toBe(false);
+  });
+
+  it('passes message status to AiMessage for streaming replies', () => {
+    wrapper = createWrapper({
+      messages: [
+        {
+          id: 'ai-1',
+          direction: 'ai',
+          text: 'Hello world',
+          quickReplies: [],
+          status: 'streaming',
+          timestamp: 1,
+        },
+      ],
+    });
+
+    const aiMessage = wrapper.findComponent({ name: 'AssistantAiMessage' });
+    expect(aiMessage.props('status')).toBe('streaming');
   });
 });

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/__tests__/AssistantMessageList.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/__tests__/AssistantMessageList.spec.js
@@ -76,4 +76,12 @@ describe('AssistantMessageList', () => {
       wrapper.find('[data-testid="assistant-human-message"]').exists(),
     ).toBe(true);
   });
+
+  it('shows the thinking indicator while the assistant is processing', () => {
+    wrapper = createWrapper({ isThinking: true });
+
+    expect(
+      wrapper.find('[data-testid="assistant-thinking-indicator"]').exists(),
+    ).toBe(true);
+  });
 });

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/__tests__/ThinkingIndicator.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/__tests__/ThinkingIndicator.spec.js
@@ -1,0 +1,60 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import ThinkingIndicator from '../ThinkingIndicator.vue';
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key) => key.split('.').pop(),
+  }),
+}));
+
+const createWrapper = () =>
+  mount(ThinkingIndicator, {
+    global: {
+      stubs: {
+        UnnnicIcon: true,
+      },
+    },
+  });
+
+describe('AssistantThinkingIndicator', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('shows the first thinking message after the initial delay', async () => {
+    wrapper = createWrapper();
+
+    vi.advanceTimersByTime(500);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('[data-testid="assistant-thinking-text"]').text()).toBe(
+      'processing',
+    );
+  });
+
+  it('rotates to the next thinking message after the delay', async () => {
+    wrapper = createWrapper();
+
+    vi.advanceTimersByTime(500);
+    await wrapper.vm.$nextTick();
+
+    vi.advanceTimersByTime(4000);
+    await wrapper.vm.$nextTick();
+    vi.advanceTimersByTime(500);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('[data-testid="assistant-thinking-text"]').text()).toBe(
+      'connecting',
+    );
+  });
+});

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/__tests__/TypingIndicator.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/__tests__/TypingIndicator.spec.js
@@ -1,0 +1,20 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import TypingIndicator from '../TypingIndicator.vue';
+
+describe('AssistantTypingIndicator', () => {
+  let wrapper;
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('renders the typing dots', () => {
+    wrapper = mount(TypingIndicator);
+
+    expect(
+      wrapper.find('[data-testid="assistant-typing-indicator"]').exists(),
+    ).toBe(true);
+    expect(wrapper.findAll('.typing-indicator__dot')).toHaveLength(3);
+  });
+});

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/index.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/index.vue
@@ -22,7 +22,7 @@
           :isTyping="isTyping"
           :isLoadingHistory="isLoadingHistory"
           @send="handleSendSuggestionToInput"
-          @word-revealed="scrollToBottom()"
+          @word-revealed="scrollToBottomIfNear()"
         />
 
         <section
@@ -119,8 +119,13 @@ const {
   sendMessage,
 } = useCopilotChat(connection, roomUuid);
 
-const { listRef, bottomAnchorRef, showGoToBottom, scrollToBottom } =
-  useAutoScroll(messages, isThinking, isTyping);
+const {
+  listRef,
+  bottomAnchorRef,
+  showGoToBottom,
+  scrollToBottom,
+  scrollToBottomIfNear,
+} = useAutoScroll(messages, isThinking, isTyping);
 
 const enableRoomSummary = computed(
   () => !!project.value?.config?.has_chats_summary,

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/index.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/index.vue
@@ -4,6 +4,7 @@
     data-testid="desk-copilot"
   >
     <section
+      ref="listRef"
       class="desk-copilot__chat"
       data-testid="desk-copilot-chat"
     >
@@ -21,7 +22,25 @@
           :isLoadingHistory="isLoadingHistory"
           @send="handleSendSuggestionToInput"
         />
+
+        <section
+          v-if="showGoToBottom"
+          class="desk-copilot__go-to-bottom"
+        >
+          <UnnnicButton
+            class="desk-copilot__go-to-bottom-button"
+            type="tertiary"
+            size="small"
+            iconCenter="arrow_downward"
+            data-testid="assistant-scroll-to-bottom"
+            :aria-label="
+              $t('contact_info.desk_copilot.assistant.scroll_to_bottom')
+            "
+            @click="scrollToBottom()"
+          />
+        </section>
       </template>
+      <div ref="bottomAnchorRef" />
     </section>
 
     <template v-if="isConfigured">
@@ -50,6 +69,7 @@ import AssistantMessageList from './assistant/AssistantMessageList.vue';
 import AssistantInput from './assistant/AssistantInput.vue';
 import SuggestionChips from './assistant/SuggestionChips.vue';
 import CartBadge from './assistant/CartBadge.vue';
+import { useAutoScroll } from '@/composables/assistant/useAutoScroll';
 import { useCopilotChat } from '@/composables/assistant/useCopilotChat';
 import { useCopilotConnection } from '@/composables/useCopilotConnection';
 import { useConfig } from '@/store/modules/config';
@@ -96,6 +116,9 @@ const {
   sendMessage,
 } = useCopilotChat(connection, roomUuid);
 
+const { listRef, bottomAnchorRef, showGoToBottom, scrollToBottom } =
+  useAutoScroll(messages, isThinking);
+
 const enableRoomSummary = computed(
   () => !!project.value?.config?.has_chats_summary,
 );
@@ -127,6 +150,45 @@ onMounted(() => {
     flex: 1;
     min-height: 0;
     overflow: hidden auto;
+  }
+
+  &__go-to-bottom {
+    display: flex;
+    justify-content: center;
+    position: sticky;
+    bottom: -$unnnic-space-4;
+    left: 0;
+    right: 0;
+    height: $unnnic-space-16;
+    z-index: 1;
+    pointer-events: none;
+    background-image: linear-gradient(
+      to bottom,
+      transparent,
+      $unnnic-color-bg-base
+    );
+  }
+
+  &__go-to-bottom-button {
+    pointer-events: auto;
+    align-self: center;
+    animation: assistant-go-to-bottom-enter 0.4s ease both;
+  }
+}
+
+@keyframes assistant-go-to-bottom-enter {
+  from {
+    opacity: 0;
+    transform: translateY(100%);
+  }
+
+  30% {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }
 </style>

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/index.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/index.vue
@@ -19,8 +19,10 @@
         <AssistantMessageList
           :messages="messages"
           :isThinking="isThinking"
+          :isTyping="isTyping"
           :isLoadingHistory="isLoadingHistory"
           @send="handleSendSuggestionToInput"
+          @word-revealed="scrollToBottom()"
         />
 
         <section
@@ -110,6 +112,7 @@ const roomUuid = computed(() => activeRoom.value?.uuid);
 const {
   messages,
   isThinking,
+  isTyping,
   isLoadingHistory,
   cartCount,
   suggestions,
@@ -117,7 +120,7 @@ const {
 } = useCopilotChat(connection, roomUuid);
 
 const { listRef, bottomAnchorRef, showGoToBottom, scrollToBottom } =
-  useAutoScroll(messages, isThinking);
+  useAutoScroll(messages, isThinking, isTyping);
 
 const enableRoomSummary = computed(
   () => !!project.value?.config?.has_chats_summary,

--- a/src/composables/assistant/__tests__/useAutoScroll.spec.ts
+++ b/src/composables/assistant/__tests__/useAutoScroll.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { defineComponent, nextTick, ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import { useAutoScroll } from '../useAutoScroll';
+
+const TestHost = defineComponent({
+  setup() {
+    const messages = ref<{ id: string }[]>([]);
+    const isThinking = ref(false);
+    const { listRef, bottomAnchorRef, showGoToBottom, scrollToBottom } =
+      useAutoScroll(messages, isThinking);
+
+    return {
+      messages,
+      isThinking,
+      listRef,
+      bottomAnchorRef,
+      showGoToBottom,
+      scrollToBottom,
+    };
+  },
+  template: `
+    <div
+      ref="listRef"
+      data-testid="list"
+      style="height: 80px; overflow: auto;"
+    >
+      <div data-testid="content" style="height: 400px" />
+      <div ref="bottomAnchorRef" data-testid="anchor" />
+    </div>
+  `,
+});
+
+describe('useAutoScroll', () => {
+  let wrapper;
+  let scrollIntoView;
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.restoreAllMocks();
+  });
+
+  function mountHost() {
+    scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+    wrapper = mount(TestHost);
+    return wrapper;
+  }
+
+  it('scrolls to the bottom when messages change', async () => {
+    mountHost();
+    await nextTick();
+
+    expect(scrollIntoView).toHaveBeenCalled();
+
+    scrollIntoView.mockClear();
+    wrapper.vm.messages.push({ id: '1' });
+    await nextTick();
+    await nextTick();
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+  });
+
+  it('scrolls to the bottom when thinking starts', async () => {
+    mountHost();
+    await nextTick();
+    scrollIntoView.mockClear();
+
+    wrapper.vm.isThinking = true;
+    await nextTick();
+    await nextTick();
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+  });
+
+  it('shows the go-to-bottom control when the user scrolls away from the end', async () => {
+    mountHost();
+    wrapper.vm.messages.push({ id: '1' });
+    await nextTick();
+
+    const list = wrapper.find('[data-testid="list"]').element;
+    Object.defineProperty(list, 'scrollHeight', {
+      value: 400,
+      configurable: true,
+    });
+    Object.defineProperty(list, 'clientHeight', {
+      value: 80,
+      configurable: true,
+    });
+    Object.defineProperty(list, 'scrollTop', { value: 0, configurable: true });
+
+    list.dispatchEvent(new Event('scroll'));
+    await nextTick();
+
+    expect(wrapper.vm.showGoToBottom).toBe(true);
+  });
+});

--- a/src/composables/assistant/__tests__/useAutoScroll.spec.ts
+++ b/src/composables/assistant/__tests__/useAutoScroll.spec.ts
@@ -9,8 +9,13 @@ const TestHost = defineComponent({
     const messages = ref<{ id: string }[]>([]);
     const isThinking = ref(false);
     const isTyping = ref(false);
-    const { listRef, bottomAnchorRef, showGoToBottom, scrollToBottom } =
-      useAutoScroll(messages, isThinking, isTyping);
+    const {
+      listRef,
+      bottomAnchorRef,
+      showGoToBottom,
+      scrollToBottom,
+      scrollToBottomIfNear,
+    } = useAutoScroll(messages, isThinking, isTyping);
 
     return {
       messages,
@@ -20,6 +25,7 @@ const TestHost = defineComponent({
       bottomAnchorRef,
       showGoToBottom,
       scrollToBottom,
+      scrollToBottomIfNear,
     };
   },
   template: `
@@ -50,13 +56,32 @@ describe('useAutoScroll', () => {
     return wrapper;
   }
 
-  it('scrolls to the bottom when messages change', async () => {
+  function mockListMetrics({
+    scrollHeight = 400,
+    clientHeight = 80,
+    scrollTop = 0,
+  } = {}) {
+    const list = wrapper.find('[data-testid="list"]').element;
+    Object.defineProperty(list, 'scrollHeight', {
+      value: scrollHeight,
+      configurable: true,
+    });
+    Object.defineProperty(list, 'clientHeight', {
+      value: clientHeight,
+      configurable: true,
+    });
+    Object.defineProperty(list, 'scrollTop', {
+      value: scrollTop,
+      configurable: true,
+    });
+    return list;
+  }
+
+  it('scrolls to the bottom when messages change while near the end', async () => {
     mountHost();
     await nextTick();
-
-    expect(scrollIntoView).toHaveBeenCalled();
-
     scrollIntoView.mockClear();
+
     wrapper.vm.messages.push({ id: '1' });
     await nextTick();
     await nextTick();
@@ -64,7 +89,7 @@ describe('useAutoScroll', () => {
     expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
   });
 
-  it('scrolls to the bottom when thinking starts', async () => {
+  it('scrolls to the bottom when thinking starts while near the end', async () => {
     mountHost();
     await nextTick();
     scrollIntoView.mockClear();
@@ -76,7 +101,7 @@ describe('useAutoScroll', () => {
     expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
   });
 
-  it('scrolls to the bottom when typing starts', async () => {
+  it('scrolls to the bottom when typing starts while near the end', async () => {
     mountHost();
     await nextTick();
     scrollIntoView.mockClear();
@@ -88,22 +113,33 @@ describe('useAutoScroll', () => {
     expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
   });
 
+  it('does not auto-scroll when the user has scrolled away from the end', async () => {
+    mountHost();
+    await nextTick();
+
+    wrapper.vm.messages.push({ id: '1' });
+    await nextTick();
+    await nextTick();
+
+    const list = mockListMetrics({ scrollTop: 0 });
+    list.dispatchEvent(new Event('scroll'));
+    await nextTick();
+    scrollIntoView.mockClear();
+
+    wrapper.vm.messages.push({ id: '2' });
+    await nextTick();
+    await nextTick();
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+    expect(wrapper.vm.showGoToBottom).toBe(true);
+  });
+
   it('shows the go-to-bottom control when the user scrolls away from the end', async () => {
     mountHost();
     wrapper.vm.messages.push({ id: '1' });
     await nextTick();
 
-    const list = wrapper.find('[data-testid="list"]').element;
-    Object.defineProperty(list, 'scrollHeight', {
-      value: 400,
-      configurable: true,
-    });
-    Object.defineProperty(list, 'clientHeight', {
-      value: 80,
-      configurable: true,
-    });
-    Object.defineProperty(list, 'scrollTop', { value: 0, configurable: true });
-
+    const list = mockListMetrics({ scrollTop: 0 });
     list.dispatchEvent(new Event('scroll'));
     await nextTick();
 

--- a/src/composables/assistant/__tests__/useAutoScroll.spec.ts
+++ b/src/composables/assistant/__tests__/useAutoScroll.spec.ts
@@ -8,12 +8,14 @@ const TestHost = defineComponent({
   setup() {
     const messages = ref<{ id: string }[]>([]);
     const isThinking = ref(false);
+    const isTyping = ref(false);
     const { listRef, bottomAnchorRef, showGoToBottom, scrollToBottom } =
-      useAutoScroll(messages, isThinking);
+      useAutoScroll(messages, isThinking, isTyping);
 
     return {
       messages,
       isThinking,
+      isTyping,
       listRef,
       bottomAnchorRef,
       showGoToBottom,
@@ -68,6 +70,18 @@ describe('useAutoScroll', () => {
     scrollIntoView.mockClear();
 
     wrapper.vm.isThinking = true;
+    await nextTick();
+    await nextTick();
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+  });
+
+  it('scrolls to the bottom when typing starts', async () => {
+    mountHost();
+    await nextTick();
+    scrollIntoView.mockClear();
+
+    wrapper.vm.isTyping = true;
     await nextTick();
     await nextTick();
 

--- a/src/composables/assistant/__tests__/useCopilotChat.spec.ts
+++ b/src/composables/assistant/__tests__/useCopilotChat.spec.ts
@@ -34,8 +34,11 @@ vi.mock('@weni/webchat-service', () => ({
   SERVICE_EVENTS: {
     MESSAGE_RECEIVED: 'message:received',
     MESSAGE_SENT: 'message:sent',
+    MESSAGE_UPDATED: 'message:updated',
     THINKING_START: 'thinking:start',
     THINKING_STOP: 'thinking:stop',
+    TYPING_START: 'typing:start',
+    TYPING_STOP: 'typing:stop',
     CART_UPDATED: 'cart:updated',
     STATE_CHANGED: 'state:changed',
     HISTORY_LOADED: 'history:loaded',
@@ -110,6 +113,65 @@ describe('useCopilotChat', () => {
 
     emit(SERVICE_EVENTS.CART_UPDATED, { count: 3 });
     expect(cartCount.value).toBe(3);
+  });
+
+  it('updates typing from service events', async () => {
+    const connection = ref<CopilotConnection | undefined>(connectionValue);
+    const roomUuid = ref<string | undefined>('room-1');
+    const { isTyping } = useCopilotChat(connection, roomUuid);
+
+    await nextTick();
+
+    emit(SERVICE_EVENTS.TYPING_START);
+    expect(isTyping.value).toBe(true);
+
+    emit(SERVICE_EVENTS.TYPING_STOP);
+    expect(isTyping.value).toBe(false);
+  });
+
+  it('upserts streaming updates from message:updated', async () => {
+    const connection = ref<CopilotConnection | undefined>(connectionValue);
+    const roomUuid = ref<string | undefined>('room-1');
+    const { messages, suggestions } = useCopilotChat(connection, roomUuid);
+
+    await nextTick();
+
+    serviceMock.getMessages.mockReturnValue([
+      {
+        id: 'ai-1',
+        type: 'text',
+        text: 'Hello',
+        timestamp: 1,
+        direction: 'incoming',
+        status: 'streaming',
+        quick_replies: ['Ask later'],
+      },
+    ]);
+
+    emit(SERVICE_EVENTS.MESSAGE_UPDATED, 'ai-1');
+
+    expect(messages.value).toHaveLength(1);
+    expect(messages.value[0].text).toBe('Hello');
+    expect(messages.value[0].status).toBe('streaming');
+    expect(suggestions.value).toEqual([]);
+
+    serviceMock.getMessages.mockReturnValue([
+      {
+        id: 'ai-1',
+        type: 'text',
+        text: 'Hello world',
+        timestamp: 1,
+        direction: 'incoming',
+        status: 'delivered',
+        quick_replies: ['Ask later'],
+      },
+    ]);
+
+    emit(SERVICE_EVENTS.MESSAGE_UPDATED, 'ai-1');
+
+    expect(messages.value[0].text).toBe('Hello world');
+    expect(messages.value[0].status).toBe('delivered');
+    expect(suggestions.value).toEqual(['Ask later']);
   });
 
   it('sends messages through the active service', async () => {

--- a/src/composables/assistant/__tests__/useStreamingBuffer.spec.ts
+++ b/src/composables/assistant/__tests__/useStreamingBuffer.spec.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest';
+import { defineComponent, nextTick, ref } from 'vue';
+import { mount } from '@vue/test-utils';
+
+import { useStreamingBuffer } from '../useStreamingBuffer';
+
+describe('useStreamingBuffer', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  function mountHost({
+    text = '',
+    isStreaming = false,
+  }: {
+    text?: string;
+    isStreaming?: boolean;
+  } = {}) {
+    const textRef = ref(text);
+    const streamingRef = ref(isStreaming);
+    const onWordRevealed = vi.fn();
+
+    const Host = defineComponent({
+      setup() {
+        const { displayedText, isBuffering } = useStreamingBuffer(
+          textRef,
+          streamingRef,
+          onWordRevealed,
+        );
+
+        return {
+          textRef,
+          streamingRef,
+          displayedText,
+          isBuffering,
+          onWordRevealed,
+        };
+      },
+      template: '<div />',
+    });
+
+    wrapper = mount(Host);
+    return wrapper;
+  }
+
+  it('shows the full text immediately when not streaming', () => {
+    mountHost({ text: 'Hello world', isStreaming: false });
+
+    expect(wrapper.vm.displayedText).toBe('Hello world');
+    expect(wrapper.vm.isBuffering).toBe(false);
+  });
+
+  it('reveals words gradually while streaming and keeps buffering until done', async () => {
+    mountHost({ text: 'Hello world', isStreaming: true });
+
+    expect(wrapper.vm.displayedText).toBe('');
+    expect(wrapper.vm.isBuffering).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(wrapper.vm.displayedText).toBe('Hello ');
+    expect(wrapper.vm.onWordRevealed).toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(wrapper.vm.displayedText).toBe('Hello world');
+    expect(wrapper.vm.isBuffering).toBe(true);
+
+    wrapper.vm.streamingRef = false;
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(wrapper.vm.displayedText).toBe('Hello world');
+    expect(wrapper.vm.isBuffering).toBe(false);
+  });
+});

--- a/src/composables/assistant/useAutoScroll.ts
+++ b/src/composables/assistant/useAutoScroll.ts
@@ -1,0 +1,79 @@
+import {
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  watch,
+  type Ref,
+} from 'vue';
+
+export const BOTTOM_SCROLL_THRESHOLD_PX = 100;
+
+type ScrollBehaviorOption = ScrollBehavior;
+
+export function useAutoScroll(
+  messages: Ref<unknown>,
+  isThinking: Ref<boolean>,
+) {
+  const listRef = ref<HTMLElement | null>(null);
+  const bottomAnchorRef = ref<HTMLElement | null>(null);
+  const showGoToBottom = ref(false);
+  const isNearBottomRef = { current: true };
+
+  function scrollToBottom(behavior: ScrollBehaviorOption = 'smooth') {
+    bottomAnchorRef.value?.scrollIntoView?.({ behavior });
+  }
+
+  function syncScrollState() {
+    const el = listRef.value;
+
+    if (!el) {
+      return;
+    }
+
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    const isNear = distanceFromBottom <= BOTTOM_SCROLL_THRESHOLD_PX;
+
+    isNearBottomRef.current = isNear;
+    showGoToBottom.value = !isNear;
+  }
+
+  function handleScroll() {
+    syncScrollState();
+  }
+
+  watch(
+    [messages, isThinking],
+    () => {
+      nextTick(() => {
+        scrollToBottom();
+        requestAnimationFrame(syncScrollState);
+      });
+    },
+    { deep: true, immediate: true },
+  );
+
+  onMounted(() => {
+    const el = listRef.value;
+
+    if (!el) {
+      return;
+    }
+
+    syncScrollState();
+    el.addEventListener('scroll', handleScroll, { passive: true });
+    window.addEventListener('resize', syncScrollState);
+  });
+
+  onBeforeUnmount(() => {
+    listRef.value?.removeEventListener('scroll', handleScroll);
+    window.removeEventListener('resize', syncScrollState);
+  });
+
+  return {
+    listRef,
+    bottomAnchorRef,
+    showGoToBottom,
+    scrollToBottom,
+  };
+}

--- a/src/composables/assistant/useAutoScroll.ts
+++ b/src/composables/assistant/useAutoScroll.ts
@@ -9,11 +9,12 @@ import {
 
 export const BOTTOM_SCROLL_THRESHOLD_PX = 100;
 
-type ScrollBehaviorOption = ScrollBehavior;
+type ScrollBehaviorOption = 'auto' | 'smooth';
 
 export function useAutoScroll(
   messages: Ref<unknown>,
   isThinking: Ref<boolean>,
+  isTyping: Ref<boolean> = ref(false),
 ) {
   const listRef = ref<HTMLElement | null>(null);
   const bottomAnchorRef = ref<HTMLElement | null>(null);
@@ -43,7 +44,7 @@ export function useAutoScroll(
   }
 
   watch(
-    [messages, isThinking],
+    [messages, isThinking, isTyping],
     () => {
       nextTick(() => {
         scrollToBottom();

--- a/src/composables/assistant/useAutoScroll.ts
+++ b/src/composables/assistant/useAutoScroll.ts
@@ -25,6 +25,14 @@ export function useAutoScroll(
     bottomAnchorRef.value?.scrollIntoView?.({ behavior });
   }
 
+  function scrollToBottomIfNear(behavior: ScrollBehaviorOption = 'smooth') {
+    if (!isNearBottomRef.current) {
+      return;
+    }
+
+    scrollToBottom(behavior);
+  }
+
   function syncScrollState() {
     const el = listRef.value;
 
@@ -47,11 +55,11 @@ export function useAutoScroll(
     [messages, isThinking, isTyping],
     () => {
       nextTick(() => {
-        scrollToBottom();
+        scrollToBottomIfNear();
         requestAnimationFrame(syncScrollState);
       });
     },
-    { deep: true, immediate: true },
+    { deep: true },
   );
 
   onMounted(() => {
@@ -76,5 +84,6 @@ export function useAutoScroll(
     bottomAnchorRef,
     showGoToBottom,
     scrollToBottom,
+    scrollToBottomIfNear,
   };
 }

--- a/src/composables/assistant/useCopilotChat.ts
+++ b/src/composables/assistant/useCopilotChat.ts
@@ -26,6 +26,7 @@ export function useCopilotChat(
 ) {
   const messages = ref<AssistantMessage[]>([]);
   const isThinking = ref(false);
+  const isTyping = ref(false);
   const cartCount = ref(0);
   const isLoadingHistory = ref(false);
 
@@ -38,7 +39,10 @@ export function useCopilotChat(
   const suggestions = computed(() => {
     const lastAiMessage = [...messages.value]
       .reverse()
-      .find((message) => message.direction === 'ai');
+      .find(
+        (message) =>
+          message.direction === 'ai' && message.status !== 'streaming',
+      );
 
     return lastAiMessage?.quickReplies || [];
   });
@@ -46,6 +50,7 @@ export function useCopilotChat(
   function resetViewState() {
     messages.value = [];
     isThinking.value = false;
+    isTyping.value = false;
     cartCount.value = 0;
     isLoadingHistory.value = false;
   }
@@ -73,13 +78,7 @@ export function useCopilotChat(
     messages.value = service.getMessages().map(mapServiceMessage);
   }
 
-  function handleMessageReceived(...args: unknown[]) {
-    const message = args[0] as Message;
-    if (!message?.id) {
-      return;
-    }
-
-    const mapped = mapServiceMessage(message);
+  function upsertMappedMessage(mapped: AssistantMessage) {
     const existingIndex = messages.value.findIndex(
       (item) => item.id === mapped.id,
     );
@@ -92,8 +91,35 @@ export function useCopilotChat(
     messages.value.push(mapped);
   }
 
+  function handleMessageReceived(...args: unknown[]) {
+    const message = args[0] as Message;
+    if (!message?.id) {
+      return;
+    }
+
+    upsertMappedMessage(mapServiceMessage(message));
+  }
+
   function handleMessageSent(...args: unknown[]) {
     handleMessageReceived(...args);
+  }
+
+  function handleMessageUpdated(...args: unknown[]) {
+    const messageId = args[0] as string;
+
+    if (!messageId || !activeService) {
+      return;
+    }
+
+    const updated = activeService
+      .getMessages()
+      .find((message) => message.id === messageId);
+
+    if (!updated) {
+      return;
+    }
+
+    upsertMappedMessage(mapServiceMessage(updated));
   }
 
   function handleThinkingStart() {
@@ -102,6 +128,14 @@ export function useCopilotChat(
 
   function handleThinkingStop() {
     isThinking.value = false;
+  }
+
+  function handleTypingStart() {
+    isTyping.value = true;
+  }
+
+  function handleTypingStop() {
+    isTyping.value = false;
   }
 
   function handleCartUpdated(...args: unknown[]) {
@@ -133,8 +167,11 @@ export function useCopilotChat(
     clearHistoryLoadedTimer();
     service.off(SERVICE_EVENTS.MESSAGE_RECEIVED, handleMessageReceived);
     service.off(SERVICE_EVENTS.MESSAGE_SENT, handleMessageSent);
+    service.off(SERVICE_EVENTS.MESSAGE_UPDATED, handleMessageUpdated);
     service.off(SERVICE_EVENTS.THINKING_START, handleThinkingStart);
     service.off(SERVICE_EVENTS.THINKING_STOP, handleThinkingStop);
+    service.off(SERVICE_EVENTS.TYPING_START, handleTypingStart);
+    service.off(SERVICE_EVENTS.TYPING_STOP, handleTypingStop);
     service.off(SERVICE_EVENTS.CART_UPDATED, handleCartUpdated);
     service.off(SERVICE_EVENTS.STATE_CHANGED, handleStateChanged);
     service.off(SERVICE_EVENTS.HISTORY_LOADED, handleHistoryLoaded);
@@ -144,8 +181,11 @@ export function useCopilotChat(
   function subscribe(service: WeniWebchatService) {
     service.on(SERVICE_EVENTS.MESSAGE_RECEIVED, handleMessageReceived);
     service.on(SERVICE_EVENTS.MESSAGE_SENT, handleMessageSent);
+    service.on(SERVICE_EVENTS.MESSAGE_UPDATED, handleMessageUpdated);
     service.on(SERVICE_EVENTS.THINKING_START, handleThinkingStart);
     service.on(SERVICE_EVENTS.THINKING_STOP, handleThinkingStop);
+    service.on(SERVICE_EVENTS.TYPING_START, handleTypingStart);
+    service.on(SERVICE_EVENTS.TYPING_STOP, handleTypingStop);
     service.on(SERVICE_EVENTS.CART_UPDATED, handleCartUpdated);
     service.on(SERVICE_EVENTS.STATE_CHANGED, handleStateChanged);
     service.on(SERVICE_EVENTS.HISTORY_LOADED, handleHistoryLoaded);
@@ -257,6 +297,7 @@ export function useCopilotChat(
   return {
     messages,
     isThinking,
+    isTyping,
     isLoadingHistory,
     cartCount,
     suggestions,

--- a/src/composables/assistant/useStreamingBuffer.ts
+++ b/src/composables/assistant/useStreamingBuffer.ts
@@ -1,0 +1,120 @@
+import { onBeforeUnmount, ref, watch, type Ref } from 'vue';
+
+const WORD_REVEAL_BASE_MS = 70;
+const WORD_REVEAL_JITTER_MS = 20;
+
+function nextDelay() {
+  return WORD_REVEAL_BASE_MS + (Math.random() * 2 - 1) * WORD_REVEAL_JITTER_MS;
+}
+
+function countWords(text: string) {
+  return (text.match(/\S+/g) || []).length;
+}
+
+function getWordsUpTo(text: string, wordCount: number) {
+  const tokens = text.match(/\S+\s*/g) || [];
+  return tokens.slice(0, wordCount).join('');
+}
+
+export function useStreamingBuffer(
+  text: Ref<string>,
+  isStreaming: Ref<boolean>,
+  onWordRevealed?: () => void,
+) {
+  const displayedText = ref(isStreaming.value ? '' : text.value || '');
+  const isBuffering = ref(isStreaming.value);
+
+  const targetTextRef = { current: text.value || '' };
+  const isStreamingRef = { current: isStreaming.value };
+  const revealedWordCountRef = { current: 0 };
+  const bufferingStartedRef = { current: isStreaming.value };
+
+  let revealTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function clearRevealTimer() {
+    if (!revealTimer) {
+      return;
+    }
+
+    clearTimeout(revealTimer);
+    revealTimer = null;
+  }
+
+  function scheduleNext() {
+    clearRevealTimer();
+
+    revealTimer = setTimeout(() => {
+      const target = targetTextRef.current;
+      const totalWords = countWords(target);
+
+      if (revealedWordCountRef.current < totalWords) {
+        revealedWordCountRef.current += 1;
+        displayedText.value = getWordsUpTo(
+          target,
+          revealedWordCountRef.current,
+        );
+        onWordRevealed?.();
+        scheduleNext();
+        return;
+      }
+
+      if (!isStreamingRef.current) {
+        displayedText.value = target;
+        isBuffering.value = false;
+        bufferingStartedRef.current = false;
+        return;
+      }
+
+      scheduleNext();
+    }, nextDelay());
+  }
+
+  watch(
+    text,
+    (value) => {
+      targetTextRef.current = value || '';
+    },
+    { immediate: true },
+  );
+
+  watch(
+    isStreaming,
+    (streaming) => {
+      isStreamingRef.current = streaming;
+
+      if (streaming && !bufferingStartedRef.current) {
+        bufferingStartedRef.current = true;
+        revealedWordCountRef.current = 0;
+        displayedText.value = '';
+        isBuffering.value = true;
+      }
+
+      if (!streaming && !isBuffering.value) {
+        displayedText.value = text.value || '';
+      }
+    },
+    { immediate: true },
+  );
+
+  watch(
+    isBuffering,
+    (buffering) => {
+      if (!buffering) {
+        clearRevealTimer();
+        return;
+      }
+
+      scheduleNext();
+    },
+    { immediate: true },
+  );
+
+  onBeforeUnmount(() => {
+    clearRevealTimer();
+  });
+
+  return {
+    displayedText,
+    isBuffering,
+  };
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -852,7 +852,15 @@
         "input_placeholder": "Ask the assistant",
         "loading_conversation": "Loading conversation",
         "processing_information": "Processing information",
-        "send_action": "Send"
+        "scroll_to_bottom": "Go to bottom",
+        "send_action": "Send",
+        "thinking_messages": {
+          "almost": "Almost ready, just a moment",
+          "connecting": "Connecting ideas",
+          "processing": "Processing information",
+          "refining": "Refining details",
+          "structuring": "Structuring reply"
+        }
       },
       "copy_summary": "Copy summary",
       "disclaimer": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -852,7 +852,15 @@
         "input_placeholder": "Pregunta al asistente",
         "loading_conversation": "Cargando conversación",
         "processing_information": "Procesando información",
-        "send_action": "Enviar"
+        "scroll_to_bottom": "Ir al final",
+        "send_action": "Enviar",
+        "thinking_messages": {
+          "almost": "Casi listo, un momento",
+          "connecting": "Conectando ideas",
+          "processing": "Procesando información",
+          "refining": "Refinando detalles",
+          "structuring": "Estructurando respuesta"
+        }
       },
       "copy_summary": "Copiar resumen",
       "disclaimer": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -852,7 +852,15 @@
         "input_placeholder": "Pergunte ao assistente",
         "loading_conversation": "Carregando conversa",
         "processing_information": "Processando informações",
-        "send_action": "Enviar"
+        "scroll_to_bottom": "Ir ao final",
+        "send_action": "Enviar",
+        "thinking_messages": {
+          "almost": "Quase pronto, só mais um instante",
+          "connecting": "Conectando ideias",
+          "processing": "Processando informações",
+          "refining": "Refinando detalhes",
+          "structuring": "Estruturando resposta"
+        }
       },
       "copy_summary": "Copiar resumo",
       "disclaimer": {

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -824,7 +824,15 @@
         "input_placeholder": "Întreabă asistentul",
         "loading_conversation": "Se încarcă conversația",
         "processing_information": "Se procesează informațiile",
-        "send_action": "Trimite"
+        "scroll_to_bottom": "Mergi jos",
+        "send_action": "Trimite",
+        "thinking_messages": {
+          "almost": "Aproape gata, doar un moment",
+          "connecting": "Conectare idei",
+          "processing": "Procesare informații",
+          "refining": "Rafinare detalii",
+          "structuring": "Structurare răspuns"
+        }
       },
       "copy_summary": "Copiază rezumatul",
       "disclaimer": {

--- a/src/types/webchat-service.d.ts
+++ b/src/types/webchat-service.d.ts
@@ -24,8 +24,11 @@ declare module '@weni/webchat-service' {
   export const SERVICE_EVENTS: {
     MESSAGE_RECEIVED: string;
     MESSAGE_SENT: string;
+    MESSAGE_UPDATED: string;
     THINKING_START: string;
     THINKING_STOP: string;
+    TYPING_START: string;
+    TYPING_STOP: string;
     CART_UPDATED: string;
     CONNECTION_STATUS_CHANGED: string;
     HISTORY_LOADED: string;


### PR DESCRIPTION
### Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Tests
- [ ] Chore
- [x] Locales

### Why
The Desk Copilot assistant needed richer real-time feedback while the AI generates a reply. Previously, the UI had no way to distinguish between the assistant thinking, the assistant streaming a response word-by-word, or a simple typing state. This change wires up those states end-to-end so agents see smooth, animated feedback at every stage of a response.

### What Changed

**Streaming word-by-word reveal (`useStreamingBuffer`)**
- New composable that gradually reveals words from a source text while `isStreaming` is `true`, firing an `onWordRevealed` callback after each word so the chat can auto-scroll.
- Once streaming stops and all words are revealed, `isBuffering` drops to `false`.

**`AiMessage` streaming mode**
- Accepts a `status` prop (`'streaming'` | other).
- While streaming or buffering, a blinking caret is shown after the last revealed word, action buttons are hidden, and the suggestion box renders without its border.
- A `wordRevealed` event is emitted upward so the parent can scroll.
- Bubble-in animations added for both AI and human messages.

**`TypingIndicator` component**
- New three-dot bouncing indicator shown when `isTyping` is `true` but `isThinking` is `false`.

**`ThinkingIndicator` animated messages**
- Replaced the static "Processing information" label with a rotating set of five messages (`processing → connecting → refining → structuring → almost`) that slide and fade between each other on a randomised 4–7.5 s interval.

**`useCopilotChat` updates**
- Tracks `isTyping` via new `TYPING_START` / `TYPING_STOP` service events.
- Handles `MESSAGE_UPDATED` events by upserting the changed message in place, enabling live streaming updates.
- Suggestions are suppressed for messages whose `status` is `'streaming'`.

**`useAutoScroll` composable**
- Watches `messages`, `isThinking`, and `isTyping` and scrolls the list to a bottom anchor after each change.
- Tracks whether the user has scrolled away from the bottom and exposes `showGoToBottom`.
- A sticky "go to bottom" button with an animated entrance is shown when the user is not near the bottom.

**Locales**
- Added `thinking_messages` keys (`processing`, `connecting`, `refining`, `structuring`, `almost`) and `scroll_to_bottom` in EN, ES, PT-BR, and RO.

### Diagram

```mermaid
flowchart TD
    SVC[WeniWebchatService] -->|TYPING_START/STOP| useCopilotChat
    SVC -->|MESSAGE_UPDATED| useCopilotChat
    SVC -->|THINKING_START/STOP| useCopilotChat
    useCopilotChat -->|isTyping, isThinking, messages| DeskCopilot
    DeskCopilot -->|isTyping, isThinking| useAutoScroll
    DeskCopilot --> AssistantMessageList
    AssistantMessageList -->|isThinking| ThinkingIndicator
    AssistantMessageList -->|isTyping| TypingIndicator
    AssistantMessageList -->|status=streaming| AiMessage
    AiMessage -->|text, isStreaming| useStreamingBuffer
    useStreamingBuffer -->|displayedText, isBuffering| AiMessage
    AiMessage -->|wordRevealed| useAutoScroll
    useAutoScroll -->|showGoToBottom, scrollToBottom| DeskCopilot
```