### PR TITLE
Add and update translations from PR#974

### DIFF
--- a/src/components/chats/BulkMessage/__tests__/ContactsStatus.spec.js
+++ b/src/components/chats/BulkMessage/__tests__/ContactsStatus.spec.js
@@ -24,8 +24,8 @@ describe('ContactsStatus', () => {
     expect(
       wrapper.find('[data-testid="contacts-status-waiting"]').exists(),
     ).toBe(true);
-    expect(wrapper.text()).toContain('Contacts in service');
-    expect(wrapper.text()).toContain('Contacts waiting for service');
+    expect(wrapper.text()).toContain('Contacts in support chats');
+    expect(wrapper.text()).toContain('Contacts waiting for support');
   });
 
   it('should emit update:status removing ongoing when toggled off', () => {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1642,17 +1642,17 @@
   "mass_message": {
     "title": "Bulk message",
     "form": {
-      "title": "Send mass message",
-      "shipping_history": "Shipping history",
-      "no_shipping_history": "No message was sent",
+      "title": "Send bulk message",
+      "shipping_history": "Message history",
+      "no_shipping_history": "No messages were sent",
       "no_contacts_filtered_alert": "No contacts match the selected filters. Try adjusting your filters.",
       "contacts_count_disclaimer": "{count, plural, one {This message will be sent to {count} contact. The number of recipients may change during delivery due to conversation transfers, conversation closures, or interactions taking place simultaneously.} other {This message will be sent to {count} contacts. The number of recipients may change during delivery due to conversation transfers, conversation closures, or interactions taking place simultaneously.}}",
       "recipients": {
         "title": "Recipients",
-        "title_tooltip": "This message will be delivered to all contacts matching the selected filters. Use this feature for operational communications such as delays, incidents, updates.",
-        "select_the_contacts_status": "Select the contacts status",
-        "contacts_in_service": "Contacts in service",
-        "contacts_waiting_for_service": "Contacts waiting for service",
+        "title_tooltip": "This message will be delivered to all contacts matching the selected filters. Use this feature for operational communications such as delays, incidents, or updates.",
+        "select_the_contacts_status": "Select contact status",
+        "contacts_in_service": "Contacts in support chats",
+        "contacts_waiting_for_service": "Contacts waiting for support",
         "filters": {
           "queues": {
             "all": "All queues",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1649,10 +1649,10 @@
       "contacts_count_disclaimer": "{count, plural, one {Este mensaje se enviará a {count} contacto. El número de destinatarios puede cambiar durante la entrega debido a transferencias de conversación, cierres de conversación o interacciones que ocurren simultáneamente.} other {Este mensaje se enviará a {count} contactos. El número de destinatarios puede cambiar durante la entrega debido a transferencias de conversación, cierres de conversación o interacciones que ocurren simultáneamente.}}",
       "recipients": {
         "title": "Destinatarios",
-        "title_tooltip": "Este mensaje se entregará a todos los contactos que coincidan con los filtros seleccionados. Usa esta función para comunicaciones operativas como retrasos, incidentes, actualizaciones.",
-        "select_the_contacts_status": "Selecciona el estado de los contactos",
-        "contacts_in_service": "Contactos en atención",
-        "contacts_waiting_for_service": "Contactos esperando atención",
+        "title_tooltip": "Este mensaje se entregará a todos los contactos que coincidan con los filtros seleccionados. Usa esta función para comunicaciones operativas como retrasos, incidentes o actualizaciones.",
+        "select_the_contacts_status": "Selecciona el status de los contactos",
+        "contacts_in_service": "Contactos en chats de soporte",
+        "contacts_waiting_for_service": "Contactos esperando chat de soporte",
         "filters": {
           "queues": {
             "all": "Todas las colas",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -1643,14 +1643,14 @@
     "title": "Mensagem em massa",
     "form": {
       "title": "Enviar mensagem em massa",
-      "shipping_history": "Histórico de envios",
+      "shipping_history": "Histórico de mensagens",
       "no_shipping_history": "Nenhuma mensagem foi enviada",
-      "no_contacts_filtered_alert": "Nenhum contato corresponde aos filtros selecionados. Tente ajustar os filtros.",
+      "no_contacts_filtered_alert": "Nenhum contato corresponde aos filtros selecionados. Tente ajustar seus filtros.",
       "contacts_count_disclaimer": "{count, plural, one {Esta mensagem será enviada para {count} contato. O número de destinatários pode mudar durante a entrega devido a transferências de conversa, encerramentos de conversa ou interações ocorrendo simultaneamente.} other {Esta mensagem será enviada para {count} contatos. O número de destinatários pode mudar durante a entrega devido a transferências de conversa, encerramentos de conversa ou interações ocorrendo simultaneamente.}}",
       "recipients": {
         "title": "Destinatários",
-        "title_tooltip": "Esta mensagem será entregue a todos os contatos que correspondem aos filtros selecionados. Use este recurso para comunicações operacionais como atrasos, incidentes, atualizações.",
-        "select_the_contacts_status": "Selecione o status dos contatos",
+        "title_tooltip": "Esta mensagem será entregue a todos os contatos que correspondem aos filtros selecionados. Use este recurso para comunicações operacionais, como atrasos, incidentes e atualizações.",
+        "select_the_contacts_status": "Selecione o status do contato",
         "contacts_in_service": "Contatos em atendimento",
         "contacts_waiting_for_service": "Contatos aguardando atendimento",
         "filters": {
@@ -1660,8 +1660,8 @@
             "placeholder": "Selecione pelo menos uma fila"
           },
           "representatives": {
-            "all": "Todos os representantes",
-            "label": "Selecione um representante",
+            "all": "Todos os atendentes",
+            "label": "Selecione um atendente",
             "placeholder": "Selecione pelo menos um representante"
           }
         }

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -1592,7 +1592,7 @@
     "title": "Mesaj în masă",
     "form": {
       "title": "Trimite mesaj în masă",
-      "shipping_history": "Istoric trimiteri",
+      "shipping_history": "Istoric mesaje",
       "no_shipping_history": "Niciun mesaj nu a fost trimis",
       "no_contacts_filtered_alert": "Niciun contact nu corespunde filtrelor selectate. Încearcă să ajustezi filtrele.",
       "contacts_count_disclaimer": "{count, plural, one {Acest mesaj va fi trimis către {count} contact. Numărul de destinatari se poate schimba în timpul livrării din cauza transferurilor de conversație, închiderilor de conversație sau interacțiunilor care au loc simultan.} few {Acest mesaj va fi trimis către {count} contacte. Numărul de destinatari se poate schimba în timpul livrării din cauza transferurilor de conversație, închiderilor de conversație sau interacțiunilor care au loc simultan.} other {Acest mesaj va fi trimis către {count} de contacte. Numărul de destinatari se poate schimba în timpul livrării din cauza transferurilor de conversație, închiderilor de conversație sau interacțiunilor care au loc simultan.}}",
@@ -1600,8 +1600,8 @@
         "title": "Destinatari",
         "title_tooltip": "Acest mesaj va fi livrat tuturor contactelor care corespund filtrelor selectate. Folosește această funcție pentru comunicări operaționale precum întârzieri, incidente, actualizări.",
         "select_the_contacts_status": "Selectează statusul contactelor",
-        "contacts_in_service": "Contacte în curs de deservire",
-        "contacts_waiting_for_service": "Contacte în așteptare",
+        "contacts_in_service": "Contacte din chaturile de asistență",
+        "contacts_waiting_for_service": "Contacte care așteaptă asistență",
         "filters": {
           "queues": {
             "all": "Toate cozile",

--- a/src/views/Settings/Forms/__tests__/__snapshots__/ExtraOptions.spec.js.snap
+++ b/src/views/Settings/Forms/__tests__/__snapshots__/ExtraOptions.spec.js.snap
@@ -6,7 +6,7 @@ exports[`SectorExtraOptions > Should match the snapshot 1`] = `
     <h2 data-v-8e9664ba="" class="switchs__title" data-testid="switchs-title">Additional options</h2>
     <unnnic-switch-stub data-v-8e9664ba="" size="small" label="" option="" helper="" textleft="" textright="Trigger message templates" disabled="false" modelvalue="false" class="margin-y-space-1" data-testid="config-switch"></unnnic-switch-stub>
     <section data-v-8e9664ba="" class="switchs__container">
-      <unnnic-switch-stub data-v-8e9664ba="" size="small" label="" option="" helper="Each message exchanged will have the name of the representative who is answering." textleft="" textright="Use signature" disabled="false" modelvalue="false" class="margin-y-space-1" data-testid="config-switch"></unnnic-switch-stub>
+      <unnnic-switch-stub data-v-8e9664ba="" size="small" label="" option="" helper="Each exchanged message will have the name of the representative who is answering." textleft="" textright="Use signature" disabled="false" modelvalue="false" class="margin-y-space-1" data-testid="config-switch"></unnnic-switch-stub>
     </section>
     <unnnic-switch-stub data-v-8e9664ba="" size="small" label="" option="" helper="When active, it allows representatives to edit the custom fields of the contact in the &quot;All Information&quot; section." textleft="" textright="Allow representatives to edit custom fields" disabled="false" modelvalue="false" class="margin-y-space-1" data-testid="config-switch"></unnnic-switch-stub>
   </section>


### PR DESCRIPTION
Add and update translations from [PR#974](https://github.com/weni-ai/chats-webapp/pull/974). Tracked in [LOC-28281](https://vtex-dev.atlassian.net/browse/LOC-28281).

Updates `mass_message.form` recipients strings in en, pt_br, es, and ro.