### PR TITLE
feat: enable queue filtering based on feature flags

### DIFF
--- a/src/components/chats/FlowsTrigger/SendFlow.vue
+++ b/src/components/chats/FlowsTrigger/SendFlow.vue
@@ -9,6 +9,7 @@
         v-model="projectUuidFlow"
       />
       <SelectQueue
+        v-if="enableFilterQueues"
         v-model="selectedQueue"
         data-testid="select-queue"
         :isDisabled="isCheckingTemplate"
@@ -59,6 +60,7 @@
 </template>
 
 <script>
+import { mapState } from 'pinia';
 import callUnnnicAlert from '@/utils/callUnnnicAlert';
 
 import ModalProgressBarFalse from '@/components/ModalProgressBarFalse.vue';
@@ -69,6 +71,8 @@ import SelectFlow from './SelectFlow.vue';
 import SelectQueue from './SelectQueue.vue';
 import SendFlowButton from './SendFlowButton.vue';
 import SelectProjects from './SelectProjects.vue';
+
+import { useFeatureFlag } from '@/store/modules/featureFlag';
 import { hasTemplateVariables } from '@/utils/flowTemplates';
 
 export default {
@@ -118,6 +122,14 @@ export default {
   },
 
   computed: {
+    ...mapState(useFeatureFlag, ['featureFlags']),
+
+    enableFilterQueues() {
+      return this.featureFlags?.active_features?.includes(
+        'weniChatsFilterFlowsByQueue',
+      );
+    },
+
     noHasContacts() {
       return !this.selectedContact && this.contacts.length === 0;
     },


### PR DESCRIPTION
### Type of Change
- [x] Feature

### Why
The queue filter in the flow trigger should only be visible to users with the `weniChatsFilterFlowsByQueue` feature flag enabled, allowing controlled rollout of this functionality.

### What Changed
The `SelectQueue` component in `SendFlow.vue` is now conditionally rendered based on the `weniChatsFilterFlowsByQueue` active feature flag. The `useFeatureFlag` Pinia store is mapped to expose `featureFlags`, and a computed property `enableFilterQueues` checks whether the flag is present before displaying the queue selector.