### PR TITLE
feat: send AI suggestion directly to room and refactor AssistantInput with media popover and recording UI

### DIFF
--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/__tests__/index.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/__tests__/index.spec.js
@@ -13,7 +13,7 @@ import { createTestingPinia } from '@pinia/testing';
 import DeskCopilotTab from '../index.vue';
 import { useCopilotConnection } from '@/composables/useCopilotConnection';
 import { useCopilotChat } from '@/composables/assistant/useCopilotChat';
-import { useMessageManager } from '@/store/modules/chats/messageManager';
+import { useRoomMessages } from '@/store/modules/chats/roomMessages';
 import i18n from '@/plugins/i18n';
 
 vi.mock('@/composables/useCopilotConnection', () => ({
@@ -236,7 +236,7 @@ describe('DeskCopilotTab', () => {
     expect(roomUuid.value).toBe('room-1');
   });
 
-  it('sends the AI suggestion into the main chat input', async () => {
+  it('sends the AI suggestion directly to the active room', async () => {
     mockCopilotConnection({
       isConfigured: true,
       connection: defaultConnection,
@@ -249,9 +249,13 @@ describe('DeskCopilotTab', () => {
       .find('[data-testid="assistant-message-list"]')
       .trigger('click');
 
-    const messageManager = useMessageManager();
-    expect(messageManager.inputMessage).toBe('Suggested text');
-    expect(messageManager.inputMessageFocused).toBe(true);
+    const roomMessages = useRoomMessages();
+    expect(roomMessages.sendRoomMessage).toHaveBeenCalledWith(
+      'Suggested text',
+      null,
+      null,
+      'room-1',
+    );
   });
 
   it('hides the summary when has_chats_summary is disabled', async () => {

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/AssistantInput.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/AssistantInput.vue
@@ -12,17 +12,30 @@
     @exit="emit('voiceExit')"
   />
 
-  <AudioRecordingBar
+  <section
     v-else-if="isRecording"
-    :durationMs="recordingDurationMs"
-    @cancel="emit('cancelRecording')"
-    @send="emit('stopRecording')"
-  />
+    class="assistant-input-recording"
+    data-testid="assistant-input-recording"
+  >
+    <AudioRecordingBar
+      :durationMs="recordingDurationMs"
+      @cancel="emit('cancelRecording')"
+    />
+    <UnnnicButton
+      type="primary"
+      size="small"
+      iconCenter="send"
+      data-testid="assistant-audio-recording-send"
+      :aria-label="$t('contact_info.desk_copilot.assistant.send_audio')"
+      @click="emit('stopRecording')"
+    />
+  </section>
 
   <section
     v-else
     class="assistant-input"
     data-testid="assistant-input"
+    @click="focusTextarea"
   >
     <textarea
       ref="textareaRef"
@@ -33,19 +46,54 @@
       data-testid="assistant-input-textarea"
       @keydown.enter.exact.prevent="handleSend"
       @input="autoGrow"
+      @click.stop
     />
 
     <hr class="assistant-input__divider" />
 
-    <section class="assistant-input__actions">
-      <UnnnicButton
-        type="tertiary"
-        size="small"
-        iconCenter="attach_file_add"
-        data-testid="assistant-input-attach"
-        :aria-label="$t('contact_info.desk_copilot.assistant.attach_action')"
-        @click="openFilePicker"
-      />
+    <section
+      class="assistant-input__actions"
+      @click.stop
+    >
+      <UnnnicPopover
+        :open="isMediaMenuOpen"
+        data-testid="assistant-input-media-popover"
+        @update:open="isMediaMenuOpen = $event"
+      >
+        <UnnnicPopoverTrigger>
+          <UnnnicButton
+            type="tertiary"
+            size="small"
+            iconCenter="attach_file_add"
+            data-testid="assistant-input-attach"
+            :aria-label="
+              $t('contact_info.desk_copilot.assistant.open_media_menu')
+            "
+            @click.stop="toggleMediaMenu"
+          />
+        </UnnnicPopoverTrigger>
+
+        <UnnnicPopoverContent
+          side="top"
+          align="start"
+          size="small"
+          data-testid="assistant-input-media-menu"
+        >
+          <UnnnicPopoverOption
+            :label="$t('contact_info.desk_copilot.assistant.upload_file')"
+            icon="attach_file"
+            data-testid="assistant-input-upload-option"
+            @click="handleUploadOption"
+          />
+          <UnnnicPopoverOption
+            v-if="isAudioRecordingSupported"
+            :label="$t('contact_info.desk_copilot.assistant.record_audio')"
+            icon="mic"
+            data-testid="assistant-input-audio-option"
+            @click="handleAudioOption"
+          />
+        </UnnnicPopoverContent>
+      </UnnnicPopover>
 
       <input
         ref="fileInputRef"
@@ -57,17 +105,18 @@
       />
 
       <VoiceModeButton
-        v-if="canEnterVoiceMode && !draft.trim()"
+        v-if="canEnterVoiceMode && !hasDraft"
         @click="emit('voiceEnter')"
       />
       <UnnnicButton
-        v-else-if="isAudioRecordingSupported && !draft.trim()"
-        type="secondary"
+        v-else
+        type="primary"
         size="small"
-        iconCenter="mic"
-        data-testid="assistant-input-mic"
-        :aria-label="$t('contact_info.desk_copilot.assistant.record_audio')"
-        @click="emit('startRecording')"
+        iconCenter="arrow_upward"
+        data-testid="assistant-input-send"
+        :disabled="!hasDraft"
+        :aria-label="$t('contact_info.desk_copilot.assistant.send_action')"
+        @click.stop="handleSend"
       />
     </section>
   </section>
@@ -132,12 +181,14 @@ const emit = defineEmits<{
 }>();
 
 const draft = ref('');
+const isMediaMenuOpen = ref(false);
 const textareaRef = ref<HTMLTextAreaElement | null>(null);
 const fileInputRef = ref<HTMLInputElement | null>(null);
 
 const fileAccept = computed(
   () => props.fileConfig?.acceptAttribute || undefined,
 );
+const hasDraft = computed(() => !!draft.value.trim());
 
 function autoGrow() {
   const el = textareaRef.value;
@@ -145,6 +196,14 @@ function autoGrow() {
 
   el.style.height = 'auto';
   el.style.height = `${el.scrollHeight}px`;
+}
+
+function focusTextarea() {
+  textareaRef.value?.focus();
+}
+
+function toggleMediaMenu() {
+  isMediaMenuOpen.value = !isMediaMenuOpen.value;
 }
 
 async function handleSend() {
@@ -157,8 +216,14 @@ async function handleSend() {
   autoGrow();
 }
 
-function openFilePicker() {
+function handleUploadOption() {
+  isMediaMenuOpen.value = false;
   fileInputRef.value?.click();
+}
+
+function handleAudioOption() {
+  isMediaMenuOpen.value = false;
+  emit('startRecording');
 }
 
 function handleFileChange(event: Event) {
@@ -209,17 +274,18 @@ onMounted(() => {
 .assistant-input {
   display: flex;
   flex-direction: column;
-  gap: $unnnic-space-2;
+  gap: $unnnic-space-3;
   width: 100%;
   padding: $unnnic-space-3 $unnnic-space-4;
   border: 1px solid $unnnic-color-border-base;
   border-radius: $unnnic-radius-2;
   background-color: $unnnic-color-bg-base;
   flex-shrink: 0;
+  cursor: text;
 
   &__textarea {
     width: 100%;
-    min-height: $unnnic-space-5;
+    min-height: calc(0.875 * 16px * 1.4);
     max-height: $unnnic-space-16;
     resize: none;
     border: none;
@@ -227,6 +293,7 @@ onMounted(() => {
     background: transparent;
     font: $unnnic-font-body;
     color: $unnnic-color-fg-base;
+    cursor: text;
 
     &::placeholder {
       color: $unnnic-color-fg-muted;
@@ -250,5 +317,13 @@ onMounted(() => {
   &__file-input {
     display: none;
   }
+}
+
+.assistant-input-recording {
+  display: flex;
+  align-items: center;
+  gap: $unnnic-space-2;
+  width: 100%;
+  flex-shrink: 0;
 }
 </style>

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/AudioRecordingBar.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/AudioRecordingBar.vue
@@ -10,24 +10,14 @@
       {{ formattedDuration }}
     </p>
 
-    <section class="audio-recording-bar__actions">
-      <UnnnicButton
-        type="tertiary"
-        size="small"
-        iconCenter="close"
-        data-testid="assistant-audio-recording-cancel"
-        :aria-label="$t('contact_info.desk_copilot.assistant.cancel_recording')"
-        @click="emit('cancel')"
-      />
-      <UnnnicButton
-        type="primary"
-        size="small"
-        iconCenter="send"
-        data-testid="assistant-audio-recording-send"
-        :aria-label="$t('contact_info.desk_copilot.assistant.send_audio')"
-        @click="emit('send')"
-      />
-    </section>
+    <UnnnicButton
+      type="tertiary"
+      size="small"
+      iconCenter="close"
+      data-testid="assistant-audio-recording-cancel"
+      :aria-label="$t('contact_info.desk_copilot.assistant.cancel_recording')"
+      @click="emit('cancel')"
+    />
   </section>
 </template>
 
@@ -49,7 +39,6 @@ const props = withDefaults(
 
 const emit = defineEmits<{
   cancel: [];
-  send: [];
 }>();
 
 const formattedDuration = computed(() => {
@@ -64,23 +53,49 @@ const formattedDuration = computed(() => {
 .audio-recording-bar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: $unnnic-space-3;
-  width: 100%;
-  padding: $unnnic-space-3 $unnnic-space-4;
+  justify-content: flex-end;
+  gap: $unnnic-space-2;
+  flex: 1;
+  min-width: 0;
+  height: $unnnic-space-10;
   border: 1px solid $unnnic-color-border-base;
   border-radius: $unnnic-radius-2;
   background-color: $unnnic-color-bg-base;
 
   &__timer {
-    font: $unnnic-font-emphasis;
-    color: $unnnic-color-fg-emphasized;
-  }
-
-  &__actions {
     display: flex;
     align-items: center;
     gap: $unnnic-space-2;
+    margin: 0;
+    padding-right: $unnnic-space-2;
+    font: $unnnic-font-display-4;
+    color: $unnnic-color-fg-emphasized;
+
+    &::before {
+      content: '';
+      width: $unnnic-space-2;
+      height: $unnnic-space-2;
+      border-radius: 50%;
+      background-color: $unnnic-color-fg-critical;
+      animation: recording-pulse 1.2s infinite;
+    }
+  }
+}
+
+@keyframes recording-pulse {
+  0% {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  50% {
+    opacity: 0.5;
+    transform: scale(1.05);
+  }
+
+  100% {
+    opacity: 1;
+    transform: scale(1);
   }
 }
 </style>

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/VoiceModeButton.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/VoiceModeButton.vue
@@ -1,6 +1,6 @@
 <template>
   <UnnnicButton
-    type="primary"
+    type="secondary"
     size="small"
     iconCenter="graphic_eq"
     data-testid="assistant-voice-mode-button"

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/__tests__/AssistantInput.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/__tests__/AssistantInput.spec.js
@@ -1,10 +1,39 @@
-import { describe, it, expect, afterEach, vi } from 'vitest';
-import { mount } from '@vue/test-utils';
+import {
+  describe,
+  it,
+  expect,
+  afterEach,
+  beforeAll,
+  afterAll,
+  vi,
+} from 'vitest';
+import { mount, config } from '@vue/test-utils';
 import AssistantInput from '../AssistantInput.vue';
+import i18n from '@/plugins/i18n';
+import UnnnicSystemPlugin from '@/plugins/UnnnicSystem.js';
 
 vi.mock('@weni/unnnic-system', () => ({
   UnnnicCallAlert: vi.fn(),
 }));
+
+beforeAll(() => {
+  config.global.plugins = (config.global.plugins || []).filter(
+    (plugin) => plugin !== i18n && plugin !== UnnnicSystemPlugin,
+  );
+});
+
+afterAll(() => {
+  if (config.global.plugins && !config.global.plugins.includes(i18n)) {
+    config.global.plugins.push(i18n);
+  }
+  if (
+    UnnnicSystemPlugin &&
+    config.global.plugins &&
+    !config.global.plugins.includes(UnnnicSystemPlugin)
+  ) {
+    config.global.plugins.push(UnnnicSystemPlugin);
+  }
+});
 
 const createWrapper = (props = {}) =>
   mount(AssistantInput, {
@@ -28,6 +57,27 @@ const createWrapper = (props = {}) =>
           template: '<button v-bind="$attrs" @click="$emit(\'click\')" />',
         },
         UnnnicIcon: true,
+        UnnnicPopover: {
+          name: 'UnnnicPopover',
+          template:
+            '<div data-testid="assistant-input-media-popover"><slot /></div>',
+        },
+        UnnnicPopoverTrigger: {
+          name: 'UnnnicPopoverTrigger',
+          template: '<div><slot /></div>',
+        },
+        UnnnicPopoverContent: {
+          name: 'UnnnicPopoverContent',
+          template:
+            '<div data-testid="assistant-input-media-menu"><slot /></div>',
+        },
+        UnnnicPopoverOption: {
+          name: 'UnnnicPopoverOption',
+          inheritAttrs: false,
+          props: ['label', 'icon'],
+          template:
+            '<button v-bind="$attrs" @click="$emit(\'click\')">{{ label }}</button>',
+        },
         AudioRecordingBar: {
           name: 'AssistantAudioRecordingBar',
           template: '<div data-testid="assistant-audio-recording-bar" />',
@@ -63,10 +113,25 @@ describe('AssistantInput', () => {
     expect(wrapper.emitted('send')?.[0]).toEqual(['Hello']);
   });
 
-  it('emits startRecording when the mic button is clicked', async () => {
+  it('emits startRecording from the media menu audio option', async () => {
     wrapper = createWrapper();
-    await wrapper.find('[data-testid="assistant-input-mic"]').trigger('click');
+    await wrapper
+      .find('[data-testid="assistant-input-audio-option"]')
+      .trigger('click');
     expect(wrapper.emitted('startRecording')).toBeTruthy();
+  });
+
+  it('opens the file picker from the upload option', async () => {
+    wrapper = createWrapper();
+    const clickSpy = vi.fn();
+    const fileInput = wrapper.find('[data-testid="assistant-input-file"]');
+    fileInput.element.click = clickSpy;
+
+    await wrapper
+      .find('[data-testid="assistant-input-upload-option"]')
+      .trigger('click');
+
+    expect(clickSpy).toHaveBeenCalled();
   });
 
   it('emits attach when a valid file is selected', async () => {
@@ -83,10 +148,23 @@ describe('AssistantInput', () => {
     expect(wrapper.emitted('attach')?.[0]).toEqual([file]);
   });
 
-  it('shows the recording bar while recording', () => {
+  it('shows the recording layout while recording', () => {
     wrapper = createWrapper({ isRecording: true, recordingDurationMs: 1000 });
     expect(
+      wrapper.find('[data-testid="assistant-input-recording"]').exists(),
+    ).toBe(true);
+    expect(
       wrapper.find('[data-testid="assistant-audio-recording-bar"]').exists(),
+    ).toBe(true);
+    expect(
+      wrapper.find('[data-testid="assistant-audio-recording-send"]').exists(),
+    ).toBe(true);
+  });
+
+  it('shows the voice mode button when voice is available and draft is empty', () => {
+    wrapper = createWrapper({ canEnterVoiceMode: true });
+    expect(
+      wrapper.find('[data-testid="assistant-voice-mode-button"]').exists(),
     ).toBe(true);
   });
 });

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/__tests__/AudioRecordingBar.spec.js
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/assistant/__tests__/AudioRecordingBar.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach, vi } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import AudioRecordingBar from '../AudioRecordingBar.vue';
 
@@ -28,7 +28,7 @@ describe('AssistantAudioRecordingBar', () => {
     wrapper?.unmount();
   });
 
-  it('formats the recording duration and emits send/cancel', async () => {
+  it('formats the recording duration and emits cancel', async () => {
     wrapper = createWrapper();
 
     expect(
@@ -38,11 +38,7 @@ describe('AssistantAudioRecordingBar', () => {
     await wrapper
       .find('[data-testid="assistant-audio-recording-cancel"]')
       .trigger('click');
-    await wrapper
-      .find('[data-testid="assistant-audio-recording-send"]')
-      .trigger('click');
 
     expect(wrapper.emitted('cancel')).toBeTruthy();
-    expect(wrapper.emitted('send')).toBeTruthy();
   });
 });

--- a/src/components/chats/ContactInfo/Redesign/DeskCopilot/index.vue
+++ b/src/components/chats/ContactInfo/Redesign/DeskCopilot/index.vue
@@ -23,7 +23,7 @@
           :isLoadingHistory="isLoadingHistory"
           :isVoiceModeActive="isVoiceModeActive"
           :voicePartialTranscript="voicePartialTranscript"
-          @send="handleSendSuggestionToInput"
+          @send="handleSendSuggestionToRoom"
           @word-revealed="scrollToBottomIfNear()"
         />
 
@@ -98,7 +98,7 @@ import { useVoiceMode } from '@/composables/assistant/useVoiceMode';
 import { useCopilotConnection } from '@/composables/useCopilotConnection';
 import { useConfig } from '@/store/modules/config';
 import { useRooms } from '@/store/modules/chats/rooms';
-import { useMessageManager } from '@/store/modules/chats/messageManager';
+import { useRoomMessages } from '@/store/modules/chats/roomMessages';
 
 defineOptions({
   name: 'DeskCopilotTab',
@@ -121,8 +121,7 @@ const emit = defineEmits<{
 
 const { project } = storeToRefs(useConfig());
 const { activeRoom } = storeToRefs(useRooms());
-const messageManagerStore = useMessageManager();
-const { inputMessage, inputMessageFocused } = storeToRefs(messageManagerStore);
+const roomMessagesStore = useRoomMessages();
 
 const {
   connection,
@@ -181,9 +180,15 @@ const enableRoomSummary = computed(
   () => !!project.value?.config?.has_chats_summary,
 );
 
-function handleSendSuggestionToInput(text: string) {
-  inputMessage.value = text;
-  inputMessageFocused.value = true;
+async function handleSendSuggestionToRoom(text: string) {
+  const trimmed = text?.trim();
+  const activeRoomUuid = activeRoom.value?.uuid;
+
+  if (!trimmed || !activeRoomUuid) {
+    return;
+  }
+
+  await roomMessagesStore.sendRoomMessage(trimmed, null, null, activeRoomUuid);
 }
 
 onMounted(() => {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -855,8 +855,9 @@
         "file_type_not_allowed": "Select a supported file type",
         "image_attachment": "Image attachment",
         "input_placeholder": "Ask the assistant",
+        "open_media_menu": "Open media menu",
         "processing_information": "Processing information",
-        "record_audio": "Record audio",
+        "record_audio": "Audio",
         "recording_in_progress": "Recording",
         "scroll_to_bottom": "Go to bottom",
         "send_action": "Send",
@@ -868,6 +869,7 @@
           "refining": "Refining details",
           "structuring": "Structuring response"
         },
+        "upload_file": "Upload file",
         "voice_mode": {
           "dismiss": "Dismiss",
           "enter": "Start voice mode",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -855,8 +855,9 @@
         "file_type_not_allowed": "Selecciona un tipo de archivo compatible",
         "image_attachment": "Adjunto de imagen",
         "input_placeholder": "Pregunta al asistente",
+        "open_media_menu": "Abrir menú de medios",
         "processing_information": "Procesando información",
-        "record_audio": "Grabar audio",
+        "record_audio": "Audio",
         "recording_in_progress": "Grabando",
         "scroll_to_bottom": "Ir al final",
         "send_action": "Enviar",
@@ -868,6 +869,7 @@
           "refining": "Refinando detalles",
           "structuring": "Estructurando respuesta"
         },
+        "upload_file": "Subir archivo",
         "voice_mode": {
           "dismiss": "Descartar",
           "enter": "Iniciar modo de voz",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -855,8 +855,9 @@
         "file_type_not_allowed": "Selecione um tipo de arquivo compatível",
         "image_attachment": "Anexo de imagem",
         "input_placeholder": "Pergunte ao assistente",
+        "open_media_menu": "Abrir menu de mídia",
         "processing_information": "Processando informações",
-        "record_audio": "Gravar áudio",
+        "record_audio": "Áudio",
         "recording_in_progress": "Gravando",
         "scroll_to_bottom": "Ir ao final",
         "send_action": "Enviar",
@@ -868,6 +869,7 @@
           "refining": "Refinando detalhes",
           "structuring": "Estruturando resposta"
         },
+        "upload_file": "Enviar arquivo",
         "voice_mode": {
           "dismiss": "Dispensar",
           "enter": "Iniciar modo de voz",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -827,8 +827,9 @@
         "file_type_not_allowed": "Selectează un tip de fișier compatibil",
         "image_attachment": "Atașament imagine",
         "input_placeholder": "Întreabă asistentul",
+        "open_media_menu": "Deschide meniul media",
         "processing_information": "Se procesează informațiile",
-        "record_audio": "Înregistrează audio",
+        "record_audio": "Audio",
         "recording_in_progress": "Se înregistrează",
         "scroll_to_bottom": "Mergi jos",
         "send_action": "Trimite",
@@ -840,6 +841,7 @@
           "refining": "Rafinare detalii",
           "structuring": "Structurare răspuns"
         },
+        "upload_file": "Încarcă fișier",
         "voice_mode": {
           "dismiss": "Închide",
           "enter": "Pornește modul vocal",


### PR DESCRIPTION
### Type of Change
- [x] Feature
- [ ] Bug fix
- [x] Refactor
- [x] Tests
- [ ] Chore
- [x] Locales

### Why
The previous assistant input sent AI suggestions into the main chat input field instead of directly to the active room. Additionally, the attach button only opened a file picker, with no way to access audio recording from the same control. The recording bar also had its send button embedded internally, making it harder to compose with other UI elements.

### What Changed
- AI suggestions from the copilot are now sent directly to the active room via `roomMessagesStore.sendRoomMessage` instead of populating the main chat input field via `useMessageManager`.
- The attach button in `AssistantInput` has been replaced with a popover media menu containing two options: **Upload file** and **Record audio** (when supported). This removes the standalone mic button from the toolbar.
- The `AudioRecordingBar` component no longer owns its send button. The send button has been moved to `AssistantInput`, which wraps the bar in a flex container alongside the send button. A pulsing red dot animation was added to the timer to indicate active recording.
- The `VoiceModeButton` style was changed from `primary` to `secondary` to accommodate the new always-visible `primary` send button.
- Clicking anywhere on the input container focuses the textarea, while inner interactive elements stop click propagation.
- New i18n keys (`open_media_menu`, `upload_file`) were added across all supported locales (en, es, pt_br, ro), and the `record_audio` label was shortened to just "Audio".
- Tests were updated to reflect the new media menu interaction, the direct-send behavior, and the restructured recording layout.